### PR TITLE
Use Cargo.lock from workspace root

### DIFF
--- a/src/bindgen/cargo/cargo_metadata.rs
+++ b/src/bindgen/cargo/cargo_metadata.rs
@@ -24,6 +24,8 @@ pub struct Metadata {
     /// A list of all crates referenced by this crate (and the crate itself)
     pub packages: Vec<Package>,
     version: usize,
+    /// path to the workspace containing the `Cargo.lock`
+    pub workspace_root: String,
 }
 
 #[derive(Clone, Deserialize, Debug)]

--- a/tests/expectations/both/external_workspace_child.c
+++ b/tests/expectations/both/external_workspace_child.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct ExtType {
+  uint32_t data;
+} ExtType;
+
+void consume_ext(ExtType _ext);

--- a/tests/expectations/both/workspace.c
+++ b/tests/expectations/both/workspace.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct ExtType {
+  uint32_t data;
+} ExtType;
+
+void consume_ext(ExtType _ext);

--- a/tests/expectations/external_workspace_child.c
+++ b/tests/expectations/external_workspace_child.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct {
+  uint32_t data;
+} ExtType;
+
+void consume_ext(ExtType _ext);

--- a/tests/expectations/external_workspace_child.cpp
+++ b/tests/expectations/external_workspace_child.cpp
@@ -1,0 +1,12 @@
+#include <cstdint>
+#include <cstdlib>
+
+struct ExtType {
+  uint32_t data;
+};
+
+extern "C" {
+
+void consume_ext(ExtType _ext);
+
+} // extern "C"

--- a/tests/expectations/tag/external_workspace_child.c
+++ b/tests/expectations/tag/external_workspace_child.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct ExtType {
+  uint32_t data;
+};
+
+void consume_ext(struct ExtType _ext);

--- a/tests/expectations/tag/workspace.c
+++ b/tests/expectations/tag/workspace.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct ExtType {
+  uint32_t data;
+};
+
+void consume_ext(struct ExtType _ext);

--- a/tests/expectations/workspace.c
+++ b/tests/expectations/workspace.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct {
+  uint32_t data;
+} ExtType;
+
+void consume_ext(ExtType _ext);

--- a/tests/expectations/workspace.cpp
+++ b/tests/expectations/workspace.cpp
@@ -1,0 +1,12 @@
+#include <cstdint>
+#include <cstdlib>
+
+struct ExtType {
+  uint32_t data;
+};
+
+extern "C" {
+
+void consume_ext(ExtType _ext);
+
+} // extern "C"

--- a/tests/rust/external_workspace_child/Cargo.toml
+++ b/tests/rust/external_workspace_child/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "child"
+version = "0.1.0"
+authors = ["cbindgen"]
+workspace = "../workspace"
+
+[dependencies.dep]
+path = "../workspace/dep"

--- a/tests/rust/external_workspace_child/cbindgen.toml
+++ b/tests/rust/external_workspace_child/cbindgen.toml
@@ -1,0 +1,2 @@
+[parse]
+parse_deps = true

--- a/tests/rust/external_workspace_child/src/lib.rs
+++ b/tests/rust/external_workspace_child/src/lib.rs
@@ -1,0 +1,5 @@
+extern crate dep;
+
+#[no_mangle]
+pub extern "C" fn consume_ext(_ext: dep::ExtType) {
+}

--- a/tests/rust/workspace/Cargo.lock
+++ b/tests/rust/workspace/Cargo.lock
@@ -1,0 +1,18 @@
+[[package]]
+name = "child"
+version = "0.1.0"
+dependencies = [
+ "dep 0.1.0",
+]
+
+[[package]]
+name = "dep"
+version = "0.1.0"
+
+[[package]]
+name = "workspace"
+version = "0.1.0"
+dependencies = [
+ "dep 0.1.0",
+]
+

--- a/tests/rust/workspace/Cargo.toml
+++ b/tests/rust/workspace/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "workspace"
+version = "0.1.0"
+authors = ["cbindgen"]
+
+[dependencies.dep]
+path = "dep"
+
+[workspace]
+members = [
+    "../external_workspace_child",
+    "dep",
+]

--- a/tests/rust/workspace/cbindgen.toml
+++ b/tests/rust/workspace/cbindgen.toml
@@ -1,0 +1,2 @@
+[parse]
+parse_deps = true

--- a/tests/rust/workspace/dep/Cargo.toml
+++ b/tests/rust/workspace/dep/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "dep"
+version = "0.1.0"
+authors = ["cbindgen"]
+
+[dependencies]

--- a/tests/rust/workspace/dep/src/lib.rs
+++ b/tests/rust/workspace/dep/src/lib.rs
@@ -1,0 +1,4 @@
+#[repr(C)]
+pub struct ExtType {
+    pub data: u32,
+}

--- a/tests/rust/workspace/src/lib.rs
+++ b/tests/rust/workspace/src/lib.rs
@@ -1,0 +1,5 @@
+extern crate dep;
+
+#[no_mangle]
+pub extern "C" fn consume_ext(_ext: dep::ExtType) {
+}


### PR DESCRIPTION
cbindgen currently assumes that the `Cargo.lock` is in directly in the
crate directory as a sibling to `Cargo.toml`; however that is usually
not the case inside a workspace.

Instead, this PR extracts the workspace root from the output of `cargo
metadata` [1] (already used to get a list of packages) and uses the
`Cargo.lock` from there.

 1. This is available since Rust 1.24; see rust-lang/cargo#4940