### PR TITLE
Add write_fmt to SourceWriter

### DIFF
--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -52,25 +52,25 @@ impl Bindings {
 
         if let Some(ref f) = self.config.header {
             out.new_line_if_not_start();
-            out.write(&f);
+            write!(out, "{}", f);
             out.new_line();
         }
         if let Some(ref f) = self.config.include_guard {
             out.new_line_if_not_start();
-            out.write(&format!("#ifndef {}", f));
+            write!(out, "#ifndef {}", f);
             out.new_line();
-            out.write(&format!("#define {}", f));
+            write!(out, "#define {}", f);
             out.new_line();
         }
         if self.config.include_version {
             out.new_line_if_not_start();
-            out.write(&format!("/* Generated with cbindgen:{} */",
-                      ::bindgen::config::VERSION));
+            write!(out, "/* Generated with cbindgen:{} */",
+                        ::bindgen::config::VERSION);
             out.new_line();
         }
         if let Some(ref f) = self.config.autogen_warning {
             out.new_line_if_not_start();
-            out.write(&f);
+            write!(out, "{}", f);
             out.new_line();
         }
 
@@ -131,7 +131,7 @@ impl Bindings {
 
         if let Some(ref f) = self.config.autogen_warning {
             out.new_line_if_not_start();
-            out.write(&f);
+            write!(out, "{}", f);
             out.new_line();
         }
 
@@ -159,21 +159,20 @@ impl Bindings {
                   if i != 0 {
                       out.write(", ")
                   }
-                  out.write("typename ");
-                  out.write(param);
+                  write!(out, "typename {}", param);
               }
               out.write(">");
               out.new_line();
-              out.write(&format!("struct {};", template.generic.name));
+              write!(out, "struct {};", template.generic.name);
               out.new_line();
 
               for &(ref monomorph_path, ref generic_values) in &template.monomorphs {
                 out.new_line();
                 out.write("template<>");
                 out.new_line();
-                out.write(&format!("struct {}<", template.generic.name));
+                write!(out, "struct {}<", template.generic.name);
                 out.write_horizontal_source_list(generic_values, ListType::Join(", "));
-                out.write(&format!("> : public {}", monomorph_path));
+                write!(out, "> : public {}", monomorph_path);
                 out.open_brace();
                 out.close_brace(true);
                 out.new_line();
@@ -184,21 +183,21 @@ impl Bindings {
 
         if let Some(ref f) = self.config.autogen_warning {
             out.new_line_if_not_start();
-            out.write(&f);
+            write!(out, "{}", f);
             out.new_line();
         }
         if let Some(ref f) = self.config.include_guard {
             out.new_line_if_not_start();
             if self.config.language == Language::C {
-                out.write(&format!("#endif /* {} */", f));
+                write!(out, "#endif /* {} */", f);
             } else {
-                out.write(&format!("#endif // {}", f));
+                write!(out, "#endif // {}", f);
             }
             out.new_line();
         }
         if let Some(ref f) = self.config.trailer {
             out.new_line_if_not_start();
-            out.write(&f);
+            write!(out, "{}", f);
             out.new_line();
         }
     }
@@ -209,17 +208,13 @@ impl Bindings {
             wrote_namespace = true;
 
             out.new_line();
-            out.write("namespace ");
-            out.write(namespace);
-            out.write(" {");
+            write!(out, "namespace {} {{", namespace);
         }
         if let Some(ref namespaces) = self.config.namespaces {
             wrote_namespace = true;
             for namespace in namespaces {
                 out.new_line();
-                out.write("namespace ");
-                out.write(namespace);
-                out.write(" {");
+                write!(out, "namespace {} {{", namespace);
             }
         }
         if wrote_namespace {
@@ -234,16 +229,14 @@ impl Bindings {
 
             for namespace in namespaces.iter().rev() {
                 out.new_line_if_not_start();
-                out.write("} // namespace ");
-                out.write(namespace);
+                write!(out, "}} // namespace {}", namespace);
             }
         }
         if let Some(ref namespace) = self.config.namespace {
             wrote_namespace = true;
 
             out.new_line_if_not_start();
-            out.write("} // namespace ");
-            out.write(namespace);
+            write!(out, "}} // namespace {}", namespace);
         }
         if wrote_namespace {
             out.new_line();

--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -109,11 +109,9 @@ impl CDecl {
 
         // Write the type-specifier and type-qualifier first
         if self.type_qualifers.len() != 0 {
-            out.write(&self.type_qualifers);
-            out.write(" ");
-            out.write(&self.type_name);
+            write!(out, "{} {}", self.type_qualifers, self.type_name);
         } else {
-            out.write(&self.type_name);
+            write!(out, "{}", self.type_name);
         };
 
         // When we have an identifier, put a space between the type and the declarators
@@ -152,7 +150,7 @@ impl CDecl {
 
         // Write the identifier
         if let Some(ident) = ident {
-            out.write(ident);
+            write!(out, "{}", ident);
         }
 
         // Write the right part of declarators after the identifier
@@ -168,7 +166,7 @@ impl CDecl {
                     if last_was_pointer {
                         out.write(")");
                     }
-                    out.write(&format!("[{}]", constant));
+                    write!(out, "[{}]", constant);
 
                     last_was_pointer = false;
                 },

--- a/src/bindgen/ir/cfg.rs
+++ b/src/bindgen/ir/cfg.rs
@@ -245,7 +245,7 @@ impl Cfg {
                 }
 
                 out.write("defined(");
-                out.write(define);
+                write!(out, "{}", define);
                 out.write(")");
             }
             &Cfg::Named(ref cfg_name, ref cfg_value) => {
@@ -266,7 +266,7 @@ impl Cfg {
                 }
 
                 out.write("defined(");
-                out.write(define);
+                write!(out, "{}", define);
                 out.write(")");
             }
             &Cfg::Any(ref cfgs) => {

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -137,9 +137,9 @@ impl Source for Constant {
                 out.write("static const ");
             }
             self.ty.write(config, out);
-            out.write(&format!(" {} = {};", self.name, self.value.0))
+            write!(out, " {} = {};", self.name, self.value.0)
         } else {
-            out.write(&format!("#define {} {}", self.name, self.value.0))
+            write!(out, "#define {} {}", self.name, self.value.0)
         }
     }
 }

--- a/src/bindgen/ir/documentation.rs
+++ b/src/bindgen/ir/documentation.rs
@@ -77,7 +77,7 @@ impl Source for Documentation {
             if line.len() != 0 {
                 out.write(" ");
             }
-            out.write(line);
+            write!(out, "{}", line);
             out.new_line();
         }
         if config.language == Language::C {

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -169,13 +169,13 @@ impl Source for Enum {
             if size.is_none() {
                 out.write("typedef enum");
             } else {
-                out.write(&format!("enum {}", self.name));
+                write!(out, "enum {}", self.name);
             }
         } else {
             if let Some(prim) = size {
-                out.write(&format!("enum class {} : {}", self.name, prim));
+                write!(out, "enum class {} : {}", self.name, prim);
             } else {
-                out.write(&format!("enum class {}", self.name));
+                write!(out, "enum class {}", self.name);
             }
         }
         out.open_brace();
@@ -184,7 +184,7 @@ impl Source for Enum {
                 out.new_line()
             }
             value.2.write(config, out);
-            out.write(&format!("{} = {},", value.0, value.1));
+            write!(out, "{} = {},", value.0, value.1);
         }
         if config.enumeration.add_sentinel(&self.annotations) {
             out.new_line();
@@ -194,7 +194,7 @@ impl Source for Enum {
 
         if config.language == Language::C && size.is_none() {
             out.close_brace(false);
-            out.write(&format!(" {};", self.name));
+            write!(out, " {};", self.name);
         } else {
             out.close_brace(true);
         }
@@ -202,7 +202,7 @@ impl Source for Enum {
         if config.language == Language::C {
             if let Some(prim) = size {
                 out.new_line();
-                out.write(&format!("typedef {} {};", prim, self.name));
+                write!(out, "typedef {} {};", prim, self.name);
             }
         }
 

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -105,7 +105,7 @@ impl Source for Function {
                 out.write("extern ");
             } else {
                 if let Some(ref prefix) = prefix {
-                    out.write(prefix);
+                    write!(out, "{}", prefix);
                     out.write(" ");
                 }
             }
@@ -113,7 +113,7 @@ impl Source for Function {
             if !func.extern_decl {
                 if let Some(ref postfix) = postfix {
                     out.write(" ");
-                    out.write(postfix);
+                    write!(out, "{}", postfix);
                 }
             }
             out.write(";");
@@ -133,7 +133,7 @@ impl Source for Function {
                 out.write("extern ");
             } else {
                 if let Some(ref prefix) = prefix {
-                    out.write(prefix);
+                    write!(out, "{}", prefix);
                     out.new_line();
                 }
             }
@@ -141,7 +141,7 @@ impl Source for Function {
             if !func.extern_decl {
                 if let Some(ref postfix) = postfix {
                     out.new_line();
-                    out.write(postfix);
+                    write!(out, "{}", postfix);
                 }
             }
             out.write(";");

--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -93,6 +93,6 @@ impl Source for Static {
             }
         }
         self.ty.write(config, out);
-        out.write(&format!(" {};", self.name));
+        write!(out, " {};", self.name);
     }
 }

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -103,11 +103,11 @@ impl Source for OpaqueItem {
         self.documentation.write(config, out);
 
         if config.language == Language::C {
-            out.write(&format!("struct {};", self.name));
+            write!(out, "struct {};", self.name);
             out.new_line();
-            out.write(&format!("typedef struct {} {};", self.name, self.name));
+            write!(out, "typedef struct {} {};", self.name, self.name);
         } else {
-            out.write(&format!("struct {};", self.name));
+            write!(out, "struct {};", self.name);
         }
 
         self.cfg.write_after(config, out);

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -224,7 +224,7 @@ impl Source for Struct {
         if config.language == Language::C {
             out.write("typedef struct");
         } else {
-            out.write(&format!("struct {}", self.name));
+            write!(out, "struct {}", self.name);
         }
         out.open_brace();
 
@@ -254,7 +254,7 @@ impl Source for Struct {
 
                 out.new_line();
 
-                out.write(&format!("bool operator{}(const {}& {}) const", op, self.name, other));
+                write!(out, "bool operator{}(const {}& {}) const", op, self.name, other);
                 out.open_brace();
                 out.write("return ");
                 out.write_vertical_list(&self.fields.iter()
@@ -293,7 +293,7 @@ impl Source for Struct {
 
         if config.language == Language::C {
             out.close_brace(false);
-            out.write(&format!(" {};", self.name));
+            write!(out, " {};", self.name);
         } else {
             out.close_brace(true);
         }

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -225,7 +225,7 @@ impl Source for Union {
         if config.language == Language::C {
             out.write("typedef union");
         } else {
-            out.write(&format!("union {}", self.name));
+            write!(out, "union {}", self.name);
         }
         out.open_brace();
 
@@ -240,7 +240,7 @@ impl Source for Union {
 
         if config.language == Language::C {
             out.close_brace(false);
-            out.write(&format!(" {};", self.name));
+            write!(out, " {};", self.name);
         } else {
             out.close_brace(true);
         }


### PR DESCRIPTION
Allows to use write! macro on SourceWriter and so avoid allocation and construction of temporary Strings for dynamically constructed output.

.write method can still be used for static strings as a convenience.