### PR TITLE
Propagate prefixes to struct literals

### DIFF
--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -54,8 +54,13 @@ impl Literal {
             Literal::Struct {
                 name: _,
                 ref mut export_name,
-                fields: _,
-            } => config.export.rename(export_name),
+                fields,
+            } => {
+                config.export.rename(export_name);
+                for (_, lit) in fields {
+                    lit.rename_for_config(config);
+                }
+            }
             Literal::Expr(_) => {}
         }
     }

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -11,7 +11,8 @@ use syn;
 use bindgen::config::{Config, Language};
 use bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use bindgen::ir::{
-    AnnotationSet, Cfg, ConditionWrite, Documentation, Item, ItemContainer, Path, ToCondition, Type, GenericParams,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericParams, Item, ItemContainer, Path,
+    ToCondition, Type,
 };
 use bindgen::writer::{Source, SourceWriter};
 
@@ -157,10 +158,11 @@ impl Constant {
 
         let ty = ty.unwrap();
 
-        if !ty.is_primitive_or_ptr_primitive() && match *item.expr {
-            syn::Expr::Struct(_) => false,
-            _ => true,
-        } {
+        if !ty.is_primitive_or_ptr_primitive()
+            && match *item.expr {
+                syn::Expr::Struct(_) => false,
+                _ => true,
+            } {
             return Err("Unhanded const definition".to_owned());
         }
 
@@ -186,10 +188,11 @@ impl Constant {
             return Err("Cannot have a zero sized const definition.".to_owned());
         }
         let ty = ty.unwrap();
-        if !ty.is_primitive_or_ptr_primitive() && match item.expr {
-            syn::Expr::Struct(_) => false,
-            _ => true,
-        } {
+        if !ty.is_primitive_or_ptr_primitive()
+            && match item.expr {
+                syn::Expr::Struct(_) => false,
+                _ => true,
+            } {
             return Err("Unhanded const definition".to_owned());
         }
 
@@ -261,7 +264,7 @@ impl Item for Constant {
     fn rename_for_config(&mut self, config: &Config) {
         config.export.rename(&mut self.export_name);
         self.value.rename_for_config(config);
-        self.ty.rename_for_config(config, &GenericParams::default());// FIXME: should probably propagate something here
+        self.ty.rename_for_config(config, &GenericParams::default()); // FIXME: should probably propagate something here
     }
 
     fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {

--- a/tests/expectations/both/prefixed_struct_literal.c
+++ b/tests/expectations/both/prefixed_struct_literal.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct PREFIXFoo {
+  int32_t a;
+  uint32_t b;
+} PREFIXFoo;
+
+#define PREFIXBAR (PREFIXFoo){ .a = 42, .b = 1337 }
+
+#define PREFIXFoo_FOO (PREFIXFoo){ .a = 42, .b = 47 }
+
+void root(PREFIXFoo x);

--- a/tests/expectations/both/prefixed_struct_literal_deep.c
+++ b/tests/expectations/both/prefixed_struct_literal_deep.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct PREFIXBar {
+  int32_t a;
+} PREFIXBar;
+
+typedef struct PREFIXFoo {
+  int32_t a;
+  uint32_t b;
+  PREFIXBar bar;
+} PREFIXFoo;
+
+#define PREFIXVAL (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } }
+
+void root(PREFIXFoo x);

--- a/tests/expectations/prefixed_struct_literal.c
+++ b/tests/expectations/prefixed_struct_literal.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct {
+  int32_t a;
+  uint32_t b;
+} PREFIXFoo;
+
+#define PREFIXBAR (PREFIXFoo){ .a = 42, .b = 1337 }
+
+#define PREFIXFoo_FOO (PREFIXFoo){ .a = 42, .b = 47 }
+
+void root(PREFIXFoo x);

--- a/tests/expectations/prefixed_struct_literal.cpp
+++ b/tests/expectations/prefixed_struct_literal.cpp
@@ -1,0 +1,17 @@
+#include <cstdint>
+#include <cstdlib>
+
+struct PREFIXFoo {
+  int32_t a;
+  uint32_t b;
+};
+
+static const PREFIXFoo PREFIXBAR = (PREFIXFoo){ .a = 42, .b = 1337 };
+
+static const PREFIXFoo PREFIXFoo_FOO = (PREFIXFoo){ .a = 42, .b = 47 };
+
+extern "C" {
+
+void root(PREFIXFoo x);
+
+} // extern "C"

--- a/tests/expectations/prefixed_struct_literal_deep.c
+++ b/tests/expectations/prefixed_struct_literal_deep.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct {
+  int32_t a;
+} PREFIXBar;
+
+typedef struct {
+  int32_t a;
+  uint32_t b;
+  PREFIXBar bar;
+} PREFIXFoo;
+
+#define PREFIXVAL (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } }
+
+void root(PREFIXFoo x);

--- a/tests/expectations/prefixed_struct_literal_deep.cpp
+++ b/tests/expectations/prefixed_struct_literal_deep.cpp
@@ -1,0 +1,20 @@
+#include <cstdint>
+#include <cstdlib>
+
+struct PREFIXBar {
+  int32_t a;
+};
+
+struct PREFIXFoo {
+  int32_t a;
+  uint32_t b;
+  PREFIXBar bar;
+};
+
+static const PREFIXFoo PREFIXVAL = (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } };
+
+extern "C" {
+
+void root(PREFIXFoo x);
+
+} // extern "C"

--- a/tests/expectations/tag/prefixed_struct_literal.c
+++ b/tests/expectations/tag/prefixed_struct_literal.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct PREFIXFoo {
+  int32_t a;
+  uint32_t b;
+};
+
+#define PREFIXBAR (PREFIXFoo){ .a = 42, .b = 1337 }
+
+#define PREFIXFoo_FOO (PREFIXFoo){ .a = 42, .b = 47 }
+
+void root(struct PREFIXFoo x);

--- a/tests/expectations/tag/prefixed_struct_literal_deep.c
+++ b/tests/expectations/tag/prefixed_struct_literal_deep.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct PREFIXBar {
+  int32_t a;
+};
+
+struct PREFIXFoo {
+  int32_t a;
+  uint32_t b;
+  struct PREFIXBar bar;
+};
+
+#define PREFIXVAL (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } }
+
+void root(struct PREFIXFoo x);

--- a/tests/rust/prefixed_struct_literal.rs
+++ b/tests/rust/prefixed_struct_literal.rs
@@ -1,0 +1,14 @@
+#[repr(C)]
+struct Foo {
+    a: i32,
+    b: u32,
+}
+
+impl Foo {
+    const FOO: Foo = Foo{ a: 42, b: 47, };
+}
+
+const BAR: Foo = Foo{ a: 42, b: 1337, };
+
+#[no_mangle]
+pub extern "C" fn root(x: Foo) { }

--- a/tests/rust/prefixed_struct_literal.toml
+++ b/tests/rust/prefixed_struct_literal.toml
@@ -1,0 +1,2 @@
+[export]
+prefix = "PREFIX"

--- a/tests/rust/prefixed_struct_literal_deep.rs
+++ b/tests/rust/prefixed_struct_literal_deep.rs
@@ -1,0 +1,20 @@
+#[repr(C)]
+struct Foo {
+    a: i32,
+    b: u32,
+    bar: Bar,
+}
+
+#[repr(C)]
+struct Bar {
+    a: i32,
+}
+
+const VAL: Foo = Foo {
+    a: 42,
+    b: 1337,
+    bar: Bar { a: 323 },
+};
+
+#[no_mangle]
+pub extern "C" fn root(x: Foo) {}

--- a/tests/rust/prefixed_struct_literal_deep.toml
+++ b/tests/rust/prefixed_struct_literal_deep.toml
@@ -1,0 +1,2 @@
+[export]
+prefix = "PREFIX"


### PR DESCRIPTION
Fix #238

This ensures that constants of a struct type have their type and the
type of their underlying value expressions renamed in the case of a
prefix.