### PR TITLE
Use typedef for C enums as for structs

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -162,7 +162,11 @@ impl Source for Enum {
         };
 
         if config.language == Language::C {
-            out.write(&format!("enum {}", self.name));
+            if size.is_none() {
+                out.write("typedef enum");
+            } else {
+                out.write(&format!("enum {}", self.name));
+            }
         } else {
             if let Some(prim) = size {
                 out.write(&format!("enum class {} : {}", self.name, prim));
@@ -183,7 +187,13 @@ impl Source for Enum {
             out.new_line();
             out.write("Sentinel /* this must be last for serialization purposes. */");
         }
-        out.close_brace(true);
+
+        if config.language == Language::C && size.is_none() {
+            out.close_brace(false);
+            out.write(&format!(" {};", self.name));
+        } else {
+            out.close_brace(true);
+        }
 
         if config.language == Language::C {
             if let Some(prim) = size {


### PR DESCRIPTION
When declared as `#[repr(C)]`, enums are currently declared as
```C
enum Foo {
   ...
};
```
but show up in function arguments as
```C
void bar(Foo arg);
```
which isn't valid because it's missing the `enum` specifier.

Rather than insert it there, I followed the convention for struct declarations and made `#[repr(C)]` enums get declared as
```C
typedef enum {
    ...
} Foo;
```

Enums that are declared as `#[repr(<size>)]` and were previously typedef'd should remain unchanged.