### PR TITLE
Emit correct prototypes for functions without arguments in C mode

### DIFF
--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -109,7 +109,7 @@ impl CDecl {
         }
     }
 
-    fn write<F: Write>(&self, out: &mut SourceWriter<F>, ident: Option<&str>) {
+    fn write<F: Write>(&self, out: &mut SourceWriter<F>, ident: Option<&str>, void_prototype: bool) {
         // Write the type-specifier and type-qualifier first
         if self.type_qualifers.len() != 0 {
             write!(out, "{} {}", self.type_qualifers, self.type_name);
@@ -177,6 +177,9 @@ impl CDecl {
                     }
 
                     out.write("(");
+                    if args.is_empty() && void_prototype {
+                        out.write("void");
+                    }
                     if layout_vertical {
                         let align_length = out.line_length_for_align();
                         out.push_set_spaces(align_length);
@@ -189,7 +192,7 @@ impl CDecl {
                             // Convert &Option<String> to Option<&str>
                             let arg_ident = arg_ident.as_ref().map(|x| x.as_ref());
 
-                            arg_ty.write(out, arg_ident);
+                            arg_ty.write(out, arg_ident, void_prototype);
                         }
                         out.pop_tab();
                     } else {
@@ -201,7 +204,7 @@ impl CDecl {
                             // Convert &Option<String> to Option<&str>
                             let arg_ident = arg_ident.as_ref().map(|x| x.as_ref());
 
-                            arg_ty.write(out, arg_ident);
+                            arg_ty.write(out, arg_ident, void_prototype);
                         }
                     }
                     out.write(")");
@@ -213,14 +216,14 @@ impl CDecl {
     }
 }
 
-pub fn write_func<F: Write>(out: &mut SourceWriter<F>, f: &Function, layout_vertical: bool) {
-    &CDecl::from_func(f, layout_vertical).write(out, Some(&f.name));
+pub fn write_func<F: Write>(out: &mut SourceWriter<F>, f: &Function, layout_vertical: bool, void_prototype: bool) {
+    &CDecl::from_func(f, layout_vertical).write(out, Some(&f.name), void_prototype);
 }
 
 pub fn write_field<F: Write>(out: &mut SourceWriter<F>, t: &Type, ident: &str) {
-    &CDecl::from_type(t).write(out, Some(ident));
+    &CDecl::from_type(t).write(out, Some(ident), false);
 }
 
 pub fn write_type<F: Write>(out: &mut SourceWriter<F>, t: &Type) {
-    &CDecl::from_type(t).write(out, None);
+    &CDecl::from_type(t).write(out, None, false);
 }

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use syn;
 
 use bindgen::cdecl;
-use bindgen::config::{Config, Layout};
+use bindgen::config::{Config, Layout, Language};
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::{AnnotationSet, Cfg, CfgWrite, Documentation, SynFnRetTyHelpers, Type};
 use bindgen::library::Library;
@@ -105,6 +105,7 @@ impl Function {
 impl Source for Function {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         fn write_1<W: Write>(func: &Function, config: &Config, out: &mut SourceWriter<W>) {
+            let void_prototype = config.language == Language::C;
             let prefix = config.function.prefix(&func.annotations);
             let postfix = config.function.postfix(&func.annotations);
 
@@ -120,7 +121,7 @@ impl Source for Function {
                     out.write(" ");
                 }
             }
-            cdecl::write_func(out, &func, false);
+            cdecl::write_func(out, &func, false, void_prototype);
             if !func.extern_decl {
                 if let Some(ref postfix) = postfix {
                     out.write(" ");
@@ -133,6 +134,7 @@ impl Source for Function {
         }
 
         fn write_2<W: Write>(func: &Function, config: &Config, out: &mut SourceWriter<W>) {
+            let void_prototype = config.language == Language::C;
             let prefix = config.function.prefix(&func.annotations);
             let postfix = config.function.postfix(&func.annotations);
 
@@ -148,7 +150,7 @@ impl Source for Function {
                     out.new_line();
                 }
             }
-            cdecl::write_func(out, &func, true);
+            cdecl::write_func(out, &func, true, void_prototype);
             if !func.extern_decl {
                 if let Some(ref postfix) = postfix {
                     out.new_line();

--- a/tests/expectations/cdecl.c
+++ b/tests/expectations/cdecl.c
@@ -30,6 +30,6 @@ typedef bool (*M[16])(int32_t, int32_t);
 
 typedef void (*N[16])(int32_t, int32_t);
 
-void (*O())();
+void (*O(void))(void);
 
 void root(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m, N n);

--- a/tests/expectations/extern-2.c
+++ b/tests/expectations/extern-2.c
@@ -2,6 +2,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-void first();
+void first(void);
 
-void second();
+void second(void);

--- a/tests/expectations/extern.c
+++ b/tests/expectations/extern.c
@@ -9,4 +9,4 @@ typedef struct {
 
 extern void bar(Normal a);
 
-extern int32_t foo();
+extern int32_t foo(void);

--- a/tests/expectations/static.c
+++ b/tests/expectations/static.c
@@ -14,4 +14,4 @@ extern Foo FOO;
 
 extern const int32_t NUMBER;
 
-void root();
+void root(void);


### PR DESCRIPTION
`fun test() -> bool` was declared as `bool test();`.
Omitting the list of arguments in the prototype instructs the compiler to allow any type of arguments in the declaration of the `test` function. `bool test(void)` in C is equivalent to `bool test()` in C++ and will only allow declarations without arguments.
GCC warns about this with the `-Wstrict-prototype` flag set.

This change only affects `Language::C`. AFAIK the current C++ behavior is prefered.