### PR TITLE
Fix tagged enum's interactions with prefixing.

### DIFF
--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -146,14 +146,22 @@ impl Item for Struct {
     }
 
     fn rename_for_config(&mut self, config: &Config) {
-        config.export.rename(&mut self.name);
-        for &mut (_, ref mut ty, _) in &mut self.fields {
-            let generic_parameter = match ty.get_root_path() {
-                Some(ref p) => self.generic_params.contains(p),
-                None => false,
-            };
-            if !generic_parameter {
-                ty.rename_for_config(config);
+        if !self.is_tagged {
+            config.export.rename(&mut self.name);
+        }
+        {
+            let fields = self
+                .fields
+                .iter_mut()
+                .skip(if self.is_tagged { 1 } else { 0 });
+            for &mut (_, ref mut ty, _) in fields {
+                let generic_parameter = match ty.get_root_path() {
+                    Some(ref p) => self.generic_params.contains(p),
+                    None => false,
+                };
+                if !generic_parameter {
+                    ty.rename_for_config(config);
+                }
             }
         }
 

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -146,7 +146,7 @@ impl Item for Struct {
     }
 
     fn rename_for_config(&mut self, config: &Config) {
-        if !self.is_tagged {
+        if !self.is_tagged || config.language == Language::C {
             config.export.rename(&mut self.name);
         }
         {

--- a/tests/expectations/both/prefix.c
+++ b/tests/expectations/both/prefix.c
@@ -15,14 +15,14 @@ enum PREFIX_AbsoluteFontWeight_Tag {
 };
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 
-typedef struct Weight_Body {
+typedef struct PREFIX_Weight_Body {
   PREFIX_AbsoluteFontWeight_Tag tag;
   float _0;
-} Weight_Body;
+} PREFIX_Weight_Body;
 
 typedef union PREFIX_AbsoluteFontWeight {
   PREFIX_AbsoluteFontWeight_Tag tag;
-  Weight_Body weight;
+  PREFIX_Weight_Body weight;
 } PREFIX_AbsoluteFontWeight;
 
 void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/both/prefix.c
+++ b/tests/expectations/both/prefix.c
@@ -8,4 +8,21 @@ typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
 typedef int32_t PREFIX_ValuedLenArray[42];
 
-void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y);
+enum PREFIX_AbsoluteFontWeight_Tag {
+  Weight,
+  Normal,
+  Bold,
+};
+typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+
+typedef struct Weight_Body {
+  PREFIX_AbsoluteFontWeight_Tag tag;
+  float _0;
+} Weight_Body;
+
+typedef union PREFIX_AbsoluteFontWeight {
+  PREFIX_AbsoluteFontWeight_Tag tag;
+  Weight_Body weight;
+} PREFIX_AbsoluteFontWeight;
+
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/prefix.c
+++ b/tests/expectations/prefix.c
@@ -8,4 +8,21 @@ typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
 typedef int32_t PREFIX_ValuedLenArray[42];
 
-void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y);
+enum PREFIX_AbsoluteFontWeight_Tag {
+  Weight,
+  Normal,
+  Bold,
+};
+typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+
+typedef struct {
+  PREFIX_AbsoluteFontWeight_Tag tag;
+  float _0;
+} Weight_Body;
+
+typedef union {
+  PREFIX_AbsoluteFontWeight_Tag tag;
+  Weight_Body weight;
+} PREFIX_AbsoluteFontWeight;
+
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/prefix.c
+++ b/tests/expectations/prefix.c
@@ -18,11 +18,11 @@ typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 typedef struct {
   PREFIX_AbsoluteFontWeight_Tag tag;
   float _0;
-} Weight_Body;
+} PREFIX_Weight_Body;
 
 typedef union {
   PREFIX_AbsoluteFontWeight_Tag tag;
-  Weight_Body weight;
+  PREFIX_Weight_Body weight;
 } PREFIX_AbsoluteFontWeight;
 
 void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/prefix.cpp
+++ b/tests/expectations/prefix.cpp
@@ -7,8 +7,26 @@ using PREFIX_NamedLenArray = int32_t[PREFIX_LEN];
 
 using PREFIX_ValuedLenArray = int32_t[42];
 
+union PREFIX_AbsoluteFontWeight {
+  enum class Tag : uint8_t {
+    Weight,
+    Normal,
+    Bold,
+  };
+
+  struct Weight_Body {
+    Tag tag;
+    float _0;
+  };
+
+  struct {
+    Tag tag;
+  };
+  Weight_Body weight;
+};
+
 extern "C" {
 
-void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y);
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);
 
 } // extern "C"

--- a/tests/expectations/tag/prefix.c
+++ b/tests/expectations/tag/prefix.c
@@ -15,14 +15,14 @@ enum PREFIX_AbsoluteFontWeight_Tag {
 };
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 
-struct Weight_Body {
+struct PREFIX_Weight_Body {
   PREFIX_AbsoluteFontWeight_Tag tag;
   float _0;
 };
 
 union PREFIX_AbsoluteFontWeight {
   enum PREFIX_AbsoluteFontWeight_Tag tag;
-  struct Weight_Body weight;
+  struct PREFIX_Weight_Body weight;
 };
 
 void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, union PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/tag/prefix.c
+++ b/tests/expectations/tag/prefix.c
@@ -8,4 +8,21 @@ typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
 typedef int32_t PREFIX_ValuedLenArray[42];
 
-void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y);
+enum PREFIX_AbsoluteFontWeight_Tag {
+  Weight,
+  Normal,
+  Bold,
+};
+typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+
+struct Weight_Body {
+  PREFIX_AbsoluteFontWeight_Tag tag;
+  float _0;
+};
+
+union PREFIX_AbsoluteFontWeight {
+  enum PREFIX_AbsoluteFontWeight_Tag tag;
+  struct Weight_Body weight;
+};
+
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, union PREFIX_AbsoluteFontWeight z);

--- a/tests/rust/prefix.rs
+++ b/tests/rust/prefix.rs
@@ -3,5 +3,12 @@ const LEN: i32 = 42;
 pub type NamedLenArray = [i32; LEN];
 pub type ValuedLenArray = [i32; 42];
 
+#[repr(u8)]
+pub enum AbsoluteFontWeight {
+    Weight(f32),
+    Normal,
+    Bold,
+}
+
 #[no_mangle]
-pub extern "C" fn root(x: NamedLenArray, y: ValuedLenArray) { }
+pub extern "C" fn root(x: NamedLenArray, y: ValuedLenArray, z: AbsoluteFontWeight) { }


### PR DESCRIPTION
We were incorrectly prefixing the tag (again in C mode, once in C++ mode).