### PR TITLE
Add an option to specify the lockfile

### DIFF
--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -263,11 +263,12 @@ impl Builder {
             let cargo = if let Some(binding_lib_name) = binding_lib_name {
                 Cargo::load(
                     &lib_dir,
+                    None,
                     Some(&binding_lib_name),
                     self.config.parse.parse_deps,
                 )?
             } else {
-                Cargo::load(&lib_dir, None, self.config.parse.parse_deps)?
+                Cargo::load(&lib_dir, None, None, self.config.parse.parse_deps)?
             };
 
             result.extend_with(&parser::parse_lib(

--- a/src/bindgen/cargo/cargo.rs
+++ b/src/bindgen/cargo/cargo.rs
@@ -39,11 +39,15 @@ impl Cargo {
     /// need to be parsed.
     pub(crate) fn load(
         crate_dir: &Path,
+        lock_file: Option<&str>,
         binding_crate_name: Option<&str>,
         use_cargo_lock: bool,
     ) -> Result<Cargo, Error> {
         let toml_path = crate_dir.join("Cargo.toml");
-        let lock_path = crate_dir.join("Cargo.lock");
+        let lock_path = match lock_file {
+            Some(v) => PathBuf::from(v),
+            None => crate_dir.join("Cargo.lock")
+        };
 
         let lock = if use_cargo_lock {
             match cargo_lock::lock(&lock_path) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn load_bindings<'a>(input: &Path, matches: &ArgMatches<'a>) -> Result<Bindings,
     }
 
     // We have to load a whole crate, so we use cargo to gather metadata
-    let lib = Cargo::load(input, matches.value_of("crate"), true)?;
+    let lib = Cargo::load(input, matches.value_of("lockfile"), matches.value_of("crate"), true)?;
 
     // Load any config specified or search in the binding crate directory
     let mut config = match matches.value_of("config") {
@@ -119,7 +119,10 @@ fn main() {
         )
         .arg(
             Arg::with_name("INPUT")
-                .help("A crate directory or source file to generate bindings for")
+                .help(
+                    "A crate directory or source file to generate bindings for. \
+                    In general this is the folder where the Cargo.toml file of \
+                    source Rust library resides.")
                 .required(false)
                 .index(1),
         )
@@ -139,6 +142,17 @@ fn main() {
                 .long("output")
                 .value_name("PATH")
                 .help("The file to output the bindings to")
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("lockfile")
+                .long("lockfile")
+                .value_name("PATH")
+                .help(
+                    "Specify the path to the Cargo.lock file explicitly. If this \
+                    is not specified, the Cargo.lock file is searched for in the \
+                    same folder as the Cargo.toml file. This option is useful for \
+                    projects that use workspaces.")
                 .required(false),
         )
         .get_matches();


### PR DESCRIPTION
Fixes #141.

For projects in workspaces, the Cargo.lock file may not be in the same
folder as Cargo.toml. This patch allows the user to explicitly pass the
path to the Cargo.lock file so that this scenario can be handled.

r? @eqrion 