### PR TITLE
Include tag names on C structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ line_length = 80
 tab_width = 2
 # The language to output bindings in
 language = "[C|C++]"
+# A rule to use to select style of declaration in C, tagname vs typedef
+style = "[Both|Type|Tag]"
 
 [parse]
 # Whether to parse dependent crates and include their types in the generated

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -95,6 +95,50 @@ impl FromStr for Layout {
 
 deserialize_enum_str!(Layout);
 
+/// A style of Style to use when generating structs and enums.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Style {
+    Both,
+    Tag,
+    Type,
+}
+
+impl Style {
+    pub fn generate_tag(&self) -> bool {
+        match self {
+            &Style::Both => true,
+            &Style::Tag => true,
+            &Style::Type => false,
+        }
+    }
+
+    pub fn generate_typedef(&self) -> bool {
+        match self {
+            &Style::Both => true,
+            &Style::Tag => false,
+            &Style::Type => true,
+        }
+    }
+}
+
+impl FromStr for Style {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Style, Self::Err> {
+        match s {
+            "Both" => Ok(Style::Both),
+            "both" => Ok(Style::Both),
+            "Tag" =>  Ok(Style::Tag),
+            "tag" =>  Ok(Style::Tag),
+            "Type" => Ok(Style::Type),
+            "type" => Ok(Style::Type),
+            _ => Err(format!("Unrecognized Style: '{}'.", s)),
+        }
+    }
+}
+
+deserialize_enum_str!(Style);
+
 /// Settings to apply when exporting items.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -380,6 +424,8 @@ pub struct Config {
     pub tab_width: usize,
     /// The language to output bindings for
     pub language: Language,
+    /// The style to declare structs, enums and unions in for C
+    pub style: Style,
     /// The configuration options for parsing
     pub parse: ParseConfig,
     /// The configuration options for exporting
@@ -418,6 +464,7 @@ impl Default for Config {
             line_length: 100,
             tab_width: 2,
             language: Language::Cxx,
+            style: Style::Type,
             parse: ParseConfig::default(),
             export: ExportConfig::default(),
             function: FunctionConfig::default(),

--- a/src/bindgen/declarationtyperesolver.rs
+++ b/src/bindgen/declarationtyperesolver.rs
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashSet;
+
+pub struct DeclarationTypeResolver {
+    structs: HashSet<String>,
+    enums: HashSet<String>,
+    unions: HashSet<String>,
+}
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+pub enum DeclarationType {
+    Struct,
+    Enum,
+    Union,
+}
+
+impl DeclarationType {
+    pub fn to_str(&self) -> &'static str {
+        match self {
+            &DeclarationType::Struct => "struct",
+            &DeclarationType::Enum => "enum",
+            &DeclarationType::Union => "union",
+        }
+    }
+}
+
+impl DeclarationTypeResolver {
+    pub fn new() -> DeclarationTypeResolver {
+        DeclarationTypeResolver {
+            structs: HashSet::new(),
+            enums: HashSet::new(),
+            unions: HashSet::new(),
+        }
+    }
+
+    pub fn add_enum(&mut self, name: &str) {
+        self.enums.insert(name.to_owned());
+    }
+
+    pub fn add_struct(&mut self, name: &str) {
+        self.structs.insert(name.to_owned());
+    }
+
+    pub fn add_union(&mut self, name: &str) {
+        self.unions.insert(name.to_owned());
+    }
+
+    pub fn type_for(&self, name: &str) -> Option<DeclarationType> {
+        if self.structs.contains(name) {
+            Some(DeclarationType::Struct)
+        } else if self.enums.contains(name) {
+            Some(DeclarationType::Enum)
+        } else if self.unions.contains(name) {
+            Some(DeclarationType::Union)
+        } else {
+            None
+        }
+    }
+}

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -9,6 +9,7 @@ use syn;
 
 use bindgen::config::{Config, Language};
 use bindgen::ir::{AnnotationSet, Cfg, CfgWrite, Documentation, Item, ItemContainer, Type};
+use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::writer::{Source, SourceWriter};
 
 #[derive(Debug, Clone)]
@@ -127,6 +128,10 @@ impl Item for Constant {
 
     fn rename_for_config(&mut self, config: &Config) {
         config.export.rename(&mut self.name);
+    }
+
+    fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {
+        self.ty.resolve_declaration_types(resolver);
     }
 }
 

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -8,6 +8,7 @@ use syn;
 
 use bindgen::cdecl;
 use bindgen::config::{Config, Language, Layout};
+use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::{AnnotationSet, Cfg, CfgWrite, Documentation, PrimitiveType, Type};
 use bindgen::library::Library;
@@ -83,6 +84,13 @@ impl Function {
         self.ret.mangle_paths(monomorphs);
         for &mut (_, ref mut ty) in &mut self.args {
             ty.mangle_paths(monomorphs);
+        }
+    }
+
+    pub fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {
+        self.ret.resolve_declaration_types(resolver);
+        for &mut (_, ref mut ty) in &mut self.args {
+            ty.resolve_declaration_types(resolver);
         }
     }
 

--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 use syn;
 
 use bindgen::config::Config;
+use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::{AnnotationSet, Cfg, Documentation, Item, ItemContainer, Type};
 use bindgen::library::Library;
