### PR TITLE
Add a option the prefix enum values by the enum name

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -226,6 +226,8 @@ pub struct EnumConfig {
     /// Whether to add a `Sentinel` value at the end of every enum
     /// This is useful in Gecko for IPC serialization
     pub add_sentinel: bool,
+    /// Whether the enum variants should be prefixed with the enum name
+    pub prefix_with_enum_name: bool,
 }
 
 impl Default for EnumConfig {
@@ -233,6 +235,7 @@ impl Default for EnumConfig {
         EnumConfig {
             rename_variants: None,
             add_sentinel: false,
+            prefix_with_enum_name: false,
         }
     }
 }

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -227,7 +227,7 @@ pub struct EnumConfig {
     /// This is useful in Gecko for IPC serialization
     pub add_sentinel: bool,
     /// Whether the enum variants should be prefixed with the enum name
-    pub prefix_with_enum_name: bool,
+    pub prefix_with_name: bool,
 }
 
 impl Default for EnumConfig {
@@ -235,7 +235,7 @@ impl Default for EnumConfig {
         EnumConfig {
             rename_variants: None,
             add_sentinel: false,
-            prefix_with_enum_name: false,
+            prefix_with_name: false,
         }
     }
 }

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -90,8 +90,8 @@ impl Enum {
     }
 
     pub fn rename_fields(&mut self, config: &Config) {
-        if config.enumeration.prefix_with_enum_name ||
-           self.annotations.bool("prefix_with_enum_name").unwrap_or(false)
+        if config.enumeration.prefix_with_name ||
+           self.annotations.bool("prefix-with-name").unwrap_or(false)
         {
             let old = ::std::mem::replace(&mut self.values, Vec::new());
             for (name, value, doc) in old {

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -90,6 +90,15 @@ impl Enum {
     }
 
     pub fn rename_fields(&mut self, config: &Config) {
+        if config.enumeration.prefix_with_enum_name ||
+           self.annotations.bool("prefix_with_enum_name").unwrap_or(false)
+        {
+            let old = ::std::mem::replace(&mut self.values, Vec::new());
+            for (name, value, doc) in old {
+                self.values.push((format!("{}_{}", self.name, name), value, doc));
+            }
+        }
+
         let rules = [self.annotations.parse_atom::<RenameRule>("rename-all"),
                      config.enumeration.rename_variants];
 


### PR DESCRIPTION
This is mostly usefull for generated c headers because enums values
will live in the global namespace there

With this option enabled for the following code
```rust
#[repr(u8)]
pub enum Color {
    Red = 1,
    Blue = 2,
}
```
the following C Header is generated
```C
enum Color {
    Color_Red = 1,
    Color_Blue = 2,
};

typedef uint8_t Color;
```