### PR TITLE
Fix "Missing `#if defined(…) … #endif` guards in header of items from behind `#[cfg(…)]`"

### DIFF
--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -9,7 +9,9 @@ use syn;
 
 use bindgen::config::{Config, Language};
 use bindgen::declarationtyperesolver::DeclarationTypeResolver;
-use bindgen::ir::{AnnotationSet, Cfg, CfgWrite, Documentation, Item, ItemContainer, Type};
+use bindgen::ir::{
+    AnnotationSet, Cfg, ConditionWrite, Documentation, Item, ItemContainer, ToCondition, Type,
+};
 use bindgen::writer::{Source, SourceWriter};
 
 #[derive(Debug, Clone)]
@@ -137,7 +139,8 @@ impl Item for Constant {
 
 impl Source for Constant {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
-        self.cfg.write_before(config, out);
+        let condition = (&self.cfg).to_condition(config);
+        condition.write_before(config, out);
         if config.constant.allow_static_const && config.language == Language::Cxx {
             if let Type::ConstPtr(..) = self.ty {
                 out.write("static ");
@@ -149,6 +152,6 @@ impl Source for Constant {
         } else {
             write!(out, "#define {} {}", self.name, self.value.0)
         }
-        self.cfg.write_after(config, out);
+        condition.write_after(config, out);
     }
 }

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -10,8 +10,8 @@ use bindgen::config::{Config, Language};
 use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::{
-    AnnotationSet, Cfg, CfgWrite, Documentation, GenericParams, GenericPath, Item, ItemContainer,
-    Repr, ReprStyle, ReprType, Struct, Type,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericParams, GenericPath, Item,
+    ItemContainer, Repr, ReprStyle, ReprType, Struct, ToCondition, Type,
 };
 use bindgen::library::Library;
 use bindgen::rename::{IdentifierType, RenameRule};
@@ -317,7 +317,9 @@ impl Source for Enum {
             ReprType::I8 => "int8_t",
         });
 
-        self.cfg.write_before(config, out);
+        let condition = (&self.cfg).to_condition(config);
+
+        condition.write_before(config, out);
 
         self.documentation.write(config, out);
 
@@ -543,6 +545,6 @@ impl Source for Enum {
             }
         }
 
-        self.cfg.write_after(config, out);
+        condition.write_after(config, out);
     }
 }

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -10,7 +10,9 @@ use bindgen::cdecl;
 use bindgen::config::{Config, Language, Layout};
 use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
-use bindgen::ir::{AnnotationSet, Cfg, CfgWrite, Documentation, PrimitiveType, Type};
+use bindgen::ir::{
+    AnnotationSet, Cfg, ConditionWrite, Documentation, PrimitiveType, ToCondition, Type,
+};
 use bindgen::library::Library;
 use bindgen::monomorph::Monomorphs;
 use bindgen::rename::{IdentifierType, RenameRule};
