### PR TITLE
Fix order of structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.20"
 dependencies = [
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -53,6 +54,11 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fixedbitset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "itoa"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +86,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "num-traits"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ordermap"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "petgraph"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "quote"
@@ -213,11 +233,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b8f69e518f967224e628896b54e41ff6acfb4dcfefc5076325c36525dac900f"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
+"checksum fixedbitset 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b0cb3d75726fa0c5ed3dce5dfcf0796affa2a60b33967f45012d86fb95a886f2"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
 "checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
+"checksum ordermap 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c036a53e6bb62d7eee2edf7e087df56fd84c7bbae6a0bd93c2b9f54bddf62e03"
+"checksum petgraph 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "14c6ae5ccb73b438781abc93d35615019b1ad6e24b44116377fb819cfd7587de"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_derive = "0.9"
 serde_json = "0.9"
 tempdir = "0.3"
 toml = "0.3"
+petgraph = "0.4"
 
 [dependencies.syn]
 version = "0.11"

--- a/compile-tests/cycle.rs
+++ b/compile-tests/cycle.rs
@@ -1,0 +1,13 @@
+
+#[repr(C)]
+pub struct A {
+    b: *const B,
+}
+
+#[repr(C)]
+pub struct B {
+    a: *const A,
+}
+
+#[no_mangle]
+pub extern "C" fn foo(a: A) {}

--- a/src/bindgen/ir/alias.rs
+++ b/src/bindgen/ir/alias.rs
@@ -61,13 +61,16 @@ impl Specialization {
         }
     }
 
