### PR TITLE
Ensure that a constants cfg is preserved

### DIFF
--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -8,7 +8,7 @@ use std::mem;
 use syn;
 
 use bindgen::config::{Config, Language};
-use bindgen::ir::{AnnotationSet, Cfg, Documentation, Item, ItemContainer, Type};
+use bindgen::ir::{AnnotationSet, Cfg, CfgWrite, Documentation, Item, ItemContainer, Type};
 use bindgen::writer::{Source, SourceWriter};
 
 #[derive(Debug, Clone)]
@@ -132,6 +132,7 @@ impl Item for Constant {
 
 impl Source for Constant {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
+        self.cfg.write_before(config, out);
         if config.constant.allow_static_const && config.language == Language::Cxx {
             if let Type::ConstPtr(..) = self.ty {
                 out.write("static ");
@@ -143,5 +144,6 @@ impl Source for Constant {
         } else {
             write!(out, "#define {} {}", self.name, self.value.0)
         }
+        self.cfg.write_after(config, out);
     }
 }

--- a/tests/expectations/cfg-2.c
+++ b/tests/expectations/cfg-2.c
@@ -2,6 +2,14 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#if defined(NOT_DEFINED)
+#define DEFAULT_X 8
+#endif
+
+#if defined(DEFINED)
+#define DEFAULT_X 42
+#endif
+
 #if (defined(NOT_DEFINED) || defined(DEFINED))
 typedef struct {
   int32_t x;

--- a/tests/expectations/cfg-2.cpp
+++ b/tests/expectations/cfg-2.cpp
@@ -1,6 +1,14 @@
 #include <cstdint>
 #include <cstdlib>
 
+#if defined(NOT_DEFINED)
+static const int32_t DEFAULT_X = 8;
+#endif
+
+#if defined(DEFINED)
+static const int32_t DEFAULT_X = 42;
+#endif
+
 #if (defined(NOT_DEFINED) || defined(DEFINED))
 struct Foo {
   int32_t x;

--- a/tests/rust/cfg-2.rs
+++ b/tests/rust/cfg-2.rs
@@ -21,6 +21,12 @@ struct Root {
     w: Bar,
 }
 
+#[cfg(windows)]
+pub const DEFAULT_X: i32 = 0x08;
+
+#[cfg(unix)]
+pub const DEFAULT_X: i32 = 0x2a;
+
 #[no_mangle]
 pub extern "C" fn root(a: Root)
 { }


### PR DESCRIPTION
When writing out constants the cfg attribute is not written out around
the defined constant.