### PR TITLE
Add support for generic enums.

### DIFF
--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -97,9 +97,10 @@ impl Function {
     }
 
     pub fn rename_for_config(&mut self, config: &Config) {
-        self.ret.rename_for_config(config);
+        let generic_params = Default::default();
+        self.ret.rename_for_config(config, &generic_params);
         for &mut (_, ref mut ty) in &mut self.args {
-            ty.rename_for_config(config);
+            ty.rename_for_config(config, &generic_params);
         }
 
         let rules = [

--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -68,7 +68,7 @@ impl Item for Static {
     }
 
     fn rename_for_config(&mut self, config: &Config) {
-        self.ty.rename_for_config(config);
+        self.ty.rename_for_config(config, &Default::default());
     }
 
     fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -483,31 +483,33 @@ impl Type {
         }
     }
 
-    pub fn rename_for_config(&mut self, config: &Config) {
+    pub fn rename_for_config(&mut self, config: &Config, generic_params: &GenericParams) {
         match self {
             &mut Type::ConstPtr(ref mut ty) => {
-                ty.rename_for_config(config);
+                ty.rename_for_config(config, generic_params);
             }
             &mut Type::Ptr(ref mut ty) => {
-                ty.rename_for_config(config);
+                ty.rename_for_config(config, generic_params);
             }
             &mut Type::Path(ref mut path) => {
                 for generic in &mut path.generics {
-                    generic.rename_for_config(config);
+                    generic.rename_for_config(config, generic_params);
                 }
-                config.export.rename(&mut path.name);
+                if !generic_params.contains(&path.name) {
+                    config.export.rename(&mut path.name);
+                }
             }
             &mut Type::Primitive(_) => {}
             &mut Type::Array(ref mut ty, ref mut len) => {
-                ty.rename_for_config(config);
+                ty.rename_for_config(config, generic_params);
                 if let ArrayLength::Name(ref mut name) = len {
                     config.export.rename(name);
                 }
             }
             &mut Type::FuncPtr(ref mut ret, ref mut args) => {
-                ret.rename_for_config(config);
+                ret.rename_for_config(config, generic_params);
                 for arg in args {
-                    arg.rename_for_config(config);
+                    arg.rename_for_config(config, generic_params);
                 }
             }
         }

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -114,7 +114,7 @@ impl Item for Typedef {
 
     fn rename_for_config(&mut self, config: &Config) {
         config.export.rename(&mut self.name);
-        self.aliased.rename_for_config(config);
+        self.aliased.rename_for_config(config, &self.generic_params);
     }
 
     fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -121,13 +121,7 @@ impl Item for Union {
     fn rename_for_config(&mut self, config: &Config) {
         config.export.rename(&mut self.name);
         for &mut (_, ref mut ty, _) in &mut self.fields {
-            let generic_parameter = match ty.get_root_path() {
-                Some(ref p) => self.generic_params.contains(p),
-                None => false,
-            };
-            if !generic_parameter {
-                ty.rename_for_config(config);
-            }
+            ty.rename_for_config(config, &self.generic_params);
         }
 
         let rules = [

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -354,6 +354,9 @@ impl Library {
         self.unions.for_all_items(|x| {
             x.add_monomorphs(self, &mut monomorphs);
         });
+        self.enums.for_all_items(|x| {
+            x.add_monomorphs(self, &mut monomorphs);
+        });
         self.typedefs.for_all_items(|x| {
             x.add_monomorphs(self, &mut monomorphs);
         });
@@ -374,17 +377,23 @@ impl Library {
         for monomorph in monomorphs.drain_typedefs() {
             self.typedefs.try_insert(monomorph);
         }
+        for monomorph in monomorphs.drain_enums() {
+            self.enums.try_insert(monomorph);
+        }
 
         // Remove structs and opaque items that are generic
         self.opaque_items.filter(|x| x.generic_params.len() > 0);
         self.structs.filter(|x| x.generic_params.len() > 0);
         self.unions.filter(|x| x.generic_params.len() > 0);
+        self.enums.filter(|x| x.generic_params.len() > 0);
         self.typedefs.filter(|x| x.generic_params.len() > 0);
 
         // Mangle the paths that remain
         self.unions
             .for_all_items_mut(|x| x.mangle_paths(&monomorphs));
         self.structs
+            .for_all_items_mut(|x| x.mangle_paths(&monomorphs));
+        self.enums
             .for_all_items_mut(|x| x.mangle_paths(&monomorphs));
         self.typedefs
             .for_all_items_mut(|x| x.mangle_paths(&monomorphs));

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -9,11 +9,6 @@ pub fn mangle_path(name: &str, generic_values: &[Type]) -> String {
 }
 
 fn internal_mangle_path(name: &str, generic_values: &[Type], last_in_parent: bool) -> String {
-    assert!(
-        !name.contains("_"),
-        format!("name '{}' contains an underscore", name)
-    );
-
     if generic_values.is_empty() {
         return String::from(name);
     }
@@ -103,14 +98,4 @@ fn generics() {
         ),
         "Foo_Bar_T_____Bar_E"
     );
-}
-
-#[test]
-#[should_panic(expected = "name 'foo_bar' contains an underscore")]
-fn invalid() {
-    use bindgen::ir::PrimitiveType;
-
-    // foo_bar<u32> => foo_bar_f32
-    let t = Type::Primitive(PrimitiveType::UInt32);
-    assert_eq!(mangle_path("foo_bar", &vec![t]), "foo_bar_u32");
 }

--- a/src/bindgen/monomorph.rs
+++ b/src/bindgen/monomorph.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 use std::mem;
 
-use bindgen::ir::{GenericPath, OpaqueItem, Path, Struct, Type, Typedef, Union};
+use bindgen::ir::{Enum, GenericPath, OpaqueItem, Path, Struct, Type, Typedef, Union};
 
 #[derive(Default, Clone, Debug)]
 pub struct Monomorphs {
@@ -14,6 +14,7 @@ pub struct Monomorphs {
     structs: Vec<Struct>,
     unions: Vec<Union>,
     typedefs: Vec<Typedef>,
+    enums: Vec<Enum>,
 }
 
 impl Monomorphs {
@@ -30,6 +31,17 @@ impl Monomorphs {
         self.replacements
             .insert(replacement_path, monomorph.name.clone());
         self.structs.push(monomorph);
+    }
+
+    pub fn insert_enum(&mut self, generic: &Enum, monomorph: Enum, parameters: Vec<Type>) {
+        let replacement_path = GenericPath::new(generic.name.clone(), parameters);
+
+        debug_assert!(generic.generic_params.len() > 0);
+        debug_assert!(!self.contains(&replacement_path));
+
+        self.replacements
+            .insert(replacement_path, monomorph.name.clone());
+        self.enums.push(monomorph);
     }
 
     pub fn insert_union(&mut self, generic: &Union, monomorph: Union, parameters: Vec<Type>) {
@@ -88,5 +100,9 @@ impl Monomorphs {
 
     pub fn drain_typedefs(&mut self) -> Vec<Typedef> {
         mem::replace(&mut self.typedefs, Vec::new())
+    }
+
+    pub fn drain_enums(&mut self) -> Vec<Enum> {
+        mem::replace(&mut self.enums, Vec::new())
     }
 }

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -789,7 +789,7 @@ impl Parse {
 
     /// Loads a `enum` declaration
     fn load_syn_enum(&mut self, crate_name: &str, mod_cfg: &Option<Cfg>, item: &syn::ItemEnum) {
-        if item.generics.lifetimes().count() > 0 || item.generics.type_params().count() > 0 {
+        if item.generics.lifetimes().count() > 0 {
             info!(
                 "Skip {}::{} - (has generics or lifetimes or where bounds).",
                 crate_name, &item.ident

--- a/tests/expectations/both/transform-op.c
+++ b/tests/expectations/both/transform-op.c
@@ -1,0 +1,47 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct StylePoint_i32 {
+  int32_t x;
+  int32_t y;
+} StylePoint_i32;
+
+typedef struct StylePoint_f32 {
+  float x;
+  float y;
+} StylePoint_f32;
+
+enum StyleFoo_Tag {
+  Foo_i32,
+  Bar_i32,
+  Baz_i32,
+  Bazz_i32,
+};
+typedef uint8_t StyleFoo_Tag;
+
+typedef struct StyleFoo_Body_i32 {
+  StyleFoo_Tag tag;
+  int32_t x;
+  StylePoint_i32 y;
+  StylePoint_f32 z;
+} StyleFoo_Body_i32;
+
+typedef struct StyleBar_Body_i32 {
+  StyleFoo_Tag tag;
+  int32_t _0;
+} StyleBar_Body_i32;
+
+typedef struct StyleBaz_Body_i32 {
+  StyleFoo_Tag tag;
+  StylePoint_i32 _0;
+} StyleBaz_Body_i32;
+
+typedef union StyleFoo_i32 {
+  StyleFoo_Tag tag;
+  StyleFoo_Body_i32 foo;
+  StyleBar_Body_i32 bar;
+  StyleBaz_Body_i32 baz;
+} StyleFoo_i32;
+
+void foo(const StyleFoo_i32 *foo);

--- a/tests/expectations/tag/transform-op.c
+++ b/tests/expectations/tag/transform-op.c
@@ -1,0 +1,47 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct StylePoint_i32 {
+  int32_t x;
+  int32_t y;
+};
+
+struct StylePoint_f32 {
+  float x;
+  float y;
+};
+
+enum StyleFoo_Tag {
+  Foo_i32,
+  Bar_i32,
+  Baz_i32,
+  Bazz_i32,
+};
+typedef uint8_t StyleFoo_Tag;
+
+struct StyleFoo_Body_i32 {
+  StyleFoo_Tag tag;
+  int32_t x;
+  struct StylePoint_i32 y;
+  struct StylePoint_f32 z;
+};
+
+struct StyleBar_Body_i32 {
+  StyleFoo_Tag tag;
+  int32_t _0;
+};
+
+struct StyleBaz_Body_i32 {
+  StyleFoo_Tag tag;
+  struct StylePoint_i32 _0;
+};
+
+union StyleFoo_i32 {
+  enum StyleFoo_Tag tag;
+  struct StyleFoo_Body_i32 foo;
+  struct StyleBar_Body_i32 bar;
+  struct StyleBaz_Body_i32 baz;
+};
+
+void foo(const union StyleFoo_i32 *foo);

--- a/tests/expectations/transform-op.c
+++ b/tests/expectations/transform-op.c
@@ -1,0 +1,47 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct {
+  int32_t x;
+  int32_t y;
+} StylePoint_i32;
+
+typedef struct {
+  float x;
+  float y;
+} StylePoint_f32;
+
+enum StyleFoo_Tag {
+  Foo_i32,
+  Bar_i32,
+  Baz_i32,
+  Bazz_i32,
+};
+typedef uint8_t StyleFoo_Tag;
+
+typedef struct {
+  StyleFoo_Tag tag;
+  int32_t x;
+  StylePoint_i32 y;
+  StylePoint_f32 z;
+} StyleFoo_Body_i32;
+
+typedef struct {
+  StyleFoo_Tag tag;
+  int32_t _0;
+} StyleBar_Body_i32;
+
+typedef struct {
+  StyleFoo_Tag tag;
+  StylePoint_i32 _0;
+} StyleBaz_Body_i32;
+
+typedef union {
+  StyleFoo_Tag tag;
+  StyleFoo_Body_i32 foo;
+  StyleBar_Body_i32 bar;
+  StyleBaz_Body_i32 baz;
+} StyleFoo_i32;
+
+void foo(const StyleFoo_i32 *foo);

--- a/tests/expectations/transform-op.cpp
+++ b/tests/expectations/transform-op.cpp
@@ -1,0 +1,48 @@
+#include <cstdint>
+#include <cstdlib>
+
+template<typename T>
+struct StylePoint {
+  T x;
+  T y;
+};
+
+template<typename T>
+union StyleFoo {
+  enum class Tag : uint8_t {
+    Foo,
+    Bar,
+    Baz,
+    Bazz,
+  };
+
+  struct Foo_Body {
+    Tag tag;
+    int32_t x;
+    StylePoint<T> y;
+    StylePoint<float> z;
+  };
+
+  struct Bar_Body {
+    Tag tag;
+    T _0;
+  };
+
+  struct Baz_Body {
+    Tag tag;
+    StylePoint<T> _0;
+  };
+
+  struct {
+    Tag tag;
+  };
+  Foo_Body foo;
+  Bar_Body bar;
+  Baz_Body baz;
+};
+
+extern "C" {
+
+void foo(const StyleFoo<int32_t> *foo);
+
+} // extern "C"

--- a/tests/rust/transform-op.rs
+++ b/tests/rust/transform-op.rs
@@ -1,0 +1,16 @@
+#[repr(C)]
+pub struct Point<T> {
+    pub x: T,
+    pub y: T,
+}
+
+#[repr(u8)]
+pub enum Foo<T> {
+    Foo { x: i32, y: Point<T>, z: Point<f32>, },
+    Bar(T),
+    Baz(Point<T>),
+    Bazz,
+}
+
+#[no_mangle]
+pub extern "C" fn foo(foo: *const Foo<i32>) {}

--- a/tests/rust/transform-op.toml
+++ b/tests/rust/transform-op.toml
@@ -1,0 +1,2 @@
+[export]
+prefix = "Style"


### PR DESCRIPTION
Going to need this if I ever aim to generate TransformOperation bindings and
remove a bunch of slow and ugly Gecko code:

  https://searchfox.org/mozilla-central/rev/80ac71c1c54af788b32e851192dfd2de2ec18e18/servo/components/style/values/generics/transform.rs#189

With the caveat that I'll need to remove the options, but I can manage to do
that.

This also fixes a bunch of renaming bugs that I found while at it.

This patch has the gotcha that we need to remove the assertion of no-underscores
in mangled names... But I think it should be fine, and I'd rather not do a more
breaking change.

You can generate conflicting names in C using enum variants with the same name
as a struct regardless, for example, so I don't think this is terribly
important.