@@ -126,7 +128,8 @@ impl Source for Function {
             let prefix = config.function.prefix(&func.annotations);
             let postfix = config.function.postfix(&func.annotations);
 
-            func.cfg.write_before(config, out);
+            let condition = (&func.cfg).to_condition(config);
+            condition.write_before(config, out);
 
             func.documentation.write(config, out);
 
@@ -147,7 +150,7 @@ impl Source for Function {
             }
             out.write(";");
 
-            func.cfg.write_after(config, out);
+            condition.write_after(config, out);
         }
 
         fn write_2<W: Write>(func: &Function, config: &Config, out: &mut SourceWriter<W>) {
@@ -155,7 +158,9 @@ impl Source for Function {
             let prefix = config.function.prefix(&func.annotations);
             let postfix = config.function.postfix(&func.annotations);
 
-            func.cfg.write_before(config, out);
+            let condition = (&func.cfg).to_condition(config);
+
+            condition.write_before(config, out);
 
             func.documentation.write(config, out);
 
@@ -176,7 +181,7 @@ impl Source for Function {
             }
             out.write(";");
 
-            func.cfg.write_after(config, out);
+            condition.write_after(config, out);
         };
 
         let option_1 = out.measure(|out| write_1(self, config, out));

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -10,7 +10,8 @@ use bindgen::config::{Config, Language};
 use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::{
-    AnnotationSet, Cfg, CfgWrite, Documentation, GenericParams, Item, ItemContainer, Path, Type,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericParams, Item, ItemContainer, Path,
+    ToCondition, Type,
 };
 use bindgen::library::Library;
 use bindgen::mangle;
@@ -107,7 +108,8 @@ impl Item for OpaqueItem {
 
 impl Source for OpaqueItem {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
-        self.cfg.write_before(config, out);
+        let condition = (&self.cfg).to_condition(config);
+        condition.write_before(config, out);
 
         self.documentation.write(config, out);
 
@@ -119,6 +121,6 @@ impl Source for OpaqueItem {
             write!(out, "struct {};", self.name);
         }
 
-        self.cfg.write_after(config, out);
+        condition.write_after(config, out);
     }
 }

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -10,7 +10,8 @@ use bindgen::config::{Config, Language};
 use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::{
-    AnnotationSet, Cfg, CfgWrite, Documentation, GenericParams, Item, ItemContainer, Repr, Type,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericParams, Item, ItemContainer, Repr,
+    ToCondition, Type,
 };
 use bindgen::library::Library;
 use bindgen::mangle;
@@ -234,7 +235,8 @@ impl Item for Struct {
 
 impl Source for Struct {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
-        self.cfg.write_before(config, out);
+        let condition = (&self.cfg).to_condition(config);
+        condition.write_before(config, out);
 
         self.documentation.write(config, out);
 
@@ -396,7 +398,7 @@ impl Source for Struct {
             out.close_brace(true);
         }
 
-        self.cfg.write_after(config, out);
+        condition.write_after(config, out);
     }
 }
 

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -11,7 +11,8 @@ use bindgen::config::{Config, Language};
 use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::{
-    AnnotationSet, Cfg, CfgWrite, Documentation, GenericParams, Item, ItemContainer, Path, Type,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericParams, Item, ItemContainer, Path,
+    ToCondition, Type,
 };
 use bindgen::library::Library;
 use bindgen::mangle;
@@ -168,7 +169,8 @@ impl Item for Typedef {
 
 impl Source for Typedef {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
-        self.cfg.write_before(config, out);
+        let condition = (&self.cfg).to_condition(config);
+        condition.write_before(config, out);
 
         self.documentation.write(config, out);
 
@@ -183,6 +185,6 @@ impl Source for Typedef {
         }
         out.write(";");
 
-        self.cfg.write_after(config, out);
+        condition.write_after(config, out);
     }
 }

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -11,7 +11,8 @@ use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::dependencies::Dependencies;
 use bindgen::ir::SynFieldHelpers;
 use bindgen::ir::{
-    AnnotationSet, Cfg, CfgWrite, Documentation, GenericParams, Item, ItemContainer, Repr, Type,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericParams, Item, ItemContainer, Repr,
+    ToCondition, Type,
 };
 use bindgen::library::Library;
 use bindgen::mangle;
@@ -220,7 +221,8 @@ impl Item for Union {
 
 impl Source for Union {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
-        self.cfg.write_before(config, out);
+        let condition = (&self.cfg).to_condition(config);
+        condition.write_before(config, out);
 
         self.documentation.write(config, out);
 
@@ -265,6 +267,6 @@ impl Source for Union {
             out.close_brace(true);
         }
 
-        self.cfg.write_after(config, out);
+        condition.write_after(config, out);
     }
 }

--- a/tests/expectations/both/mod_attr.c
+++ b/tests/expectations/both/mod_attr.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#if defined(BAR)
+#define BAR 2
+#endif
+
+#if defined(FOO)
+#define FOO 1
+#endif
+
+#if defined(BAR)
+typedef struct Bar {
+
+} Bar;
+#endif
+
+#if defined(FOO)
+typedef struct Foo {
+
+} Foo;
+#endif
+
+#if defined(BAR)
+void bar(const Bar *bar);
+#endif
+
+#if defined(FOO)
+void foo(const Foo *foo);
+#endif

--- a/tests/expectations/mod_attr.c
+++ b/tests/expectations/mod_attr.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#if defined(BAR)
+#define BAR 2
+#endif
+
+#if defined(FOO)
+#define FOO 1
+#endif
+
+#if defined(BAR)
+typedef struct {
+
+} Bar;
+#endif
+
+#if defined(FOO)
+typedef struct {
+
+} Foo;
+#endif
+
+#if defined(BAR)
+void bar(const Bar *bar);
+#endif
+
+#if defined(FOO)
+void foo(const Foo *foo);
+#endif

--- a/tests/expectations/mod_attr.cpp
+++ b/tests/expectations/mod_attr.cpp
@@ -1,0 +1,34 @@
+#include <cstdint>
+#include <cstdlib>
+
+#if defined(BAR)
+static const int32_t BAR = 2;
+#endif
+
+#if defined(FOO)
+static const int32_t FOO = 1;
+#endif
+
+#if defined(BAR)
+struct Bar {
+
+};
+#endif
+
+#if defined(FOO)
+struct Foo {
+
+};
+#endif
+
+extern "C" {
+
+#if defined(BAR)
+void bar(const Bar *bar);
+#endif
+
+#if defined(FOO)
+void foo(const Foo *foo);
+#endif
+
+} // extern "C"

--- a/tests/expectations/tag/mod_attr.c
+++ b/tests/expectations/tag/mod_attr.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#if defined(BAR)
+#define BAR 2
+#endif
+
+#if defined(FOO)
+#define FOO 1
+#endif
+
+#if defined(BAR)
+struct Bar {
+
+};
+#endif
+
+#if defined(FOO)
+struct Foo {
+
+};
+#endif
+
+#if defined(BAR)
+void bar(const struct Bar *bar);
+#endif
+
+#if defined(FOO)
+void foo(const struct Foo *foo);
+#endif

--- a/tests/rust/mod_attr/Cargo.lock
+++ b/tests/rust/mod_attr/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "mod_attr"
+version = "0.1.0"
+

--- a/tests/rust/mod_attr/Cargo.toml
+++ b/tests/rust/mod_attr/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mod_attr"
+version = "0.1.0"
+authors = ["cbindgen"]
+
+[lib]
+name = "mod_attr"
+crate-type = ["lib", "dylib"]
+
+[features]
+foobar = []

--- a/tests/rust/mod_attr/cbindgen.toml
+++ b/tests/rust/mod_attr/cbindgen.toml
@@ -1,0 +1,4 @@
+[defines]
+"foo" = "FOO"
+"bar" = "BAR"
+# "feature = foobar" = "FOOBAR"

--- a/tests/rust/mod_attr/src/lib.rs
+++ b/tests/rust/mod_attr/src/lib.rs
@@ -1,0 +1,24 @@
+#[cfg(foo)]
+pub const FOO: i32 = 1;
+
+#[cfg(foo)]
+#[no_mangle]
+pub unsafe extern "C" fn foo(foo: &Foo) {}
+
+#[cfg(foo)]
+#[repr(C)]
+pub struct Foo {}
+
+#[cfg(feature = "foobar")]
+pub mod foo {
+    #[cfg(bar)]
+    pub const BAR: i32 = 2;
+
+    #[cfg(bar)]
+    #[no_mangle]
+    pub unsafe extern "C" fn bar(bar: &Bar) {}
+
+    #[cfg(bar)]
+    #[repr(C)]
+    pub struct Bar {}
+}


### PR DESCRIPTION
Fixes https://github.com/eqrion/cbindgen/issues/175.

<details open>

```toml
# cbindgen.toml
[defines]
"foo" = "FOO"
"bar" = "BAR"
```

</details>

<details open>

```rust
// lib.rs

#[cfg(foo)]
pub const FOO: i32 = 1;

#[cfg(foo)]
#[no_mangle]
pub unsafe extern "C" fn foo(dw: &Foo) {}

#[cfg(foo)]
#[repr(C)]
pub struct Foo {}

#[cfg(feature = "foobar")]
pub mod foo {
    #[cfg(bar)]
    pub const BAR: i32 = 2;

    #[cfg(bar)]
    #[no_mangle]
    pub unsafe extern "C" fn bar(dnw: &Bar) {}

    #[cfg(bar)]
    #[repr(C)]
    pub struct Bar {}
}
```

</details>

Before this PR:

<details open>

```c
// lib.h

#include <stdint.h>
#include <stdlib.h>
#include <stdbool.h>

#define BAR 2

#if defined(FOO)
#define FOO 1
#endif

typedef struct {

} Bar;

#if defined(FOO)
typedef struct {

} Foo;
#endif

void bar(const Bar *dnw);

#if defined(FOO)
void foo(const Foo *dw);
#endif
```

</details>

After this PR:

<details open>

```c
// lib.h

#include <stdint.h>
#include <stdlib.h>
#include <stdbool.h>

#if defined(BAR)
#define BAR 2
#endif

#if defined(FOO)
#define FOO 1
#endif

#if defined(BAR)
typedef struct {

} Bar;
#endif

#if defined(FOO)
typedef struct {

} Foo;
#endif

#if defined(BAR)
void bar(const Bar *dnw);
#endif

#if defined(FOO)
void foo(const Foo *dw);
#endif
```

</details>

Notice how `#if defined(BAR) … #endif` now shows up as expected.

Another change this PR introduces is a warning for missing entries in `[defines]`:

In the case of this snippet:
```
WARN: Missing `[defines]` entry for `feature = "foobar"` in cbindgen config.
WARN: Missing `[defines]` entry for `feature = "foobar"` in cbindgen config.
WARN: Missing `[defines]` entry for `feature = "foobar"` in cbindgen config.
WARN: Missing `[defines]` entry for `feature = "foobar"` in cbindgen config.
```

( @emilio / @Gankro: This is the bug I mentioned to you at last week's Rust Berlin. 🙂)