### PR TITLE
Support extern crate ... as ...; imports

### DIFF
--- a/src/bindgen/rust_lib.rs
+++ b/src/bindgen/rust_lib.rs
@@ -291,8 +291,12 @@ fn process_mod<F>(pkg: &PackageRef,
                     context.cfg_stack.pop();
                 }
             }
-            syn::ItemKind::ExternCrate(_) => {
-                let dep_pkg_name = item.ident.to_string();
+            syn::ItemKind::ExternCrate(ref cr) => {
+                let dep_pkg_name = if let Some(ref name) = *cr {
+                    name.to_string()
+                } else {
+                    item.ident.to_string()
+                };
 
                 let cfg = Cfg::load(&item.attrs);
                 if let &Some(ref cfg) = &cfg {


### PR DESCRIPTION
If a crate is imported as `extern dependency as some_other_name;`, cbindgen fails to find it with a `can't find version for some_other_name` error message. The syn `ExternCrate` node comes with an optional alias, so use that when looking for a dependency crate if it exists.