### PR TITLE
Allow CARGO_TARGET_DIR override in cargo_expand

### DIFF
--- a/src/bindgen/cargo/cargo_expand.rs
+++ b/src/bindgen/cargo/cargo_expand.rs
@@ -16,32 +16,39 @@ pub fn expand(manifest_path: &Path,
               crate_name: &str,
               version: &str) -> Result<String, String> {
     let cargo = env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
+    let run = |target_dir: &Path| {
+        let mut cmd = Command::new(cargo);
+        cmd.env("CARGO_TARGET_DIR", target_dir);
+        cmd.arg("rustc");
+        cmd.arg("--manifest-path");
+        cmd.arg(manifest_path);
+        cmd.arg("--all-features");
+        cmd.arg("-p");
+        cmd.arg(&format!("{}:{}", crate_name, version));
+        cmd.arg("--");
+        cmd.arg("-Z");
+        cmd.arg("unstable-options");
+        cmd.arg("--pretty=expanded");
+        let output = cmd.output().unwrap();
 
-    // Create a temp directory to use as a target dir for cargo expand, for
-    // hygenic purposes.
-    let target_dir = TempDir::new("cbindgen-expand")
-                             .map_err(|_| format!("couldn't create a temp target directory"))?;
+        let src = from_utf8(&output.stdout).unwrap().to_owned();
+        let error = from_utf8(&output.stderr).unwrap().to_owned();
 
-    let mut cmd = Command::new(cargo);
-    cmd.env("CARGO_TARGET_DIR", target_dir.path());
-    cmd.arg("rustc");
-    cmd.arg("--manifest-path");
-    cmd.arg(manifest_path);
-    cmd.arg("--all-features");
-    cmd.arg("-p");
-    cmd.arg(&format!("{}:{}", crate_name, version));
-    cmd.arg("--");
-    cmd.arg("-Z");
-    cmd.arg("unstable-options");
-    cmd.arg("--pretty=expanded");
-    let output = cmd.output().unwrap();
+        if src.len() == 0 {
+            Err(error)
+        } else {
+            Ok(src)
+        }
+    };
 
-    let src = from_utf8(&output.stdout).unwrap().to_owned();
-    let error = from_utf8(&output.stderr).unwrap().to_owned();
-
-    if src.len() == 0 {
-        Err(error)
+    if let Ok(ref path) = env::var("CARGO_EXPAND_TARGET_DIR") {
+        run(&Path::new(path))
     } else {
-        Ok(src)
+        // Create a temp directory to use as a target dir for cargo expand, for
+        // hygenic purposes.
+        let target_dir = TempDir::new("cbindgen-expand")
+            .map_err(|_| format!("couldn't create a temp target directory"))?;
+
+        run(target_dir.path())
     }
 }


### PR DESCRIPTION
Addresses part of #72 

Permits defining an override for the `CARGO_TARGET_DIR` variable when running cargo-expand. I used a separate variable `CARGO_EXPAND_TARGET_DIR` so as not to overload `CARGO_TARGET_DIR` in a build script, for example.