### PR TITLE
Don't prefix enum variants with name in C++

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -123,8 +123,9 @@ impl Item for Enum {
     }
 
     fn rename_for_config(&mut self, config: &Config) {
-        if config.enumeration.prefix_with_name ||
-           self.annotations.bool("prefix-with-name").unwrap_or(false)
+        if config.language == Language::C
+            && (config.enumeration.prefix_with_name
+                || self.annotations.bool("prefix-with-name").unwrap_or(false))
         {
             let old = ::std::mem::replace(&mut self.values, Vec::new());
             for (name, value, doc) in old {


### PR DESCRIPTION
In C++, output already uses enum classes so enum variants are only accessible via enum name `E::A` and there is no point in manually prefixing them again to make it `E::E_A`.

C uses global scope for all enum variants, so transformation continues to work as it did.

I realise this change might be somewhat controversial, but it seems reasonable to me and would like to hear concerns if any.