### PR TITLE
Use C-style comments in C mode

### DIFF
--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -163,7 +163,11 @@ impl Bindings {
         }
         if let Some(ref f) = self.config.include_guard {
             out.new_line_if_not_start();
-            out.write(&format!("#endif // {}", f));
+            if self.config.language == Language::C {
+                out.write(&format!("#endif /* {} */", f));
+            } else {
+                out.write(&format!("#endif // {}", f));
+            }
             out.new_line();
         }
         if let Some(ref f) = self.config.trailer {

--- a/src/bindgen/ir/documentation.rs
+++ b/src/bindgen/ir/documentation.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 
 use syn;
 
-use bindgen::config::Config;
+use bindgen::config::{Config, Language};
 use bindgen::writer::{Source, SourceWriter};
 
 #[derive(Debug, Clone)]
@@ -44,14 +44,26 @@ impl Documentation {
 }
 
 impl Source for Documentation {
-    fn write<F: Write>(&self,config: &Config, out: &mut SourceWriter<F>) {
+    fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         if self.doc_comment.is_empty() || !config.documentation {
             return;
         }
 
+        if config.language == Language::C {
+            out.write("/*");
+            out.new_line();
+        }
         for line in &self.doc_comment {
-            out.write("// ");
+            if config.language != Language::C {
+                out.write("// ");
+            } else {
+                out.write(" * ");
+            }
             out.write(line);
+            out.new_line();
+        }
+        if config.language == Language::C {
+            out.write(" */");
             out.new_line();
         }
     }


### PR DESCRIPTION
I picked one code style for C comments here that seems well established in C land. There might be better ones but that one was also pretty simple and straightforward to implement without needing special handling.

This fixes https://github.com/eqrion/cbindgen/issues/59