### PR TITLE
Add more control over the generated items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ include = ["Foo", "Bar"]
 exclude = ["Bad"]
 # A prefix to add before the name of every item
 prefix = "CAPI_"
+# Types of items that we'll generate.
+item_types = ["constants", "globals", "enums", "structs", "unions", "typedefs", "opaque", "functions"]
 
 # Table of name conversions to apply to item names
 [export.rename]

--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -153,43 +153,36 @@ impl Bindings {
             out.new_line();
         }
 
+        if !self.functions.is_empty() || !self.globals.is_empty() {
+            if self.config.language == Language::Cxx {
+                out.new_line_if_not_start();
+                out.write("extern \"C\" {");
+                out.new_line();
+            }
+
+            for global in &self.globals {
+                out.new_line_if_not_start();
+                global.write(&self.config, &mut out);
+                out.new_line();
+            }
+
+            for function in &self.functions {
+                out.new_line_if_not_start();
+                function.write(&self.config, &mut out);
+                out.new_line();
+            }
+
+            if self.config.language == Language::Cxx {
+                out.new_line_if_not_start();
+                out.write("} // extern \"C\"");
+                out.new_line();
+            }
+        }
+
         if self.config.language == Language::Cxx {
-            out.new_line_if_not_start();
-            out.write("extern \"C\" {");
-            out.new_line();
-        }
-
-        for global in &self.globals {
-            out.new_line_if_not_start();
-            global.write(&self.config, &mut out);
-            out.new_line();
-        }
-
-        if let Some(ref f) = self.config.autogen_warning {
-            out.new_line_if_not_start();
-            write!(out, "{}", f);
-            out.new_line();
-        }
-
-        for function in &self.functions {
-            out.new_line_if_not_start();
-            function.write(&self.config, &mut out);
-            out.new_line();
-        }
-
-        if self.config.language == Language::Cxx {
-            out.new_line_if_not_start();
-            out.write("} // extern \"C\"");
-            out.new_line();
-
             self.close_namespaces(&mut out);
         }
 
-        if let Some(ref f) = self.config.autogen_warning {
-            out.new_line_if_not_start();
-            write!(out, "{}", f);
-            out.new_line();
-        }
         if let Some(ref f) = self.config.include_guard {
             out.new_line_if_not_start();
             if self.config.language == Language::C {

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -92,25 +92,22 @@ impl Library {
         dependencies.sort();
 
         let items = dependencies.order;
-        let constants =
-            if self.config.export.should_generate(ItemType::Constants) {
-                self.constants.to_vec()
-            } else {
-                vec![]
-            };
+        let constants = if self.config.export.should_generate(ItemType::Constants) {
+            self.constants.to_vec()
+        } else {
+            vec![]
+        };
 
-        let globals =
-            if self.config.export.should_generate(ItemType::Globals) {
-                self.globals.to_vec()
-            } else {
-                vec![]
-            };
-        let functions =
-            if self.config.export.should_generate(ItemType::Functions) {
-                mem::replace(&mut self.functions, vec![])
-            } else {
-                vec![]
-            };
+        let globals = if self.config.export.should_generate(ItemType::Globals) {
+            self.globals.to_vec()
+        } else {
+            vec![]
+        };
+        let functions = if self.config.export.should_generate(ItemType::Functions) {
+            mem::replace(&mut self.functions, vec![])
+        } else {
+            vec![]
+        };
 
         Ok(Bindings::new(
             self.config,
@@ -126,10 +123,10 @@ impl Library {
             ($field:ident, $kind:ident) => {
                 if self.config.export.should_generate(ItemType::$kind) {
                     if let Some(x) = self.$field.get_items(p) {
-                        return Some(x)
+                        return Some(x);
                     }
                 }
-            }
+            };
         }
 
         find!(enums, Enums);

--- a/tests/expectations/both/item_types.c
+++ b/tests/expectations/both/item_types.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+enum OnlyThisShouldBeGenerated {
+  Foo,
+  Bar,
+};
+typedef uint8_t OnlyThisShouldBeGenerated;

--- a/tests/expectations/cfg-field.cpp
+++ b/tests/expectations/cfg-field.cpp
@@ -1,6 +1,2 @@
 #include <cstdint>
 #include <cstdlib>
-
-extern "C" {
-
-} // extern "C"

--- a/tests/expectations/global_attr.cpp
+++ b/tests/expectations/global_attr.cpp
@@ -1,6 +1,2 @@
 #include <cstdint>
 #include <cstdlib>
-
-extern "C" {
-
-} // extern "C"

--- a/tests/expectations/include.cpp
+++ b/tests/expectations/include.cpp
@@ -1,7 +1,3 @@
 #include <cstdint>
 #include <cstdlib>
 #include <math.h>
-
-extern "C" {
-
-} // extern "C"

--- a/tests/expectations/include_item.cpp
+++ b/tests/expectations/include_item.cpp
@@ -9,7 +9,3 @@ struct A {
 struct B {
   A data;
 };
-
-extern "C" {
-
-} // extern "C"

--- a/tests/expectations/item_types.c
+++ b/tests/expectations/item_types.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+enum OnlyThisShouldBeGenerated {
+  Foo,
+  Bar,
+};
+typedef uint8_t OnlyThisShouldBeGenerated;

--- a/tests/expectations/item_types.cpp
+++ b/tests/expectations/item_types.cpp
@@ -1,0 +1,7 @@
+#include <cstdint>
+#include <cstdlib>
+
+enum class OnlyThisShouldBeGenerated : uint8_t {
+  Foo,
+  Bar,
+};

--- a/tests/expectations/nested_import.cpp
+++ b/tests/expectations/nested_import.cpp
@@ -1,6 +1,2 @@
 #include <cstdint>
 #include <cstdlib>
-
-extern "C" {
-
-} // extern "C"

--- a/tests/expectations/tag/item_types.c
+++ b/tests/expectations/tag/item_types.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+enum OnlyThisShouldBeGenerated {
+  Foo,
+  Bar,
+};
+typedef uint8_t OnlyThisShouldBeGenerated;

--- a/tests/rust/item_types.rs
+++ b/tests/rust/item_types.rs
@@ -1,0 +1,12 @@
+
+pub const MY_CONST: u8 = 4;
+
+#[no_mangle]
+pub extern "C" fn ExternFunction() {
+}
+
+#[repr(u8)]
+pub enum OnlyThisShouldBeGenerated {
+    Foo,
+    Bar,
+}

--- a/tests/rust/item_types.toml
+++ b/tests/rust/item_types.toml
@@ -1,0 +1,3 @@
+[export]
+item_types = ["enums"]
+include = ["OnlyThisShouldBeGenerated"]


### PR DESCRIPTION
I'm going to need this for the style system, otherwise we generate a bunch of constants and such that we don't need.

Also I fixed a stylistic nit where the warning message was printed redundantly, and avoided generating empty extern blocks.