### PR TITLE
Support repr(usize) and repr(isize) enum.

### DIFF
--- a/compile-tests/enum.rs
+++ b/compile-tests/enum.rs
@@ -27,9 +27,27 @@ enum C {
     c4 = 5,
 }
 
+#[repr(usize)]
+enum D {
+    d1 = 0,
+    d2 = 2,
+    d3,
+    d4 = 5,
+}
+
+#[repr(isize)]
+enum E {
+    e1 = 0,
+    e2 = 2,
+    e3,
+    e4 = 5,
+}
+
 #[no_mangle]
-extern "C" fn root(x: *mut Opaque,
-                   y: A,
-                   z: B,
-                   w: C)
+extern "C" fn root(o: *mut Opaque,
+                   a: A,
+                   b: B,
+                   c: C,
+                   d: D,
+                   e: E)
 { }

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -32,9 +32,11 @@ impl Enum {
         let repr = Repr::load(attrs);
 
         if repr != Repr::C &&
+           repr != Repr::USize &&
            repr != Repr::U32 &&
            repr != Repr::U16 &&
            repr != Repr::U8 &&
+           repr != Repr::ISize &&
            repr != Repr::I32 &&
            repr != Repr::I16 &&
            repr != Repr::I8 {
@@ -152,9 +154,11 @@ impl Source for Enum {
 
         let size = match self.repr {
             Repr::C => None,
+            Repr::USize => Some("uintptr_t"),
             Repr::U32 => Some("uint32_t"),
             Repr::U16 => Some("uint16_t"),
             Repr::U8 => Some("uint8_t"),
+            Repr::ISize => Some("intptr_t"),
             Repr::I32 => Some("int32_t"),
             Repr::I16 => Some("int16_t"),
             Repr::I8 => Some("int8_t"),

--- a/src/bindgen/ir/repr.rs
+++ b/src/bindgen/ir/repr.rs
@@ -11,21 +11,27 @@ pub enum Repr {
     U8,
     U16,
     U32,
+    USize,
     I8,
     I16,
     I32,
+    ISize,
 }
 
 impl Repr {
     pub fn load(attrs: &Vec<syn::Attribute>) -> Repr {
         if Repr::has_attr(Repr::repr_c(), attrs) {
             Repr::C
+        } else if Repr::has_attr(Repr::repr_usize(), attrs) {
+            Repr::USize
         } else if Repr::has_attr(Repr::repr_u32(), attrs) {
             Repr::U32
         } else if Repr::has_attr(Repr::repr_u16(), attrs) {
             Repr::U16
         } else if Repr::has_attr(Repr::repr_u8(), attrs) {
             Repr::U8
+        } else if Repr::has_attr(Repr::repr_isize(), attrs) {
+            Repr::ISize
         } else if Repr::has_attr(Repr::repr_i32(), attrs) {
             Repr::I32
         } else if Repr::has_attr(Repr::repr_i16(), attrs) {
@@ -46,6 +52,11 @@ impl Repr {
                             vec![syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(syn::Ident::new("C")))])
     }
 
+    fn repr_usize() -> syn::MetaItem {
+        syn::MetaItem::List(syn::Ident::new("repr"),
+                            vec![syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(syn::Ident::new("usize")))])
+    }
+
     fn repr_u32() -> syn::MetaItem {
         syn::MetaItem::List(syn::Ident::new("repr"),
                             vec![syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(syn::Ident::new("u32")))])
@@ -59,6 +70,11 @@ impl Repr {
     fn repr_u8() -> syn::MetaItem {
         syn::MetaItem::List(syn::Ident::new("repr"),
                             vec![syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(syn::Ident::new("u8")))])
+    }
+
+    fn repr_isize() -> syn::MetaItem {
+        syn::MetaItem::List(syn::Ident::new("repr"),
+                            vec![syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(syn::Ident::new("isize")))])
     }
 
     fn repr_i32() -> syn::MetaItem {


### PR DESCRIPTION
There some enums use repr(usize) and repr(isize) in rust std. Try to use intptr_t and uintptr_t[1] for these enums.

[1]
http://www.cplusplus.com/reference/cstdint/