### PR TITLE
Implement doc handling for macro expansion

### DIFF
--- a/src/bindgen/ir/annotation.rs
+++ b/src/bindgen/ir/annotation.rs
@@ -49,13 +49,15 @@ impl AnnotationSet {
         let mut lines = Vec::new();
 
         for attr in attrs {
-            if attr.style == syn::AttrStyle::Outer &&
-               attr.is_sugared_doc {
-                if let syn::MetaItem::NameValue(_, syn::Lit::Str(ref comment, _)) = attr.value {
-                    let line = comment.trim_left_matches("///").trim();
-
-                    if line.starts_with("cbindgen:") {
-                        lines.push(line.to_owned());
+            if attr.style == syn::AttrStyle::Outer {
+                if let syn::MetaItem::NameValue(
+                    ref name, syn::Lit::Str(ref comment, _)) = attr.value
+                {
+                    if &*name == "doc" {
+                        let line = comment.trim_left_matches("///").trim();
+                        if line.starts_with("cbindgen:") {
+                            lines.push(line.to_owned());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I'm not sure if this is the best way to fix it, but this seems to work quite well. I have no idea how this is supposed to work but obviously one could also fix this in sym.

This fixes https://github.com/eqrion/cbindgen/issues/60