@@ -68,6 +69,10 @@ impl Item for Static {
 
     fn rename_for_config(&mut self, config: &Config) {
         self.ty.rename_for_config(config);
+    }
+
+    fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {
+        self.ty.resolve_declaration_types(resolver);
     }
 
     fn add_dependencies(&self, library: &Library, out: &mut Dependencies) {

--- a/src/bindgen/ir/item.rs
+++ b/src/bindgen/ir/item.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use std::mem;
 
 use bindgen::config::Config;
+use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::{AnnotationSet, Cfg, Constant, Enum, OpaqueItem, Static, Struct, Type, Typedef,
                   Union};
@@ -21,6 +22,8 @@ pub trait Item {
 
     fn container(&self) -> ItemContainer;
 
+    fn collect_declaration_types(&self, _resolver: &mut DeclarationTypeResolver) { unimplemented!() }
+    fn resolve_declaration_types(&mut self, _resolver: &DeclarationTypeResolver) { unimplemented!() }
     fn rename_for_config(&mut self, _config: &Config) {}
     fn add_dependencies(&self, _library: &Library, _out: &mut Dependencies) {}
     fn instantiate_monomorph(

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 use syn;
 
 use bindgen::config::{Config, Language};
+use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::{AnnotationSet, Cfg, CfgWrite, Documentation, GenericParams, Item, ItemContainer,
                   Path, Type};
@@ -62,6 +63,10 @@ impl Item for OpaqueItem {
         ItemContainer::OpaqueItem(self.clone())
     }
 
+    fn collect_declaration_types(&self, resolver: &mut DeclarationTypeResolver) {
+        resolver.add_struct(&self.name);
+    }
+
     fn rename_for_config(&mut self, config: &Config) {
         config.export.rename(&mut self.name);
     }
@@ -101,7 +106,8 @@ impl Source for OpaqueItem {
 
         self.generic_params.write(config, out);
 
-        if config.language == Language::C {
+        if config.style.generate_typedef() &&
+            config.language == Language::C {
             write!(out, "typedef struct {} {};", self.name, self.name);
         } else {
             write!(out, "struct {};", self.name);

--- a/src/bindgen/ir/path.rs
+++ b/src/bindgen/ir/path.rs
@@ -5,6 +5,7 @@
 use syn;
 
 use bindgen::ir::Type;
+use bindgen::declarationtyperesolver::{DeclarationType, DeclarationTypeResolver};
 use bindgen::utilities::IterHelpers;
 
 pub type Path = String;
@@ -13,6 +14,7 @@ pub type Path = String;
 pub struct GenericPath {
     pub name: String,
     pub generics: Vec<Type>,
+    pub ctype: Option<DeclarationType>,
 }
 
 impl GenericPath {
@@ -20,7 +22,12 @@ impl GenericPath {
         GenericPath {
             name: name,
             generics: generics,
+            ctype: None,
         }
+    }
+
+    pub fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {
+        self.ctype = resolver.type_for(&self.name);
     }
 
     pub fn load(path: &syn::Path) -> Result<GenericPath, String> {

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -9,6 +9,7 @@ use syn;
 
 use bindgen::cdecl;
 use bindgen::config::Config;
+use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::{Documentation, GenericParams, GenericPath, Path};
 use bindgen::library::Library;
@@ -486,6 +487,30 @@ impl Type {
                 ret.rename_for_config(config);
                 for arg in args {
                     arg.rename_for_config(config);
+                }
+            }
+        }
+    }
+
+    pub fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {
+        match self {
+            &mut Type::ConstPtr(ref mut ty) => {
+                ty.resolve_declaration_types(resolver);
+            }
+            &mut Type::Ptr(ref mut ty) => {
+                ty.resolve_declaration_types(resolver);
+            }
+            &mut Type::Path(ref mut path) => {
+                path.resolve_declaration_types(resolver);
+            }
+            &mut Type::Primitive(_) => {}
+            &mut Type::Array(ref mut ty, _) => {
+                ty.resolve_declaration_types(resolver);
+            }
+            &mut Type::FuncPtr(ref mut ret, ref mut args) => {
+                ret.resolve_declaration_types(resolver);
+                for arg in args {
+                    arg.resolve_declaration_types(resolver);
                 }
             }
         }

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -8,6 +8,7 @@ use std::io::Write;
 use syn;
 
 use bindgen::config::{Config, Language};
+use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::{AnnotationSet, Cfg, CfgWrite, Documentation, GenericParams, Item, ItemContainer,
                   Path, Type};
@@ -112,6 +113,10 @@ impl Item for Typedef {
     fn rename_for_config(&mut self, config: &Config) {
         config.export.rename(&mut self.name);
         self.aliased.rename_for_config(config);
+    }
+
+    fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {
+        self.aliased.resolve_declaration_types(resolver);
     }
 
     fn add_dependencies(&self, library: &Library, out: &mut Dependencies) {

--- a/src/bindgen/mod.rs
+++ b/src/bindgen/mod.rs
@@ -39,6 +39,7 @@ mod builder;
 mod cargo;
 mod cdecl;
 mod config;
+mod declarationtyperesolver;
 mod dependencies;
 mod error;
 mod ir;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use clap::{App, Arg, ArgMatches};
 mod logging;
 mod bindgen;
 
-use bindgen::{Bindings, Builder, Cargo, Config, Error, Language};
+use bindgen::{Bindings, Builder, Cargo, Config, Error, Language, Style};
 
 fn apply_config_overrides<'a>(config: &mut Config, matches: &ArgMatches<'a>) {
     // We allow specifying a language to override the config default. This is
@@ -36,6 +36,21 @@ fn apply_config_overrides<'a>(config: &mut Config, matches: &ArgMatches<'a>) {
                 return;
             }
         };
+    }
+
+    if let Some(style) = matches.value_of("style") {
+        config.style = match style {
+            "Both" => Style::Both,
+            "both" => Style::Both,
+            "Tag" =>  Style::Tag,
+            "tag" =>  Style::Tag,
+            "Type" => Style::Type,
+            "type" => Style::Type,
+            _ => {
+                error!("Unknown style specified.");
+                return;
+            }
+        }
     }
 
     if matches.is_present("d") {
@@ -110,6 +125,14 @@ fn main() {
                 .value_name("LANGUAGE")
                 .help("Specify the language to output bindings in")
                 .possible_values(&["c++", "C++", "c", "C"]),
+        )
+        .arg(
+            Arg::with_name("style")
+                .short("s")
+                .long("style")
+                .value_name("STYLE")
+                .help("Specify the declaration style to use for bindings")
+                .possible_values(&["Both", "both", "Tag", "tag", "Type", "type"]),
         )
         .arg(
             Arg::with_name("d")

--- a/tests/expectations/both/alias.c
+++ b/tests/expectations/both/alias.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+enum Status {
+  Ok,
+  Err,
+};
+typedef uint32_t Status;
+
+typedef struct Dep {
+  int32_t a;
+  float b;
+} Dep;
+
+typedef struct Foo_i32 {
+  int32_t a;
+  int32_t b;
+  Dep c;
+} Foo_i32;
+
+typedef Foo_i32 IntFoo;
+
+typedef struct Foo_f64 {
+  double a;
+  double b;
+  Dep c;
+} Foo_f64;
+
+typedef Foo_f64 DoubleFoo;
+
+typedef int32_t Unit;
+
+typedef Status SpecialStatus;
+
+void root(IntFoo x, DoubleFoo y, Unit z, SpecialStatus w);

--- a/tests/expectations/both/annotation.c
+++ b/tests/expectations/both/annotation.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+enum C {
+  X = 2,
+  Y,
+};
+typedef uint32_t C;
+
+typedef struct A {
+  int32_t m0;
+} A;
+
+typedef struct B {
+  int32_t x;
+  float y;
+} B;
+
+void root(A x, B y, C z);

--- a/tests/expectations/both/cdecl.c
+++ b/tests/expectations/both/cdecl.c
@@ -1,0 +1,35 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef void (*A)();
+
+typedef void (*B)();
+
+typedef bool (*C)(int32_t, int32_t);
+
+typedef bool (*(*D)(int32_t))(float);
+
+typedef int32_t (*(*E)())[16];
+
+typedef const int32_t *F;
+
+typedef const int32_t *const *G;
+
+typedef int32_t *const *H;
+
+typedef int32_t (*I)[16];
+
+typedef double (**J)(float);
+
+typedef int32_t K[16];
+
+typedef const int32_t *L[16];
+
+typedef bool (*M[16])(int32_t, int32_t);
+
+typedef void (*N[16])(int32_t, int32_t);
+
+void (*O(void))(void);
+
+void root(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m, N n);

--- a/tests/expectations/both/cfg-2.c
+++ b/tests/expectations/both/cfg-2.c
@@ -1,0 +1,35 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#if defined(NOT_DEFINED)
+#define DEFAULT_X 8
+#endif
+
+#if defined(DEFINED)
+#define DEFAULT_X 42
+#endif
+
+#if (defined(NOT_DEFINED) || defined(DEFINED))
+typedef struct Foo {
+  int32_t x;
+} Foo;
+#endif
+
+#if defined(NOT_DEFINED)
+typedef struct Bar {
+  Foo y;
+} Bar;
+#endif
+
+#if defined(DEFINED)
+typedef struct Bar {
+  Foo z;
+} Bar;
+#endif
+
+typedef struct Root {
+  Bar w;
+} Root;
+
+void root(Root a);

--- a/tests/expectations/both/cfg-field.c
+++ b/tests/expectations/both/cfg-field.c
@@ -1,0 +1,3 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>

--- a/tests/expectations/both/cfg.c
+++ b/tests/expectations/both/cfg.c
@@ -1,0 +1,45 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+enum BarType {
+  A,
+  B,
+  C,
+};
+typedef uint32_t BarType;
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+enum FooType {
+  A,
+  B,
+  C,
+};
+typedef uint32_t FooType;
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+typedef struct FooHandle {
+  FooType ty;
+  int32_t x;
+  float y;
+} FooHandle;
+#endif
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+typedef struct BarHandle {
+  BarType ty;
+  int32_t x;
+  float y;
+} BarHandle;
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+void root(FooHandle a);
+#endif
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+void root(BarHandle a);
+#endif

--- a/tests/expectations/both/constant.c
+++ b/tests/expectations/both/constant.c
@@ -1,0 +1,13 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define FOO 10
+
+#define ZOM 3.14
+
+typedef struct Foo {
+  int32_t x[FOO];
+} Foo;
+
+void root(Foo x);

--- a/tests/expectations/both/display_list.c
+++ b/tests/expectations/both/display_list.c
@@ -1,0 +1,44 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Rect {
+  float x;
+  float y;
+  float w;
+  float h;
+} Rect;
+
+typedef struct Color {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+  uint8_t a;
+} Color;
+
+enum DisplayItem_Tag {
+  Fill,
+  Image,
+  ClearScreen,
+};
+typedef uint8_t DisplayItem_Tag;
+
+typedef struct Fill_Body {
+  DisplayItem_Tag tag;
+  Rect _0;
+  Color _1;
+} Fill_Body;
+
+typedef struct Image_Body {
+  DisplayItem_Tag tag;
+  uint32_t id;
+  Rect bounds;
+} Image_Body;
+
+typedef union DisplayItem {
+  DisplayItem_Tag tag;
+  Fill_Body fill;
+  Image_Body image;
+} DisplayItem;
+
+bool push_item(DisplayItem item);

--- a/tests/expectations/both/enum.c
+++ b/tests/expectations/both/enum.c
@@ -42,7 +42,7 @@ enum E {
 };
 typedef intptr_t E;
 
-typedef enum {
+typedef enum K {
   k1,
   k2,
   k3,
@@ -62,39 +62,39 @@ enum F_Tag {
 };
 typedef uint8_t F_Tag;
 
-typedef struct {
+typedef struct Foo_Body {
   F_Tag tag;
   int16_t _0;
 } Foo_Body;
 
-typedef struct {
+typedef struct Bar_Body {
   F_Tag tag;
   uint8_t x;
   int16_t y;
 } Bar_Body;
 
-typedef union {
+typedef union F {
   F_Tag tag;
   Foo_Body foo;
   Bar_Body bar;
 } F;
 
-typedef enum {
+typedef enum G_Tag {
   G_Foo,
   G_Bar,
   G_Baz,
 } G_Tag;
 
-typedef struct {
+typedef struct G_Foo_Body {
   int16_t _0;
 } G_Foo_Body;
 
-typedef struct {
+typedef struct G_Bar_Body {
   uint8_t x;
   int16_t y;
 } G_Bar_Body;
 
-typedef struct {
+typedef struct G {
   G_Tag tag;
   union {
     G_Foo_Body foo;
@@ -109,16 +109,16 @@ enum H_Tag {
 };
 typedef uint8_t H_Tag;
 
-typedef struct {
+typedef struct H_Foo_Body {
   int16_t _0;
 } H_Foo_Body;
 
-typedef struct {
+typedef struct H_Bar_Body {
   uint8_t x;
   int16_t y;
 } H_Bar_Body;
 
-typedef struct {
+typedef struct H {
   H_Tag tag;
   union {
     H_Foo_Body foo;

--- a/tests/expectations/both/euclid.c
+++ b/tests/expectations/both/euclid.c
@@ -1,0 +1,116 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct TypedLength_f32__UnknownUnit {
+  float _0;
+} TypedLength_f32__UnknownUnit;
+
+typedef struct TypedLength_f32__LayoutUnit {
+  float _0;
+} TypedLength_f32__LayoutUnit;
+
+typedef TypedLength_f32__UnknownUnit Length_f32;
+
+typedef TypedLength_f32__LayoutUnit LayoutLength;
+
+typedef struct TypedSideOffsets2D_f32__UnknownUnit {
+  float top;
+  float right;
+  float bottom;
+  float left;
+} TypedSideOffsets2D_f32__UnknownUnit;
+
+typedef struct TypedSideOffsets2D_f32__LayoutUnit {
+  float top;
+  float right;
+  float bottom;
+  float left;
+} TypedSideOffsets2D_f32__LayoutUnit;
+
+typedef TypedSideOffsets2D_f32__UnknownUnit SideOffsets2D_f32;
+
+typedef TypedSideOffsets2D_f32__LayoutUnit LayoutSideOffsets2D;
+
+typedef struct TypedSize2D_f32__UnknownUnit {
+  float width;
+  float height;
+} TypedSize2D_f32__UnknownUnit;
+
+typedef struct TypedSize2D_f32__LayoutUnit {
+  float width;
+  float height;
+} TypedSize2D_f32__LayoutUnit;
+
+typedef TypedSize2D_f32__UnknownUnit Size2D_f32;
+
+typedef TypedSize2D_f32__LayoutUnit LayoutSize2D;
+
+typedef struct TypedPoint2D_f32__UnknownUnit {
+  float x;
+  float y;
+} TypedPoint2D_f32__UnknownUnit;
+
+typedef struct TypedPoint2D_f32__LayoutUnit {
+  float x;
+  float y;
+} TypedPoint2D_f32__LayoutUnit;
+
+typedef TypedPoint2D_f32__UnknownUnit Point2D_f32;
+
+typedef TypedPoint2D_f32__LayoutUnit LayoutPoint2D;
+
+typedef struct TypedRect_f32__UnknownUnit {
+  TypedPoint2D_f32__UnknownUnit origin;
+  TypedSize2D_f32__UnknownUnit size;
+} TypedRect_f32__UnknownUnit;
+
+typedef struct TypedRect_f32__LayoutUnit {
+  TypedPoint2D_f32__LayoutUnit origin;
+  TypedSize2D_f32__LayoutUnit size;
+} TypedRect_f32__LayoutUnit;
+
+typedef TypedRect_f32__UnknownUnit Rect_f32;
+
+typedef TypedRect_f32__LayoutUnit LayoutRect;
+
+typedef struct TypedTransform2D_f32__UnknownUnit__LayoutUnit {
+  float m11;
+  float m12;
+  float m21;
+  float m22;
+  float m31;
+  float m32;
+} TypedTransform2D_f32__UnknownUnit__LayoutUnit;
+
+typedef struct TypedTransform2D_f32__LayoutUnit__UnknownUnit {
+  float m11;
+  float m12;
+  float m21;
+  float m22;
+  float m31;
+  float m32;
+} TypedTransform2D_f32__LayoutUnit__UnknownUnit;
+
+void root(TypedLength_f32__UnknownUnit length_a,
+          TypedLength_f32__LayoutUnit length_b,
+          Length_f32 length_c,
+          LayoutLength length_d,
+          TypedSideOffsets2D_f32__UnknownUnit side_offsets_a,
+          TypedSideOffsets2D_f32__LayoutUnit side_offsets_b,
+          SideOffsets2D_f32 side_offsets_c,
+          LayoutSideOffsets2D side_offsets_d,
+          TypedSize2D_f32__UnknownUnit size_a,
+          TypedSize2D_f32__LayoutUnit size_b,
+          Size2D_f32 size_c,
+          LayoutSize2D size_d,
+          TypedPoint2D_f32__UnknownUnit point_a,
+          TypedPoint2D_f32__LayoutUnit point_b,
+          Point2D_f32 point_c,
+          LayoutPoint2D point_d,
+          TypedRect_f32__UnknownUnit rect_a,
+          TypedRect_f32__LayoutUnit rect_b,
+          Rect_f32 rect_c,
+          LayoutRect rect_d,
+          TypedTransform2D_f32__UnknownUnit__LayoutUnit transform_a,
+          TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);

--- a/tests/expectations/both/expand.c
+++ b/tests/expectations/both/expand.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Foo {
+
+} Foo;
+
+void root(Foo a);

--- a/tests/expectations/both/extern-2.c
+++ b/tests/expectations/both/extern-2.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+void first(void);
+
+void second(void);

--- a/tests/expectations/both/extern.c
+++ b/tests/expectations/both/extern.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Normal {
+  int32_t x;
+  float y;
+} Normal;
+
+extern void bar(Normal a);
+
+extern int32_t foo(void);

--- a/tests/expectations/both/include.c
+++ b/tests/expectations/both/include.c
@@ -1,0 +1,4 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>

--- a/tests/expectations/both/include_item.c
+++ b/tests/expectations/both/include_item.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct A {
+  int32_t x;
+  float y;
+} A;
+
+typedef struct B {
+  A data;
+} B;

--- a/tests/expectations/both/inner_mod.c
+++ b/tests/expectations/both/inner_mod.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Foo {
+  float x;
+} Foo;
+
+void root(Foo a);

--- a/tests/expectations/both/mod_path.c
+++ b/tests/expectations/both/mod_path.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define EXPORT_ME_TOO 42
+
+typedef struct ExportMe {
+  uint64_t val;
+} ExportMe;
+
+void export_me(ExportMe *val);

--- a/tests/expectations/both/monomorph-1.c
+++ b/tests/expectations/both/monomorph-1.c
@@ -1,0 +1,42 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Bar_Bar_f32 Bar_Bar_f32;
+
+typedef struct Bar_Foo_f32 Bar_Foo_f32;
+
+typedef struct Bar_f32 Bar_f32;
+
+typedef struct Foo_i32 {
+  const int32_t *data;
+} Foo_i32;
+
+typedef struct Foo_f32 {
+  const float *data;
+} Foo_f32;
+
+typedef struct Foo_Bar_f32 {
+  const Bar_f32 *data;
+} Foo_Bar_f32;
+
+typedef struct Tuple_Foo_f32_____f32 {
+  const Foo_f32 *a;
+  const float *b;
+} Tuple_Foo_f32_____f32;
+
+typedef struct Tuple_f32__f32 {
+  const float *a;
+  const float *b;
+} Tuple_f32__f32;
+
+typedef Tuple_f32__f32 Indirection_f32;
+
+void root(Foo_i32 a,
+          Foo_f32 b,
+          Bar_f32 c,
+          Foo_Bar_f32 d,
+          Bar_Foo_f32 e,
+          Bar_Bar_f32 f,
+          Tuple_Foo_f32_____f32 g,
+          Indirection_f32 h);

--- a/tests/expectations/both/monomorph-2.c
+++ b/tests/expectations/both/monomorph-2.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct A A;
+
+typedef struct B B;
+
+typedef struct List_B {
+  B *members;
+  uintptr_t count;
+} List_B;
+
+typedef struct List_A {
+  A *members;
+  uintptr_t count;
+} List_A;
+
+void bar(List_B b);
+
+void foo(List_A a);

--- a/tests/expectations/both/monomorph-3.c
+++ b/tests/expectations/both/monomorph-3.c
@@ -1,0 +1,42 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Bar_Bar_f32 Bar_Bar_f32;
+
+typedef struct Bar_Foo_f32 Bar_Foo_f32;
+
+typedef struct Bar_f32 Bar_f32;
+
+typedef union Foo_i32 {
+  const int32_t *data;
+} Foo_i32;
+
+typedef union Foo_f32 {
+  const float *data;
+} Foo_f32;
+
+typedef union Foo_Bar_f32 {
+  const Bar_f32 *data;
+} Foo_Bar_f32;
+
+typedef union Tuple_Foo_f32_____f32 {
+  const Foo_f32 *a;
+  const float *b;
+} Tuple_Foo_f32_____f32;
+
+typedef union Tuple_f32__f32 {
+  const float *a;
+  const float *b;
+} Tuple_f32__f32;
+
+typedef Tuple_f32__f32 Indirection_f32;
+
+void root(Foo_i32 a,
+          Foo_f32 b,
+          Bar_f32 c,
+          Foo_Bar_f32 d,
+          Bar_Foo_f32 e,
+          Bar_Bar_f32 f,
+          Tuple_Foo_f32_____f32 g,
+          Indirection_f32 h);

--- a/tests/expectations/both/rename-crate.c
+++ b/tests/expectations/both/rename-crate.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Foo {
+  int32_t x;
+} Foo;
+
+void root(Foo a);

--- a/tests/expectations/both/rename.c
+++ b/tests/expectations/both/rename.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define C_H 10
+
+enum C_E {
+  x = 0,
+  y = 1,
+};
+typedef uint8_t C_E;
+
+typedef struct C_A C_A;
+
+typedef struct C_C C_C;
+
+typedef struct C_AwesomeB {
+  int32_t x;
+  float y;
+} C_AwesomeB;
+
+typedef union C_D {
+  int32_t x;
+  float y;
+} C_D;
+
+typedef C_A C_F;
+
+extern const int32_t G;
+
+void root(const C_A *a, C_AwesomeB b, C_C c, C_D d, C_E e, C_F f);

--- a/tests/expectations/both/simplify-option-ptr.c
+++ b/tests/expectations/both/simplify-option-ptr.c
@@ -1,0 +1,19 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct Foo {
+  const Opaque *x;
+  Opaque *y;
+  void (*z)();
+} Foo;
+
+typedef union Bar {
+  const Opaque *x;
+  Opaque *y;
+  void (*z)();
+} Bar;
+
+void root(const Opaque *a, Opaque *b, Foo c, Bar d);

--- a/tests/expectations/both/static.c
+++ b/tests/expectations/both/static.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Bar Bar;
+
+typedef struct Foo {
+
+} Foo;
+
+extern const Bar BAR;
+
+extern Foo FOO;
+
+extern const int32_t NUMBER;
+
+void root(void);

--- a/tests/expectations/both/std_lib.c
+++ b/tests/expectations/both/std_lib.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Option_i32 Option_i32;
+
+typedef struct Result_i32__String Result_i32__String;
+
+typedef struct Vec_String Vec_String;
+
+void root(const Vec_String *a, const Option_i32 *b, const Result_i32__String *c);

--- a/tests/expectations/both/struct.c
+++ b/tests/expectations/both/struct.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct Normal {
+  int32_t x;
+  float y;
+} Normal;
+
+typedef struct NormalWithZST {
+  int32_t x;
+  float y;
+} NormalWithZST;
+
+typedef struct TupleRenamed {
+  int32_t m0;
+  float m1;
+} TupleRenamed;
+
+typedef struct TupleNamed {
+  int32_t x;
+  float y;
+} TupleNamed;
+
+void root(Opaque *a, Normal b, NormalWithZST c, TupleRenamed d, TupleNamed e);

--- a/tests/expectations/both/typedef.c
+++ b/tests/expectations/both/typedef.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Foo_i32__i32 {
+  int32_t x;
+  int32_t y;
+} Foo_i32__i32;
+
+typedef Foo_i32__i32 IntFoo_i32;
+
+void root(IntFoo_i32 a);

--- a/tests/expectations/both/union.c
+++ b/tests/expectations/both/union.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct Opaque Opaque;
+
+typedef union Normal {
+  int32_t x;
+  float y;
+} Normal;
+
+typedef union NormalWithZST {
+  int32_t x;
+  float y;
+} NormalWithZST;
+
+void root(Opaque *a, Normal b, NormalWithZST c);

--- a/tests/expectations/enum.cpp
+++ b/tests/expectations/enum.cpp
@@ -36,6 +36,13 @@ enum class E : intptr_t {
   e4 = 5,
 };
 
+enum class K {
+  k1,
+  k2,
+  k3,
+  k4,
+};
+
 struct I;
 
 struct J;
@@ -115,6 +122,6 @@ struct H {
 
 extern "C" {
 
-void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j);
+void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k);
 
 } // extern "C"

--- a/tests/expectations/tag/alias.c
+++ b/tests/expectations/tag/alias.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+enum Status {
+  Ok,
+  Err,
+};
+typedef uint32_t Status;
+
+struct Dep {
+  int32_t a;
+  float b;
+};
+
+struct Foo_i32 {
+  int32_t a;
+  int32_t b;
+  struct Dep c;
+};
+
+typedef struct Foo_i32 IntFoo;
+
+struct Foo_f64 {
+  double a;
+  double b;
+  struct Dep c;
+};
+
+typedef struct Foo_f64 DoubleFoo;
+
+typedef int32_t Unit;
+
+typedef Status SpecialStatus;
+
+void root(IntFoo x, DoubleFoo y, Unit z, SpecialStatus w);

--- a/tests/expectations/tag/annotation.c
+++ b/tests/expectations/tag/annotation.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+enum C {
+  X = 2,
+  Y,
+};
+typedef uint32_t C;
+
+struct A {
+  int32_t m0;
+};
+
+struct B {
+  int32_t x;
+  float y;
+};
+
+void root(struct A x, struct B y, C z);

--- a/tests/expectations/tag/cdecl.c
+++ b/tests/expectations/tag/cdecl.c
@@ -1,0 +1,35 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef void (*A)();
+
+typedef void (*B)();
+
+typedef bool (*C)(int32_t, int32_t);
+
+typedef bool (*(*D)(int32_t))(float);
+
+typedef int32_t (*(*E)())[16];
+
+typedef const int32_t *F;
+
+typedef const int32_t *const *G;
+
+typedef int32_t *const *H;
+
+typedef int32_t (*I)[16];
+
+typedef double (**J)(float);
+
+typedef int32_t K[16];
+
+typedef const int32_t *L[16];
+
+typedef bool (*M[16])(int32_t, int32_t);
+
+typedef void (*N[16])(int32_t, int32_t);
+
+void (*O(void))(void);
+
+void root(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m, N n);

--- a/tests/expectations/tag/cfg-2.c
+++ b/tests/expectations/tag/cfg-2.c
@@ -1,0 +1,35 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#if defined(NOT_DEFINED)
+#define DEFAULT_X 8
+#endif
+
+#if defined(DEFINED)
+#define DEFAULT_X 42
+#endif
+
+#if (defined(NOT_DEFINED) || defined(DEFINED))
+struct Foo {
+  int32_t x;
+};
+#endif
+
+#if defined(NOT_DEFINED)
+struct Bar {
+  struct Foo y;
+};
+#endif
+
+#if defined(DEFINED)
+struct Bar {
+  struct Foo z;
+};
+#endif
+
+struct Root {
+  struct Bar w;
+};
+
+void root(struct Root a);

--- a/tests/expectations/tag/cfg-field.c
+++ b/tests/expectations/tag/cfg-field.c
@@ -1,0 +1,3 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>

--- a/tests/expectations/tag/cfg.c
+++ b/tests/expectations/tag/cfg.c
@@ -1,0 +1,45 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+enum BarType {
+  A,
+  B,
+  C,
+};
+typedef uint32_t BarType;
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+enum FooType {
+  A,
+  B,
+  C,
+};
+typedef uint32_t FooType;
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+struct FooHandle {
+  FooType ty;
+  int32_t x;
+  float y;
+};
+#endif
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+struct BarHandle {
+  BarType ty;
+  int32_t x;
+  float y;
+};
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+void root(struct FooHandle a);
+#endif
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+void root(struct BarHandle a);
+#endif

--- a/tests/expectations/tag/constant.c
+++ b/tests/expectations/tag/constant.c
@@ -1,0 +1,13 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define FOO 10
+
+#define ZOM 3.14
+
+struct Foo {
+  int32_t x[FOO];
+};
+
+void root(struct Foo x);

--- a/tests/expectations/tag/display_list.c
+++ b/tests/expectations/tag/display_list.c
@@ -1,0 +1,44 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Rect {
+  float x;
+  float y;
+  float w;
+  float h;
+};
+
+struct Color {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+  uint8_t a;
+};
+
+enum DisplayItem_Tag {
+  Fill,
+  Image,
+  ClearScreen,
+};
+typedef uint8_t DisplayItem_Tag;
+
+struct Fill_Body {
+  DisplayItem_Tag tag;
+  struct Rect _0;
+  struct Color _1;
+};
+
+struct Image_Body {
+  DisplayItem_Tag tag;
+  uint32_t id;
+  struct Rect bounds;
+};
+
+union DisplayItem {
+  enum DisplayItem_Tag tag;
+  struct Fill_Body fill;
+  struct Image_Body image;
+};
+
+bool push_item(union DisplayItem item);

--- a/tests/expectations/tag/enum.c
+++ b/tests/expectations/tag/enum.c
@@ -42,18 +42,18 @@ enum E {
 };
 typedef intptr_t E;
 
-typedef enum {
+enum K {
   k1,
   k2,
   k3,
   k4,
-} K;
+};
 
-typedef struct I I;
+struct I;
 
-typedef struct J J;
+struct J;
 
-typedef struct Opaque Opaque;
+struct Opaque;
 
 enum F_Tag {
   Foo,
@@ -62,45 +62,45 @@ enum F_Tag {
 };
 typedef uint8_t F_Tag;
 
-typedef struct {
+struct Foo_Body {
   F_Tag tag;
   int16_t _0;
-} Foo_Body;
+};
 
-typedef struct {
+struct Bar_Body {
   F_Tag tag;
   uint8_t x;
   int16_t y;
-} Bar_Body;
+};
 
-typedef union {
-  F_Tag tag;
-  Foo_Body foo;
-  Bar_Body bar;
-} F;
+union F {
+  enum F_Tag tag;
+  struct Foo_Body foo;
+  struct Bar_Body bar;
+};
 
-typedef enum {
+enum G_Tag {
   G_Foo,
   G_Bar,
   G_Baz,
-} G_Tag;
+};
 
-typedef struct {
+struct G_Foo_Body {
   int16_t _0;
-} G_Foo_Body;
+};
 
-typedef struct {
+struct G_Bar_Body {
   uint8_t x;
   int16_t y;
-} G_Bar_Body;
+};
 
-typedef struct {
-  G_Tag tag;
+struct G {
+  enum G_Tag tag;
   union {
-    G_Foo_Body foo;
-    G_Bar_Body bar;
+    struct G_Foo_Body foo;
+    struct G_Bar_Body bar;
   };
-} G;
+};
 
 enum H_Tag {
   H_Foo,
@@ -109,21 +109,32 @@ enum H_Tag {
 };
 typedef uint8_t H_Tag;
 
-typedef struct {
+struct H_Foo_Body {
   int16_t _0;
-} H_Foo_Body;
+};
 
-typedef struct {
+struct H_Bar_Body {
   uint8_t x;
   int16_t y;
-} H_Bar_Body;
+};
 
-typedef struct {
-  H_Tag tag;
+struct H {
+  enum H_Tag tag;
   union {
-    H_Foo_Body foo;
-    H_Bar_Body bar;
+    struct H_Foo_Body foo;
+    struct H_Bar_Body bar;
   };
-} H;
+};
 
-void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k);
+void root(struct Opaque *o,
+          A a,
+          B b,
+          C c,
+          D d,
+          E e,
+          union F f,
+          struct G g,
+          struct H h,
+          struct I i,
+          struct J j,
+          enum K k);

--- a/tests/expectations/tag/euclid.c
+++ b/tests/expectations/tag/euclid.c
@@ -1,0 +1,116 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct TypedLength_f32__UnknownUnit {
+  float _0;
+};
+
+struct TypedLength_f32__LayoutUnit {
+  float _0;
+};
+
+typedef struct TypedLength_f32__UnknownUnit Length_f32;
+
+typedef struct TypedLength_f32__LayoutUnit LayoutLength;
+
+struct TypedSideOffsets2D_f32__UnknownUnit {
+  float top;
+  float right;
+  float bottom;
+  float left;
+};
+
+struct TypedSideOffsets2D_f32__LayoutUnit {
+  float top;
+  float right;
+  float bottom;
+  float left;
+};
+
+typedef struct TypedSideOffsets2D_f32__UnknownUnit SideOffsets2D_f32;
+
+typedef struct TypedSideOffsets2D_f32__LayoutUnit LayoutSideOffsets2D;
+
+struct TypedSize2D_f32__UnknownUnit {
+  float width;
+  float height;
+};
+
+struct TypedSize2D_f32__LayoutUnit {
+  float width;
+  float height;
+};
+
+typedef struct TypedSize2D_f32__UnknownUnit Size2D_f32;
+
+typedef struct TypedSize2D_f32__LayoutUnit LayoutSize2D;
+
+struct TypedPoint2D_f32__UnknownUnit {
+  float x;
+  float y;
+};
+
+struct TypedPoint2D_f32__LayoutUnit {
+  float x;
+  float y;
+};
+
+typedef struct TypedPoint2D_f32__UnknownUnit Point2D_f32;
+
+typedef struct TypedPoint2D_f32__LayoutUnit LayoutPoint2D;
+
+struct TypedRect_f32__UnknownUnit {
+  struct TypedPoint2D_f32__UnknownUnit origin;
+  struct TypedSize2D_f32__UnknownUnit size;
+};
+
+struct TypedRect_f32__LayoutUnit {
+  struct TypedPoint2D_f32__LayoutUnit origin;
+  struct TypedSize2D_f32__LayoutUnit size;
+};
+
+typedef struct TypedRect_f32__UnknownUnit Rect_f32;
+
+typedef struct TypedRect_f32__LayoutUnit LayoutRect;
+
+struct TypedTransform2D_f32__UnknownUnit__LayoutUnit {
+  float m11;
+  float m12;
+  float m21;
+  float m22;
+  float m31;
+  float m32;
+};
+
+struct TypedTransform2D_f32__LayoutUnit__UnknownUnit {
+  float m11;
+  float m12;
+  float m21;
+  float m22;
+  float m31;
+  float m32;
+};
+
+void root(struct TypedLength_f32__UnknownUnit length_a,
+          struct TypedLength_f32__LayoutUnit length_b,
+          Length_f32 length_c,
+          LayoutLength length_d,
+          struct TypedSideOffsets2D_f32__UnknownUnit side_offsets_a,
+          struct TypedSideOffsets2D_f32__LayoutUnit side_offsets_b,
+          SideOffsets2D_f32 side_offsets_c,
+          LayoutSideOffsets2D side_offsets_d,
+          struct TypedSize2D_f32__UnknownUnit size_a,
+          struct TypedSize2D_f32__LayoutUnit size_b,
+          Size2D_f32 size_c,
+          LayoutSize2D size_d,
+          struct TypedPoint2D_f32__UnknownUnit point_a,
+          struct TypedPoint2D_f32__LayoutUnit point_b,
+          Point2D_f32 point_c,
+          LayoutPoint2D point_d,
+          struct TypedRect_f32__UnknownUnit rect_a,
+          struct TypedRect_f32__LayoutUnit rect_b,
+          Rect_f32 rect_c,
+          LayoutRect rect_d,
+          struct TypedTransform2D_f32__UnknownUnit__LayoutUnit transform_a,
+          struct TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);

--- a/tests/expectations/tag/expand.c
+++ b/tests/expectations/tag/expand.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Foo {
+
+};
+
+void root(struct Foo a);

--- a/tests/expectations/tag/extern-2.c
+++ b/tests/expectations/tag/extern-2.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+void first(void);
+
+void second(void);

--- a/tests/expectations/tag/extern.c
+++ b/tests/expectations/tag/extern.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Normal {
+  int32_t x;
+  float y;
+};
+
+extern void bar(struct Normal a);
+
+extern int32_t foo(void);

--- a/tests/expectations/tag/include.c
+++ b/tests/expectations/tag/include.c
@@ -1,0 +1,4 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>

--- a/tests/expectations/tag/include_item.c
+++ b/tests/expectations/tag/include_item.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct A {
+  int32_t x;
+  float y;
+};
+
+struct B {
+  struct A data;
+};

--- a/tests/expectations/tag/inner_mod.c
+++ b/tests/expectations/tag/inner_mod.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Foo {
+  float x;
+};
+
+void root(struct Foo a);

--- a/tests/expectations/tag/mod_path.c
+++ b/tests/expectations/tag/mod_path.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define EXPORT_ME_TOO 42
+
+struct ExportMe {
+  uint64_t val;
+};
+
+void export_me(struct ExportMe *val);

--- a/tests/expectations/tag/monomorph-1.c
+++ b/tests/expectations/tag/monomorph-1.c
@@ -1,0 +1,42 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Bar_Bar_f32;
+
+struct Bar_Foo_f32;
+
+struct Bar_f32;
+
+struct Foo_i32 {
+  const int32_t *data;
+};
+
+struct Foo_f32 {
+  const float *data;
+};
+
+struct Foo_Bar_f32 {
+  const struct Bar_f32 *data;
+};
+
+struct Tuple_Foo_f32_____f32 {
+  const struct Foo_f32 *a;
+  const float *b;
+};
+
+struct Tuple_f32__f32 {
+  const float *a;
+  const float *b;
+};
+
+typedef struct Tuple_f32__f32 Indirection_f32;
+
+void root(struct Foo_i32 a,
+          struct Foo_f32 b,
+          struct Bar_f32 c,
+          struct Foo_Bar_f32 d,
+          struct Bar_Foo_f32 e,
+          struct Bar_Bar_f32 f,
+          struct Tuple_Foo_f32_____f32 g,
+          Indirection_f32 h);

--- a/tests/expectations/tag/monomorph-2.c
+++ b/tests/expectations/tag/monomorph-2.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct A;
+
+struct B;
+
+struct List_B {
+  struct B *members;
+  uintptr_t count;
+};
+
+struct List_A {
+  struct A *members;
+  uintptr_t count;
+};
+
+void bar(struct List_B b);
+
+void foo(struct List_A a);

--- a/tests/expectations/tag/monomorph-3.c
+++ b/tests/expectations/tag/monomorph-3.c
@@ -1,0 +1,42 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Bar_Bar_f32;
+
+struct Bar_Foo_f32;
+
+struct Bar_f32;
+
+union Foo_i32 {
+  const int32_t *data;
+};
+
+union Foo_f32 {
+  const float *data;
+};
+
+union Foo_Bar_f32 {
+  const struct Bar_f32 *data;
+};
+
+union Tuple_Foo_f32_____f32 {
+  const union Foo_f32 *a;
+  const float *b;
+};
+
+union Tuple_f32__f32 {
+  const float *a;
+  const float *b;
+};
+
+typedef union Tuple_f32__f32 Indirection_f32;
+
+void root(union Foo_i32 a,
+          union Foo_f32 b,
+          struct Bar_f32 c,
+          union Foo_Bar_f32 d,
+          struct Bar_Foo_f32 e,
+          struct Bar_Bar_f32 f,
+          union Tuple_Foo_f32_____f32 g,
+          Indirection_f32 h);

--- a/tests/expectations/tag/rename-crate.c
+++ b/tests/expectations/tag/rename-crate.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Foo {
+  int32_t x;
+};
+
+void root(struct Foo a);

--- a/tests/expectations/tag/rename.c
+++ b/tests/expectations/tag/rename.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define C_H 10
+
+enum C_E {
+  x = 0,
+  y = 1,
+};
+typedef uint8_t C_E;
+
+struct C_A;
+
+struct C_C;
+
+struct C_AwesomeB {
+  int32_t x;
+  float y;
+};
+
+union C_D {
+  int32_t x;
+  float y;
+};
+
+typedef struct C_A C_F;
+
+extern const int32_t G;
+
+void root(const struct C_A *a, struct C_AwesomeB b, struct C_C c, union C_D d, C_E e, C_F f);

--- a/tests/expectations/tag/simplify-option-ptr.c
+++ b/tests/expectations/tag/simplify-option-ptr.c
@@ -1,0 +1,19 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Opaque;
+
+struct Foo {
+  const struct Opaque *x;
+  struct Opaque *y;
+  void (*z)();
+};
+
+union Bar {
+  const struct Opaque *x;
+  struct Opaque *y;
+  void (*z)();
+};
+
+void root(const struct Opaque *a, struct Opaque *b, struct Foo c, union Bar d);

--- a/tests/expectations/tag/static.c
+++ b/tests/expectations/tag/static.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Bar;
+
+struct Foo {
+
+};
+
+extern const struct Bar BAR;
+
+extern struct Foo FOO;
+
+extern const int32_t NUMBER;
+
+void root(void);

--- a/tests/expectations/tag/std_lib.c
+++ b/tests/expectations/tag/std_lib.c
@@ -1,0 +1,13 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Option_i32;
+
+struct Result_i32__String;
+
+struct Vec_String;
+
+void root(const struct Vec_String *a,
+          const struct Option_i32 *b,
+          const struct Result_i32__String *c);

--- a/tests/expectations/tag/struct.c
+++ b/tests/expectations/tag/struct.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Opaque;
+
+struct Normal {
+  int32_t x;
+  float y;
+};
+
+struct NormalWithZST {
+  int32_t x;
+  float y;
+};
+
+struct TupleRenamed {
+  int32_t m0;
+  float m1;
+};
+
+struct TupleNamed {
+  int32_t x;
+  float y;
+};
+
+void root(struct Opaque *a,
+          struct Normal b,
+          struct NormalWithZST c,
+          struct TupleRenamed d,
+          struct TupleNamed e);

--- a/tests/expectations/tag/typedef.c
+++ b/tests/expectations/tag/typedef.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Foo_i32__i32 {
+  int32_t x;
+  int32_t y;
+};
+
+typedef struct Foo_i32__i32 IntFoo_i32;
+
+void root(IntFoo_i32 a);

--- a/tests/expectations/tag/union.c
+++ b/tests/expectations/tag/union.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct Opaque;
+
+union Normal {
+  int32_t x;
+  float y;
+};
+
+union NormalWithZST {
+  int32_t x;
+  float y;
+};
+
+void root(struct Opaque *a, union Normal b, union NormalWithZST c);

--- a/tests/rust/enum.rs
+++ b/tests/rust/enum.rs
@@ -80,6 +80,14 @@ enum J {
     Baz
 }
 
+#[repr(C)]
+enum K {
+    k1,
+    k2,
+    k3,
+    k4,
+}
+
 #[no_mangle]
 pub extern "C" fn root(
     o: *mut Opaque,
@@ -92,5 +100,6 @@ pub extern "C" fn root(
     g: G,
     h: H,
     i: I,
-    j: J
+    j: J,
+    k: K,
 ) { }


### PR DESCRIPTION
Much C code uses tag names instead of type names on structs. E.g:

    struct account x;

vs

    account x;

When implementing legacy C interfaces in Rust it is nice be able to generate header files that are compatible with this practice.

This pull request introduces three style, tag only, typedef only and both tag and typedef.

Tag only:

    struct balance {
      int dollars;
      int cents;
    };

    struct account {
        struct balance;
    };

Type only:

    typedef struct {
      int dollars;
      int cents;
    } balance;

    typedef struct {
      balance;
    } account;

Both only:

    typedef struct balance {
      int dollars;
      int cents;
    } balance;

    typedef struct account {
      balance;
    } account;

The default is Typedef only and no changes has been made to the generated headers (although it seems some other change has resulted in some new types). The test script has been modified to also build the tests with tag only and both. These files end up in tests/expectations/{tag, both}