### PR TITLE
Simplify opaque struct output in C

### DIFF
--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -103,8 +103,6 @@ impl Source for OpaqueItem {
         self.documentation.write(config, out);
 
         if config.language == Language::C {
-            write!(out, "struct {};", self.name);
-            out.new_line();
             write!(out, "typedef struct {} {};", self.name, self.name);
         } else {
             write!(out, "struct {};", self.name);

--- a/tests/expectations/enum.c
+++ b/tests/expectations/enum.c
@@ -42,7 +42,6 @@ enum E {
 };
 typedef intptr_t E;
 
-struct Opaque;
 typedef struct Opaque Opaque;
 
 void root(Opaque *o, A a, B b, C c, D d, E e);

--- a/tests/expectations/monomorph-1.c
+++ b/tests/expectations/monomorph-1.c
@@ -2,13 +2,10 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-struct Bar_Bar_f32;
 typedef struct Bar_Bar_f32 Bar_Bar_f32;
 
-struct Bar_Foo_f32;
 typedef struct Bar_Foo_f32 Bar_Foo_f32;
 
-struct Bar_f32;
 typedef struct Bar_f32 Bar_f32;
 
 typedef struct {

--- a/tests/expectations/monomorph-2.c
+++ b/tests/expectations/monomorph-2.c
@@ -2,10 +2,8 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-struct A;
 typedef struct A A;
 
-struct B;
 typedef struct B B;
 
 typedef struct {

--- a/tests/expectations/monomorph-3.c
+++ b/tests/expectations/monomorph-3.c
@@ -2,13 +2,10 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-struct Bar_Bar_f32;
 typedef struct Bar_Bar_f32 Bar_Bar_f32;
 
-struct Bar_Foo_f32;
 typedef struct Bar_Foo_f32 Bar_Foo_f32;
 
-struct Bar_f32;
 typedef struct Bar_f32 Bar_f32;
 
 typedef union {

--- a/tests/expectations/simplify-option-ptr.c
+++ b/tests/expectations/simplify-option-ptr.c
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-struct Opaque;
 typedef struct Opaque Opaque;
 
 typedef struct {

--- a/tests/expectations/static.c
+++ b/tests/expectations/static.c
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-struct Bar;
 typedef struct Bar Bar;
 
 typedef struct {

--- a/tests/expectations/std_lib.c
+++ b/tests/expectations/std_lib.c
@@ -2,13 +2,10 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-struct Option_i32;
 typedef struct Option_i32 Option_i32;
 
-struct Result_i32__String;
 typedef struct Result_i32__String Result_i32__String;
 
-struct Vec_String;
 typedef struct Vec_String Vec_String;
 
 void root(const Vec_String *a, const Option_i32 *b, const Result_i32__String *c);

--- a/tests/expectations/struct.c
+++ b/tests/expectations/struct.c
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-struct Opaque;
 typedef struct Opaque Opaque;
 
 typedef struct {

--- a/tests/expectations/union.c
+++ b/tests/expectations/union.c
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-struct Opaque;
 typedef struct Opaque Opaque;
 
 typedef union {


### PR DESCRIPTION
There is no need for a separate forward struct declaration, just like in case with regular structures.