### PR TITLE
Increase parse error message to include more context

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -257,10 +257,10 @@ impl Parser {
 
             if !self.cache_src.contains_key(&owned_mod_path) {
                 fn limit_string(text: &str) -> &str {
-                    if text.len() <= 30 {
+                    if text.len() <= 100 {
                         text
                     } else {
-                        &text[..30]
+                        &text[..100]
                     }
                 }
 


### PR DESCRIPTION
I was getting a parse error on webrender and there was insufficient context to figure out what was going on.