### PR TITLE
Implement optional convenience constructors for tagged enums

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -319,6 +319,9 @@ pub struct EnumConfig {
     pub add_sentinel: bool,
     /// Whether the enum variants should be prefixed with the enum name
     pub prefix_with_name: bool,
+    /// Whether to generate static `::X(..)` constructors and `IsX()`
+    /// methods for tagged enums.
+    pub derive_helper_methods: bool,
 }
 
 impl Default for EnumConfig {
@@ -327,6 +330,7 @@ impl Default for EnumConfig {
             rename_variants: None,
             add_sentinel: false,
             prefix_with_name: false,
+            derive_helper_methods: false,
         }
     }
 }
@@ -337,6 +341,12 @@ impl EnumConfig {
             return x;
         }
         self.add_sentinel
+    }
+    pub(crate) fn derive_helper_methods(&self, annotations: &AnnotationSet) -> bool {
+        if let Some(x) = annotations.bool("derive-helper-methods") {
+            return x;
+        }
+        self.derive_helper_methods
     }
 }
 

--- a/tests/expectations/annotation.c
+++ b/tests/expectations/annotation.c
@@ -17,4 +17,52 @@ typedef struct {
   float y;
 } B;
 
-void root(A x, B y, C z);
+enum F_Tag {
+  Foo,
+  Bar,
+  Baz,
+};
+typedef uint8_t F_Tag;
+
+typedef struct {
+  F_Tag tag;
+  int16_t _0;
+} Foo_Body;
+
+typedef struct {
+  F_Tag tag;
+  uint8_t x;
+  int16_t y;
+} Bar_Body;
+
+typedef union {
+  F_Tag tag;
+  Foo_Body foo;
+  Bar_Body bar;
+} F;
+
+enum H_Tag {
+  Hello,
+  There,
+  Everyone,
+};
+typedef uint8_t H_Tag;
+
+typedef struct {
+  int16_t _0;
+} Hello_Body;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} There_Body;
+
+typedef struct {
+  H_Tag tag;
+  union {
+    Hello_Body hello;
+    There_Body there;
+  };
+} H;
+
+void root(A x, B y, C z, F f, H h);

--- a/tests/expectations/annotation.cpp
+++ b/tests/expectations/annotation.cpp
@@ -26,8 +26,124 @@ struct B {
   float y;
 };
 
+union F {
+  enum class Tag : uint8_t {
+    Foo,
+    Bar,
+    Baz,
+  };
+
+  struct Foo_Body {
+    Tag tag;
+    int16_t _0;
+  };
+
+  struct Bar_Body {
+    Tag tag;
+    uint8_t x;
+    int16_t y;
+  };
+
+  struct {
+    Tag tag;
+  };
+  Foo_Body foo;
+  Bar_Body bar;
+
+  static F Foo(int16_t const& a0) {
+    F result;
+    result.foo._0 = a0;
+    result.tag = Tag::Foo;
+    return result;
+  }
+
+  static F Bar(uint8_t const& aX,
+               int16_t const& aY) {
+    F result;
+    result.bar.x = aX;
+    result.bar.y = aY;
+    result.tag = Tag::Bar;
+    return result;
+  }
+
+  static F Baz() {
+    F result;
+    result.tag = Tag::Baz;
+    return result;
+  }
+
+  bool IsFoo() const {
+    return tag == Tag::Foo;
+  }
+
+  bool IsBar() const {
+    return tag == Tag::Bar;
+  }
+
+  bool IsBaz() const {
+    return tag == Tag::Baz;
+  }
+};
+
+struct H {
+  enum class Tag : uint8_t {
+    Hello,
+    There,
+    Everyone,
+  };
+
+  struct Hello_Body {
+    int16_t _0;
+  };
+
+  struct There_Body {
+    uint8_t x;
+    int16_t y;
+  };
+
+  Tag tag;
+  union {
+    Hello_Body hello;
+    There_Body there;
+  };
+
+  static H Hello(int16_t const& a0) {
+    H result;
+    result.hello._0 = a0;
+    result.tag = Tag::Hello;
+    return result;
+  }
+
+  static H There(uint8_t const& aX,
+                 int16_t const& aY) {
+    H result;
+    result.there.x = aX;
+    result.there.y = aY;
+    result.tag = Tag::There;
+    return result;
+  }
+
+  static H Everyone() {
+    H result;
+    result.tag = Tag::Everyone;
+    return result;
+  }
+
+  bool IsHello() const {
+    return tag == Tag::Hello;
+  }
+
+  bool IsThere() const {
+    return tag == Tag::There;
+  }
+
+  bool IsEveryone() const {
+    return tag == Tag::Everyone;
+  }
+};
+
 extern "C" {
 
-void root(A x, B y, C z);
+void root(A x, B y, C z, F f, H h);
 
 } // extern "C"

