### PR TITLE
Allow generating structs without a typedef

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::default::Default;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{self, BufReader};
@@ -110,6 +110,8 @@ pub struct ExportConfig {
     pub rename: HashMap<String, String>,
     /// A prefix to add before the name of every item
     pub prefix: Option<String>,
+    /// A list of C structures to avoid declaring with a typedef
+    pub no_typedef: HashSet<String>
 }
 
 impl Default for ExportConfig {
@@ -118,6 +120,7 @@ impl Default for ExportConfig {
             include: Vec::new(),
             exclude: Vec::new(),
             rename: HashMap::new(),
+            no_typedef: HashSet::new(),
             prefix: None,
         }
     }
@@ -131,6 +134,10 @@ impl ExportConfig {
         if let Some(ref prefix) = self.prefix {
             item_name.insert_str(0, &prefix);
         }
+    }
+
+    pub(crate) fn typedef_struct(&self, item_name: &str) -> bool {
+        !self.no_typedef.contains(item_name)
     }
 }
 

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -130,7 +130,7 @@ impl Source for Function {
                     out.write(" ");
                 }
             }
-            cdecl::write_func(out, &func, false, void_prototype);
+            cdecl::write_func(out, &func, false, void_prototype, &config);
             if !func.extern_decl {
                 if let Some(ref postfix) = postfix {
                     out.write(" ");
@@ -159,7 +159,7 @@ impl Source for Function {
                     out.new_line();
                 }
             }
-            cdecl::write_func(out, &func, true, void_prototype);
+            cdecl::write_func(out, &func, true, void_prototype, &config);
             if !func.extern_decl {
                 if let Some(ref postfix) = postfix {
                     out.new_line();

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -217,7 +217,8 @@ impl Source for Struct {
 
         self.generic_params.write(config, out);
 
-        if config.language == Language::C {
+        let typedef_struct = config.export.typedef_struct(&self.name);
+        if config.language == Language::C && typedef_struct {
             out.write("typedef struct");
         } else {
             write!(out, "struct {}", self.name);
@@ -347,7 +348,10 @@ impl Source for Struct {
 
         if config.language == Language::C {
             out.close_brace(false);
-            write!(out, " {};", self.name);
+            if typedef_struct {
+                write!(out, " {}", self.name);
+            }
+            write!(out, ";");
         } else {
             out.close_brace(true);
         }

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -558,20 +558,20 @@ impl Source for String {
 }
 
 impl Source for Type {
-    fn write<F: Write>(&self, _config: &Config, out: &mut SourceWriter<F>) {
-        cdecl::write_type(out, &self);
+    fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
+        cdecl::write_type(out, &self, config);
     }
 }
 
 impl Source for (String, Type) {
-    fn write<F: Write>(&self, _config: &Config, out: &mut SourceWriter<F>) {
-        cdecl::write_field(out, &self.1, &self.0);
+    fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
+        cdecl::write_field(out, &self.1, &self.0, config);
     }
 }
 
 impl Source for (String, Type, Documentation) {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         self.2.write(config, out);
-        cdecl::write_field(out, &self.1, &self.0);
+        cdecl::write_field(out, &self.1, &self.0, config);
     }
 }

--- a/tests/expectations/no-typedef.c
+++ b/tests/expectations/no-typedef.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct simple {
+  uint64_t len;
+};
+
+const struct simple *simple(const struct simple *simple);

--- a/tests/expectations/no-typedef.cpp
+++ b/tests/expectations/no-typedef.cpp
@@ -1,0 +1,12 @@
+#include <cstdint>
+#include <cstdlib>
+
+struct simple {
+  uint64_t len;
+};
+
+extern "C" {
+
+const struct simple *simple(const struct simple *simple);
+
+} // extern "C"

--- a/tests/rust/no-typedef.rs
+++ b/tests/rust/no-typedef.rs
@@ -1,0 +1,9 @@
+#[repr(C)]
+pub struct simple {
+    len: u64,
+}
+
+#[no_mangle]
+pub extern "C" fn simple(simple: *const simple) -> *const simple {
+    simple
+}

--- a/tests/rust/no-typedef.toml
+++ b/tests/rust/no-typedef.toml
@@ -1,0 +1,2 @@
+[export]
+no_typedef = ["simple"]


### PR DESCRIPTION
Add a configuration option that allows users to specify structs that
should not be decaired with a typedef. This is particularly useful when
a function that is accompanied by a struct of the same name.

I hit this issue today with `sigaction()` and `struct sigaction`. This was
my first thought/attempt at a solution. I'd be more than happy to attempt
to fix this with a different approach.