### PR TITLE
Fix prefixing + formatting for enums 

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -396,7 +396,10 @@ impl Item for Enum {
                 .iter()
                 .map(|variant| {
                     EnumVariant::new(
-                        r.apply_to_pascal_case(&variant.name, IdentifierType::EnumVariant(self)),
+                        r.apply_to_pascal_case(
+                            &variant.export_name,
+                            IdentifierType::EnumVariant(self),
+                        ),
                         variant.discriminant.clone(),
                         variant.body.as_ref().map(|body| {
                             (

--- a/src/bindgen/rename.rs
+++ b/src/bindgen/rename.rs
@@ -79,9 +79,22 @@ impl RenameRule {
             RenameRule::ScreamingSnakeCase => {
                 // Same as SnakeCase code above, but uses to_uppercase
                 let mut result = String::new();
+                let mut add_separator = true;
+                let mut prev_uppercase = false;
                 for (i, c) in text.char_indices() {
-                    if c.is_uppercase() && i != 0 {
-                        result.push_str("_");
+                    if c == '_' {
+                        add_separator = false;
+                        prev_uppercase = false;
+                    }
+                    if c.is_uppercase() {
+                        if i != 0 && add_separator && !prev_uppercase {
+                            result.push_str("_");
+                        } else {
+                            add_separator = true;
+                        }
+                        prev_uppercase = true;
+                    } else {
+                        prev_uppercase = false;
                     }
                     for x in c.to_uppercase() {
                         result.push(x);


### PR DESCRIPTION
A configuration such as
``` toml
[enum]
rename_variants = "ScreamingSnakeCase"
prefix_with_name = true
```

Should map an enum such `Foo::Bar` to `FOO_BAR` or `PREFIX_FOO_BAR` if there is a prefix set.