### PR TITLE
Require Path instead of &str for write_to_file()

### DIFF
--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -37,8 +37,8 @@ impl Bindings {
         }
     }
 
-    pub fn write_to_file(&self, path: &str) {
-        if let Some(parent) = path::Path::new(path).parent() {
+    pub fn write_to_file<P: AsRef<path::Path>>(&self, path: P) {
+        if let Some(parent) = path::Path::new(path.as_ref()).parent() {
             fs::create_dir_all(parent).unwrap();
         }
 


### PR DESCRIPTION
This PR eliminates some conversion, i.e., this code:
```rust
let header_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.h");
let header_path_str = header_path.to_str().unwrap();
generator.write_to_file(header_path_str);
```
reduces to:
```rust
let header_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.h");
generator.write_to_file(header_path);
```

I do not think this affects existing code because [File::open](https://doc.rust-lang.org/std/fs/struct.File.html#method.open) works the same.