-    pub fn add_specializations(&self, library: &Library, out: &mut SpecializationList) {
+    pub fn add_specializations(&self, library: &Library,
+                               out: &mut SpecializationList,
+                               cycle_check: &mut CycleCheckList)
+    {
         match self.specialize(library) {
             Ok(Some(specialization)) => {
                 if !out.items.contains(specialization.name()) {
                     out.items.insert(specialization.name().to_owned());
 
-                    specialization.add_specializations(library, out);
+                    specialization.add_specializations(library, out, cycle_check);
 
                     out.order.push(specialization);
                 }
@@ -215,12 +218,18 @@ impl Typedef {
         self.aliased.add_deps(library, out);
     }
 
-    pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
-        self.aliased.add_monomorphs(library, out);
+    pub fn add_monomorphs(&self, library: &Library,
+                          out: &mut Monomorphs,
+                          cycle_check: &mut CycleCheckList)
+    {
+        self.aliased.add_monomorphs(library, out, cycle_check);
     }
 
-    pub fn add_specializations(&self, library: &Library, out: &mut SpecializationList) {
-        self.aliased.add_specializations(library, out);
+    pub fn add_specializations(&self, library: &Library,
+                               out: &mut SpecializationList,
+                               cycle_check: &mut CycleCheckList)
+    {
+        self.aliased.add_specializations(library, out, cycle_check);
     }
 
     pub fn mangle_paths(&mut self, monomorphs: &Monomorphs) {

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -53,17 +53,23 @@ impl Function {
         }
     }
 
-    pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
-        self.ret.add_monomorphs(library, out);
+    pub fn add_monomorphs(&self, library: &Library,
+                          out: &mut Monomorphs,
+                          cycle_check: &mut CycleCheckList)
+    {
+        self.ret.add_monomorphs(library, out, cycle_check);
         for &(_, ref ty) in &self.args {
-            ty.add_monomorphs(library, out);
+            ty.add_monomorphs(library, out, cycle_check);
         }
     }
 
-    pub fn add_specializations(&self, library: &Library, out: &mut SpecializationList) {
-        self.ret.add_specializations(library, out);
+    pub fn add_specializations(&self, library: &Library,
+                               out: &mut SpecializationList,
+                               cycle_check: &mut CycleCheckList)
+    {
+        self.ret.add_specializations(library, out, cycle_check);
         for &(_, ref ty) in &self.args {
-            ty.add_specializations(library, out);
+            ty.add_specializations(library, out, cycle_check);
         }
     }
 

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -4,6 +4,7 @@
 
 use std::collections::BTreeMap;
 use std::io::Write;
+use std::fmt::{Display, self};
 
 use syn;
 
@@ -23,6 +24,12 @@ pub struct Struct {
     pub fields: Vec<(String, Type, Documentation)>,
     pub generic_params: Vec<String>,
     pub documentation: Documentation,
+}
+
+impl Display for Struct {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Struct {}", self.name)
+    }
 }
 
 impl Struct {
@@ -64,6 +71,15 @@ impl Struct {
             generic_params: generic_params,
             documentation: Documentation::load(doc),
         })
+    }
+
+    pub fn as_opaque(&self) -> OpaqueItem {
+        OpaqueItem {
+            name: self.name.clone(),
+            generic_params: self.generic_params.clone(),
+            annotations: self.annotations.clone(),
+            documentation: self.documentation.clone(),
+        }
     }
 
     pub fn add_deps(&self, library: &Library, out: &mut DependencyList) {

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -88,12 +88,16 @@ impl Struct {
         }
     }
 
-    pub fn add_monomorphs(&self, library: &Library, generic_values: &Vec<Type>, out: &mut Monomorphs) {
+    pub fn add_monomorphs(&self, library: &Library,
+                          generic_values: &Vec<Type>,
+                          out: &mut Monomorphs,
+                          cycle_check: &mut CycleCheckList)
+    {
         assert!(self.generic_params.len() == generic_values.len());
 
         if self.generic_params.len() == 0 {
             for &(_, ref ty, _) in &self.fields {
-                ty.add_monomorphs(library, out);
+                ty.add_monomorphs(library, out, cycle_check);
             }
             return;
         }
@@ -113,19 +117,22 @@ impl Struct {
         };
 
         for &(_, ref ty, _) in &monomorph.fields {
-            ty.add_monomorphs(library, out);
+            ty.add_monomorphs(library, out, cycle_check);
         }
 
         if !out.contains_key(&self.name) {
             out.insert(self.name.clone(), BTreeMap::new());
         }
-        out.get_mut(&self.name).unwrap().insert(generic_values.clone(), 
+        out.get_mut(&self.name).unwrap().insert(generic_values.clone(),
                                                 Monomorph::Struct(monomorph));
     }
 
-    pub fn add_specializations(&self, library: &Library, out: &mut SpecializationList) {
+    pub fn add_specializations(&self, library: &Library,
+                               out: &mut SpecializationList,
+                               cycle_check: &mut CycleCheckList)
+    {
         for &(_, ref ty, _) in &self.fields {
-            ty.add_specializations(library, out);
+            ty.add_specializations(library, out, cycle_check);
         }
     }
 

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -6,7 +6,6 @@ use std::io::Write;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::cmp::Ordering;
 use std::fs::File;
 use std::path;
 use std::fs;
@@ -20,6 +19,9 @@ use bindgen::ir::*;
 use bindgen::rust_lib;
 use bindgen::utilities::*;
 use bindgen::writer::{ListType, Source, SourceWriter};
+
+use petgraph::{Graph, Direction};
+use petgraph::graph::{NodeIndex};
 
 /// A path ref is used to reference a path value
 pub type PathRef = String;
@@ -127,16 +129,150 @@ pub type Monomorphs = BTreeMap<PathRef, MonomorphList>;
 
 /// A dependency list is used for gathering what order to output the types.
 pub struct DependencyList {
-    pub order: Vec<PathValue>,
-    pub items: HashSet<PathRef>,
+    pub lookup: HashSet<PathRef>,
+    pub items: Vec<PathValue>,
 }
 
 impl DependencyList {
     fn new() -> DependencyList {
         DependencyList {
-            order: Vec::new(),
-            items: HashSet::new(),
+            lookup: HashSet::new(),
+            items: Vec::new(),
         }
+    }
+
+    fn calculate_order(self, monomorphs: &Monomorphs, library: &Library) -> Vec<PathValue> {
+        let mut enums = Vec::new();
+        let mut opaque = Vec::new();
+        let mut type_def = Vec::new();
+        let mut specialization = Vec::new();
+
+        // We use i8 as edge weight because it implements display
+        let mut graph = Graph::<Struct, i8>::new();
+        let mut lookup = HashMap::<PathRef, NodeIndex>::new();
+
+        // Add all monomorphs of a all useded items to our dependency graph
+        for item in self.items.into_iter() {
+            match item {
+                e @ PathValue::Enum(_) => enums.push(e),
+                t @ PathValue::Typedef(_) => type_def.push(t),
+                s @ PathValue::Specialization(_) => specialization.push(s),
+                PathValue::OpaqueItem(o) => {
+                    if let Some(m) = monomorphs.get(&o.name) {
+                        for (_, monomorph) in m {
+                            match *monomorph {
+                                Monomorph::Struct(ref s) => {
+                                    let idx = graph.add_node(s.clone());
+                                    lookup.insert(s.name.clone(), idx);
+                                }
+                                Monomorph::OpaqueItem(ref o) => {
+                                    opaque.push(PathValue::OpaqueItem(o.clone()))
+                                }
+                            }
+                        }
+                    } else {
+                        opaque.push(PathValue::OpaqueItem(o))
+                    }
+                },
+                PathValue::Struct(s) => {
+                    if let Some(m) = monomorphs.get(&s.name){
+                        for (_, monomorph) in m {
+                            match *monomorph {
+                                Monomorph::Struct(ref s) => {
+                                    let idx = graph.add_node(s.clone());
+                                    lookup.insert(s.name.clone(), idx);
+                                }
+                                Monomorph::OpaqueItem(ref o) => {
+                                    opaque.push(PathValue::OpaqueItem(o.clone()))
+                                },
+                            }
+                        }
+                    } else {
+                        let name = s.name.clone();
+                        let idx = graph.add_node(s);
+                        lookup.insert(name, idx);
+                    }
+                }
+            }
+        }
+
+        // For each node add all dependendcies
+        // This is done by simply go through all struct fields and add each type
+        // as dependency/edge to the graph
+        for id in graph.node_indices() {
+            let fields = &graph.node_weight(id)
+                .expect("Must be there because we get the id's above")
+                .fields.clone();
+            for &(_, ref ty, _) in fields {
+                let iter = ty.lookup(library).into_iter().filter_map(|t| {
+                    match t {
+                        PathValue::Struct(ref s) if s.generic_params.is_empty() => {
+                            Some(s.name.clone())
+                        },
+                        PathValue::Struct(ref s) if monomorphs.get(&s.name).is_some() => {
+                            let monomorphs = monomorphs.get(&s.name).expect("Checked it's there above");
+                            ty.resolve_monomorphed_type(monomorphs)
+                        },
+                        PathValue::Struct(_) => unreachable!(),
+                        _ => None,
+                    }
+                });
+                for dep in iter {
+                    if let Some(to_id) = lookup.get(&dep) {
+                        graph.add_edge(id, *to_id, 0);
+                    } else {
+                        panic!("Type {} not found", dep);
+                    }
+                }
+            }
+        }
+        // Debug output
+        use petgraph::dot::Dot;
+        println!("{}", Dot::new(&graph));
+
+        let mut structs = Vec::new();
+        // loop over the graph till there are no elements left
+        while graph.node_count() > 0 {
+            // find structs without any dependency
+            let externals = graph.externals(Direction::Outgoing).collect::<Vec<_>>();
+            if externals.is_empty() {
+                // there is a cyclic graph left, so we add a struct as opaque
+                // item and remove some edge from the dependceny graph
+                if let Some(id) = graph.node_indices().next() {
+                    {
+                        let node = graph.node_weight(id)
+                            .expect("We got the id from the graph");
+                        opaque.push(PathValue::OpaqueItem(node.as_opaque()));
+                    }
+                    let n =  graph.neighbors_directed(id, Direction::Outgoing)
+                        .next()
+                        .expect("It's a cyclic graph, so this must be there");
+                    let e = graph.find_edge(n, id)
+                        .expect("It's a cyclic graph, so this must be there");
+
+                    graph.remove_edge(e);
+                } else {
+                    // No nodes left?
+                    // can this happen?
+                    break;
+                }
+            } else {
+                // Iterate over all nodes without dependency
+                // 1. Remove them from the graph
+                // 2. Push them to the orderd struct list
+                for idx in externals {
+                    if let Some(s) = graph.remove_node(idx){
+                        structs.push(PathValue::Struct(s));
+                    }
+                }
+            }
+        }
+
+        enums.extend_from_slice(&opaque);
+        enums.extend_from_slice(&structs);
+        enums.extend_from_slice(&type_def);
+        assert!(specialization.is_empty());
+        enums
     }
 }
 
@@ -642,75 +778,13 @@ impl Library {
         }
 
         // Gather a list of all the instantiations of generic structs
-        // TODO - monomorphs of a single type are not sorted by dependencies
         let mut monomorphs = Monomorphs::new();
         for (_, function) in &self.functions {
             function.add_monomorphs(&self, &mut monomorphs);
         }
-
-        // Copy the binding items in dependencies order into the generated bindings,
-        // adding any instantiations of generic structs along the way.
-        for dep in deps.order {
-            match &dep {
-                &PathValue::Struct(ref s) => {
-                    if s.generic_params.len() != 0 {
-                        if let Some(monomorphs) = monomorphs.get(&s.name) {
-                            for (_, monomorph) in monomorphs {
-                                result.items.push(match monomorph {
-                                    &Monomorph::Struct(ref x) => {
-                                        PathValue::Struct(x.clone())
-                                    }
-                                    &Monomorph::OpaqueItem(ref x) => {
-                                        PathValue::OpaqueItem(x.clone())
-                                    }
-                                });
-                            }
-                        }
-                        continue;
-                    } else {
-                        debug_assert!(!monomorphs.contains_key(&s.name));
-                    }
-                }
-                &PathValue::OpaqueItem(ref s) => {
-                    if s.generic_params.len() != 0 {
-                        if let Some(monomorphs) = monomorphs.get(&s.name) {
-                            for (_, monomorph) in monomorphs {
-                                result.items.push(match monomorph {
-                                    &Monomorph::Struct(ref x) => {
-                                        PathValue::Struct(x.clone())
-                                    }
-                                    &Monomorph::OpaqueItem(ref x) => {
-                                        PathValue::OpaqueItem(x.clone())
-                                    }
-                                });
-                            }
-                        }
-                        continue;
-                    } else {
-                        debug_assert!(!monomorphs.contains_key(&s.name));
-                    }
-                }
-                _ => { }
-            }
-            result.items.push(dep);
         }
+        result.items = deps.calculate_order(&monomorphs, &self);
 
-        // Sort enums and opaque structs into their own layers because they don't
-        // depend on each other or anything else.
-        let ordering = |a: &PathValue, b: &PathValue| {
-            match (a, b) {
-                (&PathValue::Enum(ref e1), &PathValue::Enum(ref e2)) => e1.name.cmp(&e2.name),
-                (&PathValue::Enum(_), _) => Ordering::Less,
-                (_, &PathValue::Enum(_)) => Ordering::Greater,
-
-                (&PathValue::OpaqueItem(ref o1), &PathValue::OpaqueItem(ref o2)) => o1.name.cmp(&o2.name),
-                (&PathValue::OpaqueItem(_), _) => Ordering::Less,
-                (_, &PathValue::OpaqueItem(_)) => Ordering::Greater,
-
-                _ => Ordering::Equal,
-            }
-        };
-        result.items.sort_by(ordering);
 
         result.functions = self.functions.iter()
                                          .map(|(_, function)| function.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate syn;
 extern crate toml;
+extern crate petgraph;
 
 mod bindgen;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate syn;
 extern crate toml;
+extern crate petgraph;
 
 use clap::{Arg, ArgMatches, App};
 


### PR DESCRIPTION
Improved version of #39 
Fixed Example:

```rust
struct List<T> {
     members: *mut T,
     count: usize
}

struct A;

struct B;

extern "C" fn foo(a: List<A>) {}
extern "C" fn bar(b: List<B>) {}
```

Before this commit the following code was generated:

```C++
struct A {};

struct List_A {
    A* members;
    size_t count;
};

struct List_B {
    B* members;
    size_t count;
}

struct B {};
```

After this commit the order of the generated structs are fixed:
```C++
struct A {};

struct B {};

struct List_A {
    A* members;
    size_t count;
};

struct List_B {
    B* members;
    size_t count;
}
```