### PR TITLE
Point to a solution when we hit a parse error.

### DIFF
--- a/src/bindgen/error.rs
+++ b/src/bindgen/error.rs
@@ -45,11 +45,22 @@ impl fmt::Display for Error {
                 ref crate_name,
                 ref src_path,
                 ref error,
-            } => write!(
-                f,
-                "Parsing crate `{}`:`{}`:\n{:?}",
-                crate_name, src_path, error
-            ),
+            } => {
+                write!(
+                    f,
+                    "Parsing crate `{}`:`{}`:\n{:?}",
+                    crate_name, src_path, error
+                )?;
+
+                if !src_path.is_empty() {
+                    write!(
+                        f,
+                        "\nTry running `rustc -Z parse-only {}` to see a nicer error message",
+                        src_path,
+                    )?
+                }
+                Ok(())
+            }
             &Error::ParseCannotOpenFile {
                 ref crate_name,
                 ref src_path,


### PR DESCRIPTION
When I hit this, I initially started bisecting my changes to see where the error
was.

It'd be much nicer if somebody had told me that `rustc -Z parse-only` existed.