### PR TITLE
Don't apply renaming to generic type parameters

### DIFF
--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -125,7 +125,13 @@ impl Item for Struct {
     fn rename_for_config(&mut self, config: &Config) {
         config.export.rename(&mut self.name);
         for &mut (_, ref mut ty, _) in &mut self.fields {
-            ty.rename_for_config(config);
+            let generic_parameter = match ty.get_root_path() {
+                Some(ref p) => self.generic_params.contains(p),
+                None => false,
+            };
+            if !generic_parameter {
+                ty.rename_for_config(config);
+            }
         }
 
         let field_rules = [

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -124,7 +124,13 @@ impl Item for Union {
     fn rename_for_config(&mut self, config: &Config) {
         config.export.rename(&mut self.name);
         for &mut (_, ref mut ty, _) in &mut self.fields {
-            ty.rename_for_config(config);
+            let generic_parameter = match ty.get_root_path() {
+                Some(ref p) => self.generic_params.contains(p),
+                None => false,
+            };
+            if !generic_parameter {
+                ty.rename_for_config(config);
+            }
         }
 
         let rules = [


### PR DESCRIPTION
I found that the presence of an

```toml
[export]
prefix = "Foo"
```

section in the config would cause errors in monomorphizatoin.

Given a rust struct definition like

```rust
#[repr(C)]
pub struct Bar<T> {
   f: T,
}

#[no_mangle]
pub extern "C" fn take_bar(foo: Bar<usize>) {}
```
without the prefix option, you get the C struct:

```C
typedef struct {
    uintptr_t f;
} Bar_usize;
```

but with the prefix, you get

```C
typedef struct {
    FooT f;
} Bar_usize;
```

Which results in undefined type errors for `FooT`.

My investigation led me to the conclusion that `<Struct as Item>::rename_for_config` was overeager in renaming field types and applied renaming rules regardless of whether or not the type was actually a generic type parameter. I simply inserted a check for this, and the problem went away.

As a side-note: I'd like to keep my branch one commit ahead of the v0.4.3 tag for now, at least until the issues in master are resolved. It's currently failing to find any renamed items for me, so most of my functions have undefined argument types.