### PR TITLE
Add no_includes option

### DIFF
--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -65,9 +65,7 @@ impl Bindings {
         }
     }
 
-    pub fn write<F: Write>(&self, file: F) {
-        let mut out = SourceWriter::new(file, &self.config);
-
+    pub fn write_headers<F: Write>(&self, out: &mut SourceWriter<F>) {
         if let Some(ref f) = self.config.header {
             out.new_line_if_not_start();
             write!(out, "{}", f);
@@ -118,6 +116,14 @@ impl Bindings {
         for include in &self.config.includes {
             write!(out, "#include \"{}\"", include);
             out.new_line();
+        }
+    }
+
+    pub fn write<F: Write>(&self, file: F) {
+        let mut out = SourceWriter::new(file, &self.config);
+
+        if !self.config.no_includes {
+            self.write_headers(&mut out);
         }
 
         if self.config.language == Language::Cxx {

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -41,6 +41,12 @@ impl Builder {
     }
 
     #[allow(unused)]
+    pub fn with_no_includes(mut self) -> Builder {
+        self.config.no_includes = true;
+        self
+    }
+
+    #[allow(unused)]
     pub fn with_include<S: AsRef<str>>(mut self, include: S) -> Builder {
         self.config.includes.push(String::from(include.as_ref()));
         self

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -534,6 +534,11 @@ pub struct Config {
     pub trailer: Option<String>,
     /// Optional name to use for an include guard
     pub include_guard: Option<String>,
+    /// Generates no includes at all. Overrides all other include options
+    ///
+    /// This option is useful when using cbindgen with tools such as python's cffi which
+    /// doesn't understand include directives
+    pub no_includes: bool,
     /// Optional text to output at major sections to deter manual editing
     pub autogen_warning: Option<String>,
     /// Include a comment with the version of cbindgen used to generate the file
@@ -584,6 +589,7 @@ impl Default for Config {
             include_guard: None,
             autogen_warning: None,
             include_version: false,
+            no_includes: false,
             namespace: None,
             namespaces: None,
             braces: Braces::SameLine,

--- a/tests/expectations/both/no_includes.c
+++ b/tests/expectations/both/no_includes.c
@@ -1,0 +1,1 @@
+void root(void);

--- a/tests/expectations/no_includes.c
+++ b/tests/expectations/no_includes.c
@@ -1,0 +1,1 @@
+void root(void);

--- a/tests/expectations/no_includes.cpp
+++ b/tests/expectations/no_includes.cpp
@@ -1,0 +1,5 @@
+extern "C" {
+
+void root();
+
+} // extern "C"

--- a/tests/expectations/tag/no_includes.c
+++ b/tests/expectations/tag/no_includes.c
@@ -1,0 +1,1 @@
+void root(void);

--- a/tests/rust/no_includes.rs
+++ b/tests/rust/no_includes.rs
@@ -1,0 +1,3 @@
+#[no_mangle]
+pub extern "C" fn root() {
+}

--- a/tests/rust/no_includes.toml
+++ b/tests/rust/no_includes.toml
@@ -1,0 +1,1 @@
+no_includes = true


### PR DESCRIPTION
Python's cffi can't handle include directives, which is why milksnake and pyo3-pack currently need to strip the includes from the header before they can use it. This pull request introduces a `no_includes` flag which simply disables the part that would normally write the includes.

I'm not sure if the flags should only disable the default includes (`stdint.h`/`stdlib.h`/`stdbool.h`) or all includes; For now i've chosen all.

For reference, [milksnake's include filtering](https://github.com/getsentry/milksnake/blob/ef0723e41df23d8f6357570c69c1e69cb31f9e9e/milksnake/ffi.py#L8-L16).