### PR TITLE
Fix incorrectly implemented QualifiedScreamingSnakeCase

### DIFF
--- a/src/bindgen/rename.rs
+++ b/src/bindgen/rename.rs
@@ -102,7 +102,7 @@ impl RenameRule {
                     }
                 }
 
-                result.push_str(&RenameRule::SnakeCase.apply_to_pascal_case(
+                result.push_str(&RenameRule::ScreamingSnakeCase.apply_to_pascal_case(
                     &text, context));
                 result
             }
@@ -181,7 +181,7 @@ impl RenameRule {
                     }
                 }
 
-                result.push_str(&RenameRule::SnakeCase.apply_to_snake_case(
+                result.push_str(&RenameRule::ScreamingSnakeCase.apply_to_snake_case(
                     &text, context));
                 result
             }


### PR DESCRIPTION
This correctly converts `enum Foo { X }` to `FOO_X` instead of
the current `FOO_x` which is what currently happens.

(I provided the original patch that landed the functionality but I missed the incorrect behavior)