### PR TITLE
Fixed missing prefix for named consts in `[T; <Const>]` types

### DIFF
--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -122,7 +122,8 @@ impl CDecl {
                 self.build_type(t, false);
             }
             &Type::Array(ref t, ref constant) => {
-                self.declarators.push(CDeclarator::Array(constant.clone()));
+                let len = constant.as_str().to_owned();
+                self.declarators.push(CDeclarator::Array(len));
                 self.build_type(t, false);
             }
             &Type::FuncPtr(ref ret, ref args) => {

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -176,7 +176,7 @@ pub enum ArrayLength {
 impl ArrayLength {
     pub fn as_str(&self) -> &str {
         match self {
-            ArrayLength::Name(ref string) | ArrayLength::Value(ref string) => string
+            ArrayLength::Name(ref string) | ArrayLength::Value(ref string) => string,
         }
     }
 }

--- a/tests/expectations/both/prefix.c
+++ b/tests/expectations/both/prefix.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define PREFIX_LEN 42
+
+typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
+
+typedef int32_t PREFIX_ValuedLenArray[42];
+
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y);

--- a/tests/expectations/prefix.c
+++ b/tests/expectations/prefix.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define PREFIX_LEN 42
+
+typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
+
+typedef int32_t PREFIX_ValuedLenArray[42];
+
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y);

--- a/tests/expectations/prefix.cpp
+++ b/tests/expectations/prefix.cpp
@@ -1,0 +1,14 @@
+#include <cstdint>
+#include <cstdlib>
+
+static const int32_t PREFIX_LEN = 42;
+
+using PREFIX_NamedLenArray = int32_t[PREFIX_LEN];
+
+using PREFIX_ValuedLenArray = int32_t[42];
+
+extern "C" {
+
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y);
+
+} // extern "C"

--- a/tests/expectations/tag/prefix.c
+++ b/tests/expectations/tag/prefix.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define PREFIX_LEN 42
+
+typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
+
+typedef int32_t PREFIX_ValuedLenArray[42];
+
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y);

--- a/tests/rust/prefix.rs
+++ b/tests/rust/prefix.rs
@@ -1,0 +1,7 @@
+const LEN: i32 = 42;
+
+pub type NamedLenArray = [i32; LEN];
+pub type ValuedLenArray = [i32; 42];
+
+#[no_mangle]
+pub extern "C" fn root(x: NamedLenArray, y: ValuedLenArray) { }

--- a/tests/rust/prefix.toml
+++ b/tests/rust/prefix.toml
@@ -1,0 +1,2 @@
+[export]
+prefix = "PREFIX_"


### PR DESCRIPTION
Fixes https://github.com/eqrion/cbindgen/issues/186.

cc @emilio 
