### PR TITLE
Generate member functions

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -159,6 +159,9 @@ pub struct StructConfig {
     pub derive_gt: bool,
     /// Whether to generate a greater than or equal to operator on structs with one field
     pub derive_gte: bool,
+    /// Whether to generate member functions to wrap functions taking a pointer to this struct as
+    /// first argument
+    pub generate_member_functions: bool,
 }
 
 impl Default for StructConfig {
@@ -172,6 +175,7 @@ impl Default for StructConfig {
             derive_lte: false,
             derive_gt: false,
             derive_gte: false,
+            generate_member_functions: true,
         }
     }
 }

--- a/src/bindgen/ir/alias.rs
+++ b/src/bindgen/ir/alias.rs
@@ -114,6 +114,7 @@ impl Specialization {
                                                   .collect(),
                             generic_params: self.generic_params.clone(),
                             documentation: aliased.documentation.clone(),
+                            functions: Vec::new(),
                         })))
                     }
                     PathValue::Enum(ref aliased) => {

--- a/src/bindgen/ir/alias.rs
+++ b/src/bindgen/ir/alias.rs
@@ -231,9 +231,7 @@ impl Typedef {
 
 impl Source for Typedef {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
-        if config.documentation {
-            self.documentation.write(config, out);
-        }
+        self.documentation.write(config, out);
         out.write("typedef ");
         (self.name.clone(), self.aliased.clone()).write(config, out);
         out.write(";");

--- a/src/bindgen/ir/alias.rs
+++ b/src/bindgen/ir/alias.rs
@@ -115,6 +115,7 @@ impl Specialization {
                             generic_params: self.generic_params.clone(),
                             documentation: aliased.documentation.clone(),
                             functions: Vec::new(),
+                            destructor: None,
                         })))
                     }
                     PathValue::Enum(ref aliased) => {

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -351,8 +351,8 @@ fn format_function_call_2<W: Write>(f: &Function, out: &mut SourceWriter<W>) {
     }
     out.write(&f.name);
     out.write("(");
-    let align_lenght = out.line_length_for_align();
-    out.push_set_spaces(align_lenght);
+    let align_length = out.line_length_for_align();
+    out.push_set_spaces(align_length);
     out.write("this");
     for &(ref name, _) in &f.args[1..] {
         out.write(",");

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -161,14 +161,7 @@ impl Source for Struct {
         }
         out.open_brace();
 
-        if config.documentation {
-            out.write_vertical_source_list(&self.fields, ListType::Cap(";"));
-        } else {
-            out.write_vertical_source_list(&self.fields.iter()
-                .map(|&(ref name, ref ty, _)| (name.clone(), ty.clone()))
-                .collect(),
-                ListType::Cap(";"));
-        }
+        out.write_vertical_source_list(&self.fields, ListType::Cap(";"));
 
         if config.language == Language::Cxx {
             let mut wrote_start_newline = false;

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -204,13 +204,13 @@ impl Struct {
 
                 out.write(&format!("~{}()", self.name));
                 out.open_brace();
-                let option_1 = out.measure(|out| format_function_call_1(destructor, out, false));
+                let option_1 = out.measure(|out| format_function_call_1(destructor, out));
 
                 if (config.function.args == Layout::Auto && option_1 <= config.line_length) ||
                     config.function.args == Layout::Horizontal {
-                        format_function_call_1(destructor, out, false);
+                        format_function_call_1(destructor, out);
                     } else {
-                        format_function_call_2(destructor, out, false);
+                        format_function_call_2(destructor, out);
                     }
 
                 out.close_brace(false);
@@ -229,13 +229,13 @@ impl Struct {
             out.new_line();
             f.write_formated(config, out, false);
             out.open_brace();
-            let option_1 = out.measure(|out| format_function_call_1(f, out, true));
+            let option_1 = out.measure(|out| format_function_call_1(f, out));
 
             if (config.function.args == Layout::Auto && option_1 <= config.line_length) ||
                 config.function.args == Layout::Horizontal {
-                    format_function_call_1(f, out, true);
+                    format_function_call_1(f, out);
                 } else {
-                    format_function_call_2(f, out, true);
+                    format_function_call_2(f, out);
                 }
 
             out.close_brace(false);
@@ -326,11 +326,11 @@ impl Source for Struct {
     }
 }
 
-fn format_function_call_1<W: Write>(f: &Function, out: &mut SourceWriter<W>, with_return: bool) {
-    if with_return {
-        out.write("return ::");
-    } else {
+fn format_function_call_1<W: Write>(f: &Function, out: &mut SourceWriter<W>) {
+    if f.ret == Type::Primitive(PrimitiveType::Void) {
         out.write("::");
+    } else {
+        out.write("return ::");
     }
     out.write(&f.name);
     out.write("(this");
@@ -341,11 +341,11 @@ fn format_function_call_1<W: Write>(f: &Function, out: &mut SourceWriter<W>, wit
     out.write(");");
 }
 
-fn format_function_call_2<W: Write>(f: &Function, out: &mut SourceWriter<W>, with_return: bool) {
-    if with_return {
-        out.write("return ::");
-    } else {
+fn format_function_call_2<W: Write>(f: &Function, out: &mut SourceWriter<W>) {
+    if f.ret == Type::Primitive(PrimitiveType::Void) {
         out.write("::");
+    } else {
+        out.write("return ::");
     }
     out.write(&f.name);
     out.write("(");

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -109,7 +109,7 @@ impl Struct {
         if !out.contains_key(&self.name) {
             out.insert(self.name.clone(), BTreeMap::new());
         }
-        out.get_mut(&self.name).unwrap().insert(generic_values.clone(), 
+        out.get_mut(&self.name).unwrap().insert(generic_values.clone(),
                                                 Monomorph::Struct(monomorph));
     }
 
@@ -191,6 +191,16 @@ impl Struct {
             if !destructor.extern_decl {
                 out.new_line();
                 out.new_line();
+                // Explicitly disable copy constructor and assignment
+                out.write(&format!("{0}(const {0}& ) = delete;", self.name));
+                out.new_line();
+                out.write(&format!("{0}& operator=(const {0}&) = delete;", self.name));
+                out.new_line();
+                out.write(&format!("{0}({0}&&) = default;", self.name));
+                out.new_line();
+                out.write(&format!("{0}& operator=({0}&&) = default;", self.name));
+                out.new_line();
+                out.new_line();
 
                 out.write(&format!("~{}()", self.name));
                 out.open_brace();
@@ -210,7 +220,6 @@ impl Struct {
 
     pub fn write_functions<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         if !self.functions.is_empty() {
-            out.new_line();
             out.new_line();
         }
         for f in &self.functions {

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -638,10 +638,10 @@ impl Library {
         // Gather only the items that we need for this
         // `extern "c"` interface
         let mut deps = DependencyList::new();
-        let mut oop = MemberFunctions::new();
+        let mut member_functions = MemberFunctions::new();
         for (_, function) in &self.functions {
             function.add_deps(&self, &mut deps);
-            function.add_member_function(&mut oop);
+            function.add_member_function(&mut member_functions);
         }
 
         // Gather a list of all the instantiations of generic structs
@@ -722,11 +722,11 @@ impl Library {
                 match item {
                     PathValue::Struct(mut s) => {
                         let ty = Type::Path(s.name.clone(), Vec::new());
-                        if let Some(functions) = oop.remove(&ty) {
+                        if let Some(functions) = member_functions.remove(&ty) {
                             let opaque = s.as_opaque();
                             result.items.push(PathValue::OpaqueItem(opaque));
                             s.add_member_functions(functions);
-                            result.full_objects.push(s);
+                            result.member_function_structs.push(s);
                         } else {
                             result.items.push(PathValue::Struct(s));
                         }
@@ -747,7 +747,7 @@ impl Library {
             item.rename_fields(&self.config);
         }
 
-        for item in &mut result.full_objects {
+        for item in &mut result.member_function_structs {
             item.mangle_paths(&monomorphs);
             item.rename_fields(&self.config);
         }
@@ -791,7 +791,7 @@ pub struct GeneratedBindings {
     monomorphs: Monomorphs,
     items: Vec<PathValue>,
     functions: Vec<Function>,
-    full_objects: Vec<Struct>,
+    member_function_structs: Vec<Struct>,
 }
 
 impl GeneratedBindings {
@@ -801,7 +801,7 @@ impl GeneratedBindings {
             monomorphs: Monomorphs::new(),
             items: Vec::new(),
             functions: Vec::new(),
-            full_objects: Vec::new(),
+            member_function_structs: Vec::new(),
         }
     }
 
@@ -913,10 +913,14 @@ impl GeneratedBindings {
 
         if self.config.language == Language::Cxx {
             out.new_line();
-            out.new_line();
-            for full_object in &self.full_objects {
+            let mut first = true;
+            for full_object in &self.member_function_structs {
+                if first {
+                    first = false;
+                } else {
+                    out.new_line();
+                }
                 full_object.write(&self.config, &mut out);
-                out.new_line();
                 out.new_line();
             }
         }

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -725,9 +725,7 @@ impl Library {
                         if let Some(functions) = oop.remove(&ty) {
                             let opaque = s.as_opaque();
                             result.items.push(PathValue::OpaqueItem(opaque));
-                            for f in functions {
-                                s.add_member_function(f.as_member());
-                            }
+                            s.add_member_functions(functions);
                             result.full_objects.push(s);
                         } else {
                             result.items.push(PathValue::Struct(s));


### PR DESCRIPTION
This pull request tries to make the generated c++ header more idiomatic.
In detail it tries to generate small member functions wrapping the exported functions for this type. 

For example for the following rust code
```rust
#[repr(C)]
struct MyStruct {
    some_value: i32,
}


#[no_mangle]
extern "C" fn do_something(a: *const MyStruct) {}
```

The following c++ header is generated
```C++
struct MyStruct;

void do_something(MyStruct* a);

struct MyStruct {
    uint32_t some_value;

    void do_something() {
        return ::do_something(this);
    }
};
```

In addition to generate more idiomatic code this allows to enforce some invariants of the underlying rust code. For example one could now safely assume that the pointer a for the function `do_something` is not null.

Future improvements for this feature may be to generate also constructor and destructor wrappers. 
I'm not sure about the syntax of this yet.