### PR TITLE
Fix handling of dependencies that are renamed

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -126,8 +126,7 @@ impl Parser {
         }
 
         // Check the blacklist
-        let res = !STD_CRATES.contains(&pkg_name.as_ref()) && !self.exclude.contains(&pkg_name);
-        return res;
+        !STD_CRATES.contains(&pkg_name.as_ref()) && !self.exclude.contains(&pkg_name)
     }
 
     fn parse_crate(&mut self, pkg: &PackageRef) -> Result<(), Error> {


### PR DESCRIPTION
Our use case involves running cbindgen on a project that has internal dependencies which are renamed to be distinct from the spelling of their directories. This commit fixes that problem.