### PR TITLE
Skip lifetime type args

### DIFF
--- a/src/bindgen/ir/path.rs
+++ b/src/bindgen/ir/path.rs
@@ -50,7 +50,8 @@ impl GenericPath {
                 ..
             }) => args.iter().try_skip_map(|x| match *x {
                 &syn::GenericArgument::Type(ref x) => Type::load(x),
-                _ => Err(String::new()),
+                &syn::GenericArgument::Lifetime(_) => Ok(None),
+                _ => Err(format!("can't handle generic argument {:?}", x)),
             })?,
             &syn::PathArguments::Parenthesized(_) => {
                 return Err("Path contains parentheses.".to_owned());

--- a/tests/expectations/both/lifetime_arg.c
+++ b/tests/expectations/both/lifetime_arg.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct A {
+  const int32_t *data;
+} A;
+
+void root(A _a);

--- a/tests/expectations/lifetime_arg.c
+++ b/tests/expectations/lifetime_arg.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct {
+  const int32_t *data;
+} A;
+
+void root(A _a);

--- a/tests/expectations/lifetime_arg.cpp
+++ b/tests/expectations/lifetime_arg.cpp
@@ -1,0 +1,12 @@
+#include <cstdint>
+#include <cstdlib>
+
+struct A {
+  const int32_t *data;
+};
+
+extern "C" {
+
+void root(A _a);
+
+} // extern "C"

--- a/tests/expectations/tag/lifetime_arg.c
+++ b/tests/expectations/tag/lifetime_arg.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct A {
+  const int32_t *data;
+};
+
+void root(struct A _a);

--- a/tests/rust/lifetime_arg.rs
+++ b/tests/rust/lifetime_arg.rs
@@ -1,0 +1,8 @@
+#[repr(C)]
+struct A<'a> {
+    data: &'a i32
+}
+
+#[no_mangle]
+pub extern "C" fn root<'a>(_a: A<'a>)
+{ }


### PR DESCRIPTION
The new test fails on master with `ERROR: Cannot use fn lifetime_arg::root ().`.

This matches the behavior of `cbindgen v3.3`. I'm not sure which version introduced the change.