### PR TITLE
Fix "Ignore [cfg(test)] …"

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -204,6 +204,9 @@ impl Parser {
         );
 
         for item in items {
+            if item.has_test_attr() {
+                continue;
+            }
             match item {
                 &syn::Item::Mod(ref item) => {
                     let cfg = Cfg::load(&item.attrs);
@@ -310,6 +313,9 @@ impl Parser {
         );
 
         for item in items {
+            if item.has_test_attr() {
+                continue;
+            }
             match item {
                 &syn::Item::Mod(ref item) => {
                     let next_mod_name = item.ident.to_string();
@@ -485,6 +491,9 @@ impl Parse {
         items: &[syn::Item],
     ) {
         for item in items {
+            if item.has_test_attr() {
+                continue;
+            }
             match item {
                 &syn::Item::ForeignMod(ref item) => {
                     self.load_syn_foreign_mod(binding_crate_name, crate_name, mod_cfg, item);


### PR DESCRIPTION
Fixes https://github.com/eqrion/cbindgen/issues/138.

Note: This does not recognize more advanced patterns like `#[cfg_attr(…, cfg(test))]` or `#[cfg_attr(…, test)]`, but those probably sum up to at most ~1%-ish of usages anyway (and the logic could be extended to also recognize those).
