### PR TITLE
Made it so `cargo doc` can generate docs for the library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ features = ["full"]
 [[bin]]
 name = "cbindgen"
 path = "src/main.rs"
+doc = false
 
 [lib]
 name = "cbindgen"


### PR DESCRIPTION
I've noticed that running `cargo doc` can't build the documentation because the binary and its backing library have the same name. It's not really useful to document the binary, so I've told cargo to ignore it. Otherwise running `cargo doc` spits out an error like this:

```
error: cannot document a package where a library and a binary have the same name. Consider renaming one or marking the target as `doc = false`
```