### PR TITLE
Fix order of structs in case of using multiple monomorphs of the same type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.20"
 dependencies = [
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -79,6 +80,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "num-traits"
 version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ordermap"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -218,6 +224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
 "checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
+"checksum ordermap 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c036a53e6bb62d7eee2edf7e087df56fd84c7bbae6a0bd93c2b9f54bddf62e03"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_derive = "0.9"
 serde_json = "0.9"
 tempdir = "0.3"
 toml = "0.3"
+ordermap = "0.2"
 
 [dependencies.syn]
 version = "0.11"

--- a/src/bindgen/ir/alias.rs
+++ b/src/bindgen/ir/alias.rs
@@ -64,12 +64,11 @@ impl Specialization {
     pub fn add_specializations(&self, library: &Library, out: &mut SpecializationList) {
         match self.specialize(library) {
             Ok(Some(specialization)) => {
-                if !out.items.contains(specialization.name()) {
-                    out.items.insert(specialization.name().to_owned());
+                if !out.order.contains_key(specialization.name()) {
 
                     specialization.add_specializations(library, out);
 
-                    out.order.push(specialization);
+                    out.order.insert(specialization.name().to_owned(), specialization);
                 }
             }
             Ok(None) => { }

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -315,12 +315,19 @@ impl Type {
                 }
                 if !generic_params.contains(path) {
                     if let Some(value) = library.resolve_path(path) {
-                        if !out.items.contains(path) {
-                            out.items.insert(path.clone());
-
+                        if !out.contains_key(path) {
                             value.add_deps(library, out);
 
-                            out.order.push(value);
+                            out.insert(path.clone(), value);
+                        } else if out.contains_key(path) && !generic_values.is_empty() {
+                            // The type is generic but was already pushed tho the current list
+                            // We don't know if the current monomorphed type will be known before
+                            // this point. At this point the type is known, because it it
+                            // already pushed (by the loop above), so we simply remove
+                            // the type from it old place in the list and put it to the
+                            // end of the current list
+                            out.remove(path);
+                            out.insert(path.clone(), value);
                         }
                     } else {
                         warn!("can't find {}", path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate syn;
 extern crate toml;
+extern crate ordermap;
 
 mod bindgen;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate syn;
 extern crate toml;
+extern crate ordermap;
 
 use clap::{Arg, ArgMatches, App};
 


### PR DESCRIPTION
Fixed Example:

```rust
struct List<T> {
     members: *mut T,
     count: usize
}

struct A;

struct B;

extern "C" fn foo(a: List<A>) {}
extern "C" fn bar(b: List<B>) {}
```

Before this commit the following code was generated:

```C++
struct A {};

struct List_A {
    A* members;
    size_t count;
};

struct List_B {
    B* members;
    size_t count;
}

struct B {};
```

After this commit the order of the generated structs are fixed:
```C++
struct A {};

struct B {};

struct List_A {
    A* members;
    size_t count;
};

struct List_B {
    B* members;
    size_t count;
}
```