### PR TITLE
Allow to translate doc comments

### DIFF
--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -105,8 +105,7 @@ impl CDecl {
         }
     }
 
-    fn write<F: Write>(&self, out: &mut SourceWriter<F>, ident: Option<&str>, doc: &Documentation) {
-        doc.write(out);
+    fn write<F: Write>(&self, out: &mut SourceWriter<F>, ident: Option<&str>) {
 
         // Write the type-specifier and type-qualifier first
         if self.type_qualifers.len() != 0 {
@@ -191,7 +190,7 @@ impl CDecl {
                             // This is gross, but needed to convert &Option<String> to Option<&str>
                             let arg_ident = arg_ident.as_ref().map(|x| x.as_ref());
 
-                            arg_ty.write(out, arg_ident, &Documentation::none());
+                            arg_ty.write(out, arg_ident);
                         }
                         out.pop_tab();
                     } else {
@@ -203,7 +202,7 @@ impl CDecl {
                             // This is gross, but needed to convert &Option<String> to Option<&str>
                             let arg_ident = arg_ident.as_ref().map(|x| x.as_ref());
 
-                            arg_ty.write(out, arg_ident, &Documentation::none());
+                            arg_ty.write(out, arg_ident);
                         }
                     }
                     out.write(")");
@@ -215,18 +214,14 @@ impl CDecl {
     }
 }
 
-pub fn write_func<F: Write>(out: &mut SourceWriter<F>, f: &Function, layout_vertical: bool, documentation: bool) {
-    if documentation {
-        &CDecl::from_func(f, layout_vertical).write(out, Some(&f.name), &f.doc_comment);
-    } else {
-        &CDecl::from_func(f, layout_vertical).write(out, Some(&f.name), &Documentation::none());
-    }
+pub fn write_func<F: Write>(out: &mut SourceWriter<F>, f: &Function, layout_vertical: bool) {
+    &CDecl::from_func(f, layout_vertical).write(out, Some(&f.name));
 }
 
-pub fn write_field<F: Write>(out: &mut SourceWriter<F>, t: &Type, ident: &str, doc: &Documentation) {
-    &CDecl::from_type(t).write(out, Some(ident), doc);
+pub fn write_field<F: Write>(out: &mut SourceWriter<F>, t: &Type, ident: &str) {
+    &CDecl::from_type(t).write(out, Some(ident));
 }
 
 pub fn write_type<F: Write>(out: &mut SourceWriter<F>, t: &Type) {
-    &CDecl::from_type(t).write(out, None, &Documentation::none());
+    &CDecl::from_type(t).write(out, None);
 }

--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -105,7 +105,9 @@ impl CDecl {
         }
     }
 
-    fn write<F: Write>(&self, out: &mut SourceWriter<F>, ident: Option<&str>) {
+    fn write<F: Write>(&self, out: &mut SourceWriter<F>, ident: Option<&str>, doc: &Documentation) {
+        doc.write(out);
+
         // Write the type-specifier and type-qualifier first
         if self.type_qualifers.len() != 0 {
             out.write(&self.type_qualifers);
@@ -189,7 +191,7 @@ impl CDecl {
                             // This is gross, but needed to convert &Option<String> to Option<&str>
                             let arg_ident = arg_ident.as_ref().map(|x| x.as_ref());
 
-                            arg_ty.write(out, arg_ident);
+                            arg_ty.write(out, arg_ident, &Documentation::none());
                         }
                         out.pop_tab();
                     } else {
@@ -201,7 +203,7 @@ impl CDecl {
                             // This is gross, but needed to convert &Option<String> to Option<&str>
                             let arg_ident = arg_ident.as_ref().map(|x| x.as_ref());
 
-                            arg_ty.write(out, arg_ident);
+                            arg_ty.write(out, arg_ident, &Documentation::none());
                         }
                     }
                     out.write(")");
@@ -213,14 +215,18 @@ impl CDecl {
     }
 }
 
-pub fn write_func<F: Write>(out: &mut SourceWriter<F>, f: &Function, layout_vertical: bool) {
-    &CDecl::from_func(f, layout_vertical).write(out, Some(&f.name));
+pub fn write_func<F: Write>(out: &mut SourceWriter<F>, f: &Function, layout_vertical: bool, documentation: bool) {
+    if documentation {
+        &CDecl::from_func(f, layout_vertical).write(out, Some(&f.name), &f.doc_comment);
+    } else {
+        &CDecl::from_func(f, layout_vertical).write(out, Some(&f.name), &Documentation::none());
+    }
 }
 
-pub fn write_field<F: Write>(out: &mut SourceWriter<F>, t: &Type, ident: &str) {
-    &CDecl::from_type(t).write(out, Some(ident));
+pub fn write_field<F: Write>(out: &mut SourceWriter<F>, t: &Type, ident: &str, doc: &Documentation) {
+    &CDecl::from_type(t).write(out, Some(ident), doc);
 }
 
 pub fn write_type<F: Write>(out: &mut SourceWriter<F>, t: &Type) {
-    &CDecl::from_type(t).write(out, None);
+    &CDecl::from_type(t).write(out, None, &Documentation::none());
 }

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -319,6 +319,8 @@ pub struct Config {
     /// The configuration options for enums
     #[serde(rename = "enum")]
     pub enumeration: EnumConfig,
+    /// Include doc comments from rust as documentation
+    pub documentation: bool,
 }
 
 impl Default for Config {
@@ -339,6 +341,7 @@ impl Default for Config {
             function: FunctionConfig::default(),
             structure: StructConfig::default(),
             enumeration: EnumConfig::default(),
+            documentation: true,
         }
     }
 }

--- a/src/bindgen/ir/alias.rs
+++ b/src/bindgen/ir/alias.rs
@@ -231,7 +231,7 @@ impl Typedef {
 impl Source for Typedef {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         if config.documentation {
-            self.documentation.write(out);
+            self.documentation.write(config, out);
         }
         out.write("typedef ");
         (self.name.clone(), self.aliased.clone()).write(config, out);

--- a/src/bindgen/ir/documentation.rs
+++ b/src/bindgen/ir/documentation.rs
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::io::Write;
+
+use bindgen::writer::SourceWriter;
+
+#[derive(Debug, Clone)]
+pub struct Documentation {
+    pub doc_comment: Vec<String>
+}
+
+impl Documentation {
+    pub fn load(doc: String) -> Self {
+        let doc = doc.lines().filter_map(|x|{
+            let x = x.trim_left_matches("///");
+            if x.trim().starts_with("cbindgen:") {
+                None
+            } else {
+                Some(x.into())
+            }
+        }).collect();
+        Documentation {
+            doc_comment: doc,
+        }
+    }
+
+    pub fn none() -> Self {
+        Documentation {
+            doc_comment: Vec::new(),
+        }
+    }
+
+    pub fn write<F: Write>(&self, out: &mut SourceWriter<F>) {
+        if self.doc_comment.is_empty() {
+            return;
+        }
+        for line in &self.doc_comment {
+            out.write("//");
+            out.write(line);
+            out.new_line();
+        }
+    }
+}

--- a/src/bindgen/ir/documentation.rs
+++ b/src/bindgen/ir/documentation.rs
@@ -4,7 +4,8 @@
 
 use std::io::Write;
 
-use bindgen::writer::SourceWriter;
+use bindgen::writer::{Source, SourceWriter};
+use bindgen::config::Config;
 
 #[derive(Debug, Clone)]
 pub struct Documentation {
@@ -31,9 +32,11 @@ impl Documentation {
             doc_comment: Vec::new(),
         }
     }
+}
 
-    pub fn write<F: Write>(&self, out: &mut SourceWriter<F>) {
-        if self.doc_comment.is_empty() {
+impl Source for Documentation {
+    fn write<F: Write>(&self,config: &Config, out: &mut SourceWriter<F>) {
+        if self.doc_comment.is_empty() || !config.documentation {
             return;
         }
         for line in &self.doc_comment {

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -112,9 +112,7 @@ impl Source for Enum {
             Repr::U8 => "uint8_t",
             _ => unreachable!(),
         };
-        if config.documentation {
-            self.documentation.write(out);
-        }
+        self.documentation.write(config, out);
         if config.language == Language::C {
             out.write(&format!("enum {}", self.name));
         } else {
@@ -125,9 +123,7 @@ impl Source for Enum {
             if i != 0 {
                 out.new_line()
             }
-            if config.documentation {
-                value.2.write(out);
-            }
+            value.2.write(config, out);
             out.write(&format!("{} = {},", value.0, value.1));
         }
         if config.enumeration.add_sentinel(&self.annotations) {

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -22,13 +22,15 @@ pub struct Function {
     pub ret: Type,
     pub args: Vec<(String, Type)>,
     pub extern_decl: bool,
+    pub doc_comment: Documentation,
 }
 
 impl Function {
     pub fn load(name: String,
                 annotations: AnnotationSet,
                 decl: &syn::FnDecl,
-                extern_decl: bool) -> Result<Function, String>
+                extern_decl: bool,
+                doc: String) -> Result<Function, String>
     {
         let args = decl.inputs.iter()
                               .try_skip_map(|x| x.as_ident_and_type())?;
@@ -40,6 +42,7 @@ impl Function {
             ret: ret,
             args: args,
             extern_decl: extern_decl,
+            doc_comment: Documentation::load(doc),
         })
     }
 
@@ -94,7 +97,7 @@ impl Source for Function {
                 out.write(prefix);
                 out.write(" ");
             }
-            cdecl::write_func(out, &func, false);
+            cdecl::write_func(out, &func, false, config.documentation);
             if let Some(ref postfix) = postfix {
                 out.write(" ");
                 out.write(postfix);
@@ -110,7 +113,7 @@ impl Source for Function {
                 out.write(prefix);
                 out.new_line();
             }
-            cdecl::write_func(out, &func, true);
+            cdecl::write_func(out, &func, true, config.documentation);
             if let Some(ref postfix) = postfix {
                 out.new_line();
                 out.write(postfix);

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -22,7 +22,7 @@ pub struct Function {
     pub ret: Type,
     pub args: Vec<(String, Type)>,
     pub extern_decl: bool,
-    pub doc_comment: Documentation,
+    pub documentation: Documentation,
 }
 
 impl Function {
@@ -42,7 +42,7 @@ impl Function {
             ret: ret,
             args: args,
             extern_decl: extern_decl,
-            doc_comment: Documentation::load(doc),
+            documentation: Documentation::load(doc),
         })
     }
 
@@ -97,7 +97,8 @@ impl Source for Function {
                 out.write(prefix);
                 out.write(" ");
             }
-            cdecl::write_func(out, &func, false, config.documentation);
+            func.documentation.write(config, out);
+            cdecl::write_func(out, &func, false);
             if let Some(ref postfix) = postfix {
                 out.write(" ");
                 out.write(postfix);
@@ -113,7 +114,8 @@ impl Source for Function {
                 out.write(prefix);
                 out.new_line();
             }
-            cdecl::write_func(out, &func, true, config.documentation);
+            func.documentation.write(config, out);
+            cdecl::write_func(out, &func, true);
             if let Some(ref postfix) = postfix {
                 out.new_line();
                 out.write(postfix);

--- a/src/bindgen/ir/mod.rs
+++ b/src/bindgen/ir/mod.rs
@@ -8,6 +8,7 @@ pub mod function;
 pub mod opaque;
 pub mod structure;
 pub mod ty;
+pub mod documentation;
 
 pub use self::alias::*;
 pub use self::enumeration::*;
@@ -15,3 +16,4 @@ pub use self::function::*;
 pub use self::opaque::*;
 pub use self::structure::*;
 pub use self::ty::*;
+pub use self::documentation::Documentation;

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -63,9 +63,7 @@ impl OpaqueItem {
 
 impl Source for OpaqueItem {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
-        if config.documentation {
-            self.documentation.write(out);
-        }
+        self.documentation.write(config, out);
         if config.language == Language::C {
             out.write(&format!("struct {};", self.name));
             out.new_line();

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -149,9 +149,8 @@ impl Struct {
 impl Source for Struct {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         assert!(self.generic_params.is_empty());
-        if config.documentation {
-            self.documentation.write(out);
-        }
+
+        self.documentation.write(config, out);
         if config.language == Language::C {
             out.write("typedef struct");
         } else {

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -12,6 +12,7 @@ use bindgen::config::Config;
 use bindgen::library::*;
 use bindgen::utilities::*;
 use bindgen::writer::*;
+use bindgen::ir::Documentation;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum PrimitiveType {
@@ -489,7 +490,13 @@ impl Source for Type {
 
 impl Source for (String, Type) {
     fn write<F: Write>(&self, _config: &Config, out: &mut SourceWriter<F>) {
-        cdecl::write_field(out, &self.1, &self.0);
+        cdecl::write_field(out, &self.1, &self.0, &Documentation::none());
+    }
+}
+
+impl Source for (String, Type, Documentation) {
+    fn write<F: Write>(&self, _config: &Config, out: &mut SourceWriter<F>) {
+        cdecl::write_field(out, &self.1, &self.0, &self.2);
     }
 }
 

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -490,13 +490,14 @@ impl Source for Type {
 
 impl Source for (String, Type) {
     fn write<F: Write>(&self, _config: &Config, out: &mut SourceWriter<F>) {
-        cdecl::write_field(out, &self.1, &self.0, &Documentation::none());
+        cdecl::write_field(out, &self.1, &self.0);
     }
 }
 
 impl Source for (String, Type, Documentation) {
-    fn write<F: Write>(&self, _config: &Config, out: &mut SourceWriter<F>) {
-        cdecl::write_field(out, &self.1, &self.0, &self.2);
+    fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
+        self.2.write(config, out);
+        cdecl::write_field(out, &self.1, &self.0);
     }
 }
 

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -226,24 +226,28 @@ impl Library {
             name: "String".to_owned(),
             generic_params: vec![],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("Box".to_owned(), OpaqueItem {
             name: "Box".to_owned(),
             generic_params: vec!["T".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("Rc".to_owned(), OpaqueItem {
             name: "Rc".to_owned(),
             generic_params: vec!["T".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("Arc".to_owned(), OpaqueItem {
             name: "Arc".to_owned(),
             generic_params: vec!["T".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("Result".to_owned(), OpaqueItem {
@@ -251,18 +255,21 @@ impl Library {
             generic_params: vec!["T".to_owned(),
                                  "E".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("Option".to_owned(), OpaqueItem {
             name: "Option".to_owned(),
             generic_params: vec!["T".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("Vec".to_owned(), OpaqueItem {
             name: "Vec".to_owned(),
             generic_params: vec!["T".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("HashMap".to_owned(), OpaqueItem {
@@ -270,6 +277,7 @@ impl Library {
             generic_params: vec!["K".to_owned(),
                                  "V".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("BTreeMap".to_owned(), OpaqueItem {
@@ -277,30 +285,35 @@ impl Library {
             generic_params: vec!["K".to_owned(),
                                  "V".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("HashSet".to_owned(), OpaqueItem {
             name: "HashSet".to_owned(),
             generic_params: vec!["T".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("BTreeSet".to_owned(), OpaqueItem {
             name: "BTreeSet".to_owned(),
             generic_params: vec!["T".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("LinkedList".to_owned(), OpaqueItem {
             name: "LinkedList".to_owned(),
             generic_params: vec!["T".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
 
         self.opaque_items.insert("VecDeque".to_owned(), OpaqueItem {
             name: "VecDeque".to_owned(),
             generic_params: vec!["T".to_owned()],
             annotations: AnnotationSet::new(),
+            documentation: Documentation::none(),
         });
     }
 
@@ -330,7 +343,11 @@ impl Library {
                                     }
                                 };
 
-                                match Function::load(foreign_item.ident.to_string(), annotations, decl, true) {
+                                match Function::load(foreign_item.ident.to_string(),
+                                                     annotations,
+                                                     decl,
+                                                     true,
+                                                     foreign_item.get_doc_attr()) {
                                     Ok(func) => {
                                         info!("take {}::{}", crate_name, &foreign_item.ident);
 
@@ -365,7 +382,11 @@ impl Library {
                             }
                         };
 
-                        match Function::load(item.ident.to_string(), annotations, decl, false) {
+                        match Function::load(item.ident.to_string(),
+                                             annotations,
+                                             decl,
+                                             false,
+                                             item.get_doc_attr()) {
                             Ok(func) => {
                                 info!("take {}::{}", crate_name, &item.ident);
 
@@ -393,7 +414,7 @@ impl Library {
                     };
 
                     if item.is_repr_c() {
-                        match Struct::load(struct_name.clone(), annotations.clone(), variant, generics) {
+                        match Struct::load(struct_name.clone(), annotations.clone(), variant, generics, item.get_doc_attr()) {
                             Ok(st) => {
                                 info!("take {}::{}", crate_name, &item.ident);
                                 self.structs.insert(struct_name,
@@ -404,7 +425,8 @@ impl Library {
                                 self.opaque_items.insert(struct_name.clone(),
                                                            OpaqueItem::new(struct_name,
                                                                              generics,
-                                                                             annotations));
+                                                                             annotations,
+                                                                             item.get_doc_attr()));
                             }
                         }
                     } else {
@@ -412,7 +434,8 @@ impl Library {
                         self.opaque_items.insert(struct_name.clone(),
                                                    OpaqueItem::new(struct_name,
                                                                      generics,
-                                                                     annotations));
+                                                                     annotations,
+                                                                     item.get_doc_attr()));
                     }
                 }
                 syn::ItemKind::Enum(ref variants, ref generics) => {
@@ -432,7 +455,7 @@ impl Library {
                         }
                     };
 
-                    match Enum::load(enum_name.clone(), item.get_repr(), annotations.clone(), variants) {
+                    match Enum::load(enum_name.clone(), item.get_repr(), annotations.clone(), variants, item.get_doc_attr()) {
                         Ok(en) => {
                             info!("take {}::{}", crate_name, &item.ident);
                             self.enums.insert(enum_name, en);
@@ -442,7 +465,8 @@ impl Library {
                             self.opaque_items.insert(enum_name.clone(),
                                                        OpaqueItem::new(enum_name,
                                                                          generics,
-                                                                         annotations));
+                                                                         annotations,
+                                                                         item.get_doc_attr()));
                         }
                     }
                 }
@@ -462,7 +486,8 @@ impl Library {
                     {
                         match Typedef::load(alias_name.clone(),
                                             annotations.clone(),
-                                            ty)
+                                            ty,
+                                            item.get_doc_attr())
                         {
                             Ok(typedef) => {
                                 info!("take {}::{}", crate_name, &item.ident);
@@ -478,7 +503,8 @@ impl Library {
                     let fail2 = match Specialization::load(alias_name.clone(),
                                                            annotations.clone(),
                                                            generics,
-                                                           ty) {
+                                                           ty,
+                                                           item.get_doc_attr()) {
                         Ok(spec) => {
                             info!("take {}::{}", crate_name, &item.ident);
                             self.specializations.insert(alias_name, spec);

--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -122,6 +122,50 @@ impl SynItemHelpers for ForeignItem {
     }
 }
 
+impl SynItemHelpers for Variant {
+    fn has_attr(&self, target: MetaItem) -> bool {
+        return self.attrs
+                   .iter()
+                   .any(|ref attr| attr.style == AttrStyle::Outer && attr.value == target);
+    }
+
+    fn get_doc_attr(&self) -> String {
+        let mut doc = String::new();
+        for attr in &self.attrs {
+            if attr.style == AttrStyle::Outer &&
+               attr.is_sugared_doc {
+                if let MetaItem::NameValue(_, Lit::Str(ref comment, _)) = attr.value {
+                    doc.push_str(&comment);
+                    doc.push('\n');
+                }
+            }
+        }
+        doc
+    }
+}
+
+impl SynItemHelpers for Field {
+    fn has_attr(&self, target: MetaItem) -> bool {
+        return self.attrs
+                   .iter()
+                   .any(|ref attr| attr.style == AttrStyle::Outer && attr.value == target);
+    }
+
+    fn get_doc_attr(&self) -> String {
+        let mut doc = String::new();
+        for attr in &self.attrs {
+            if attr.style == AttrStyle::Outer &&
+               attr.is_sugared_doc {
+                if let MetaItem::NameValue(_, Lit::Str(ref comment, _)) = attr.value {
+                    doc.push_str(&comment);
+                    doc.push('\n');
+                }
+            }
+        }
+        doc
+    }
+}
+
 /// Helper function for accessing Abi information
 pub trait SynAbiHelpers {
     fn is_c(&self) -> bool;


### PR DESCRIPTION
This adds an option to translate rust doc comments into documentation
comments in the generated c/c++ header. 

For example the following code is translated into the following header:

```rust
/// This is the color enum
#[repr(u8)]
pub enum Color {
    /// Red color
    Red = 1,
    Blue = 2,
}

/// This is the color struct
#[repr(C)]
pub struct ColorStruct {
     /// A field storing the color of the struct
     my_color: Color,
}

/// A function taking the color struct
#[no_mangle]
extern "C" fn take_color_struct(a: ColorStruct) {}
```

```C++
// This is the color enum
enum class Color: uint8_t {
    // Red color
    Red = 1;
    Blue = 2;
};

// This is the color struct
struct ColorStruct {
     // A field storing the color of the struct
     Color my_color;
};

// A function taking the color struct
void take_color_struct(ColorStruct a);

```