--- a/tests/expectations/both/annotation.c
+++ b/tests/expectations/both/annotation.c
@@ -17,4 +17,52 @@ typedef struct B {
   float y;
 } B;
 
-void root(A x, B y, C z);
+enum F_Tag {
+  Foo,
+  Bar,
+  Baz,
+};
+typedef uint8_t F_Tag;
+
+typedef struct Foo_Body {
+  F_Tag tag;
+  int16_t _0;
+} Foo_Body;
+
+typedef struct Bar_Body {
+  F_Tag tag;
+  uint8_t x;
+  int16_t y;
+} Bar_Body;
+
+typedef union F {
+  F_Tag tag;
+  Foo_Body foo;
+  Bar_Body bar;
+} F;
+
+enum H_Tag {
+  Hello,
+  There,
+  Everyone,
+};
+typedef uint8_t H_Tag;
+
+typedef struct Hello_Body {
+  int16_t _0;
+} Hello_Body;
+
+typedef struct There_Body {
+  uint8_t x;
+  int16_t y;
+} There_Body;
+
+typedef struct H {
+  H_Tag tag;
+  union {
+    Hello_Body hello;
+    There_Body there;
+  };
+} H;
+
+void root(A x, B y, C z, F f, H h);

--- a/tests/expectations/tag/annotation.c
+++ b/tests/expectations/tag/annotation.c
@@ -17,4 +17,52 @@ struct B {
   float y;
 };
 
-void root(struct A x, struct B y, C z);
+enum F_Tag {
+  Foo,
+  Bar,
+  Baz,
+};
+typedef uint8_t F_Tag;
+
+struct Foo_Body {
+  F_Tag tag;
+  int16_t _0;
+};
+
+struct Bar_Body {
+  F_Tag tag;
+  uint8_t x;
+  int16_t y;
+};
+
+union F {
+  enum F_Tag tag;
+  struct Foo_Body foo;
+  struct Bar_Body bar;
+};
+
+enum H_Tag {
+  Hello,
+  There,
+  Everyone,
+};
+typedef uint8_t H_Tag;
+
+struct Hello_Body {
+  int16_t _0;
+};
+
+struct There_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct H {
+  enum H_Tag tag;
+  union {
+    struct Hello_Body hello;
+    struct There_Body there;
+  };
+};
+
+void root(struct A x, struct B y, C z, union F f, struct H h);

--- a/tests/rust/annotation.rs
+++ b/tests/rust/annotation.rs
@@ -36,5 +36,8 @@ enum H {
 pub extern "C" fn root(
     x: A,
     y: B,
-    z: C
+    z: C,
+    f: F,
+    h: H,
 ) { }
+

--- a/tests/rust/annotation.rs
+++ b/tests/rust/annotation.rs
@@ -16,6 +16,22 @@ enum C {
     Y,
 }
 
+/// cbindgen:derive-helper-methods=true
+#[repr(u8)]
+enum F {
+    Foo(i16),
+    Bar { x: u8, y: i16 },
+    Baz
+}
+
+/// cbindgen:derive-helper-methods
+#[repr(C, u8)]
+enum H {
+    Hello(i16),
+    There { x: u8, y: i16 },
+    Everyone
+}
+
 #[no_mangle]
 pub extern "C" fn root(
     x: A,


### PR DESCRIPTION
This is the most important part of what I proposed in #162

Minor "bug": the convenience constructor names will be the tag names, which means if you're using the prefix name, you'll end up with static constructor names like `MyEnum_CaseA()`. This is awkward to avoid under the current design, as the original variant name is completely overwritten by `Item::rename_for_config`, and the snake_case version of the name is only stored if the variant has a body.

WIP because I kinda just hacked this together and am interested in opinions from the maintainers on implementation details. There's possibly some interesting refactoring that could be done to share code with struct ctor generation, but it seemed like it would be more complicated/messy than just duplicating a bit of logic.

Also I added some comments/whitespace to chunk this function out into more clear sections.