### PR TITLE
Ship the tests too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ description = "A tool for generating C bindings to Rust code."
 keywords = ["bindings", "ffi", "code-generation"]
 categories = ["external-ffi-bindings", "development-tools::ffi"]
 repository = "https://github.com/eqrion/cbindgen/"
-exclude = ["test.py", "tests/**"]
 
 [badges]
 travis-ci = { repository = "eqrion/cbindgen" }


### PR DESCRIPTION
Packagers would like to have access to the test suite to make sure they don't regress