### PR TITLE
Remove member name from transparent associated constants

### DIFF
--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -201,23 +201,20 @@ impl Constant {
             _ => false,
         };
 
-        if !ty.is_primitive_or_ptr_primitive() && !can_handle_const_expr
-        {
+        if !ty.is_primitive_or_ptr_primitive() && !can_handle_const_expr {
             return Err("Unhandled const definition".to_owned());
         }
 
-        let expr = Literal::load(
-            match item.expr {
-                syn::Expr::Struct(syn::ExprStruct { ref fields, .. }) => {
-                    if is_transparent && fields.len() == 1 {
-                        &fields[0].expr
-                    } else {
-                        &item.expr
-                    }
+        let expr = Literal::load(match item.expr {
+            syn::Expr::Struct(syn::ExprStruct { ref fields, .. }) => {
+                if is_transparent && fields.len() == 1 {
+                    &fields[0].expr
+                } else {
+                    &item.expr
                 }
-                _ => &item.expr,
             }
-        )?;
+            _ => &item.expr,
+        })?;
 
         let full_name = Path::new(format!("{}_{}", struct_path, name));
 

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -522,12 +522,10 @@ impl Parse {
                     self.load_syn_ty(crate_name, mod_cfg, item);
                 }
                 syn::Item::Impl(ref item_impl) => {
-                    let has_assoc_const = item_impl.items
-                        .iter()
-                        .any(|item| match item {
-                            syn::ImplItem::Const(_) => true,
-                            _ => false,
-                        });
+                    let has_assoc_const = item_impl.items.iter().any(|item| match item {
+                        syn::ImplItem::Const(_) => true,
+                        _ => false,
+                    });
                     if has_assoc_const {
                         impls_with_assoc_consts.push(item_impl);
                     }
@@ -537,12 +535,10 @@ impl Parse {
         }
 
         for item_impl in impls_with_assoc_consts {
-            let associated_constants = item_impl.items
-                .iter()
-                .filter_map(|item| match item {
-                    syn::ImplItem::Const(ref associated_constant) => Some(associated_constant),
-                    _ => None,
-                });
+            let associated_constants = item_impl.items.iter().filter_map(|item| match item {
+                syn::ImplItem::Const(ref associated_constant) => Some(associated_constant),
+                _ => None,
+            });
             self.load_syn_assoc_consts(
                 binding_crate_name,
                 crate_name,
@@ -648,7 +644,10 @@ impl Parse {
         }
     }
 
-    fn is_assoc_const_of_transparent_struct(&self, const_item: &syn::ImplItemConst) -> Result<bool, ()> {
+    fn is_assoc_const_of_transparent_struct(
+        &self,
+        const_item: &syn::ImplItemConst,
+    ) -> Result<bool, ()> {
         let ty = match Type::load(&const_item.ty) {
             Ok(Some(t)) => t,
             _ => return Ok(false),
@@ -698,10 +697,11 @@ impl Parse {
         let impl_path = ty.unwrap().get_root_path().unwrap();
 
         for item in items.into_iter() {
-            let is_assoc_const_of_transparent_struct = match self.is_assoc_const_of_transparent_struct(&item) {
-                Ok(b) => b,
-                Err(_) => continue,
-            };
+            let is_assoc_const_of_transparent_struct =
+                match self.is_assoc_const_of_transparent_struct(&item) {
+                    Ok(b) => b,
+                    Err(_) => continue,
+                };
 
             if crate_name != binding_crate_name {
                 info!(

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -714,7 +714,7 @@ impl Parse {
             let const_name = item.ident.to_string();
 
             match Constant::load_assoc(
-                const_name.clone(),
+                const_name,
                 item,
                 mod_cfg,
                 is_assoc_const_of_transparent_struct,

--- a/tests/expectations/both/const_conflict.c
+++ b/tests/expectations/both/const_conflict.c
@@ -3,4 +3,4 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define Foo_FOO 0
+#define Foo_FOO 42

--- a/tests/expectations/both/transparent.c
+++ b/tests/expectations/both/transparent.c
@@ -17,9 +17,16 @@ typedef DummyStruct TransparentComplexWrapper_i32;
 
 typedef uint32_t TransparentPrimitiveWrapper_i32;
 
+typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
+
+#define TransparentPrimitiveWithAssociatedConstants_ONE 1
+
+#define TransparentPrimitiveWithAssociatedConstants_ZERO 0
+
 void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrappingStructTuple b,
           TransparentComplexWrappingStructure c,
           TransparentPrimitiveWrappingStructure d,
           TransparentComplexWrapper_i32 e,
-          TransparentPrimitiveWrapper_i32 f);
+          TransparentPrimitiveWrapper_i32 f,
+          TransparentPrimitiveWithAssociatedConstants g);

--- a/tests/expectations/both/transparent.c
+++ b/tests/expectations/both/transparent.c
@@ -5,6 +5,8 @@
 
 typedef struct DummyStruct DummyStruct;
 
+typedef struct EnumWithAssociatedConstantInImpl EnumWithAssociatedConstantInImpl;
+
 typedef DummyStruct TransparentComplexWrappingStructTuple;
 
 typedef uint32_t TransparentPrimitiveWrappingStructTuple;
@@ -19,6 +21,8 @@ typedef uint32_t TransparentPrimitiveWrapper_i32;
 
 typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 
+#define EnumWithAssociatedConstantInImpl_TEN 10
+
 #define TransparentPrimitiveWithAssociatedConstants_ONE 1
 
 #define TransparentPrimitiveWithAssociatedConstants_ZERO 0
@@ -29,4 +33,5 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrappingStructure d,
           TransparentComplexWrapper_i32 e,
           TransparentPrimitiveWrapper_i32 f,
-          TransparentPrimitiveWithAssociatedConstants g);
+          TransparentPrimitiveWithAssociatedConstants g,
+          EnumWithAssociatedConstantInImpl h);

--- a/tests/expectations/const_conflict.c
+++ b/tests/expectations/const_conflict.c
@@ -3,4 +3,4 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define Foo_FOO 0
+#define Foo_FOO 42

--- a/tests/expectations/const_conflict.cpp
+++ b/tests/expectations/const_conflict.cpp
@@ -2,4 +2,4 @@
 #include <cstdint>
 #include <cstdlib>
 
-static const int32_t Foo_FOO = 0;
+static const uint32_t Foo_FOO = 42;

--- a/tests/expectations/tag/const_conflict.c
+++ b/tests/expectations/tag/const_conflict.c
@@ -3,4 +3,4 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define Foo_FOO 0
+#define Foo_FOO 42

--- a/tests/expectations/tag/transparent.c
+++ b/tests/expectations/tag/transparent.c
@@ -5,6 +5,8 @@
 
 struct DummyStruct;
 
+struct EnumWithAssociatedConstantInImpl;
+
 typedef struct DummyStruct TransparentComplexWrappingStructTuple;
 
 typedef uint32_t TransparentPrimitiveWrappingStructTuple;
@@ -19,6 +21,8 @@ typedef uint32_t TransparentPrimitiveWrapper_i32;
 
 typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 
+#define EnumWithAssociatedConstantInImpl_TEN 10
+
 #define TransparentPrimitiveWithAssociatedConstants_ONE 1
 
 #define TransparentPrimitiveWithAssociatedConstants_ZERO 0
@@ -29,4 +33,5 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrappingStructure d,
           TransparentComplexWrapper_i32 e,
           TransparentPrimitiveWrapper_i32 f,
-          TransparentPrimitiveWithAssociatedConstants g);
+          TransparentPrimitiveWithAssociatedConstants g,
+          struct EnumWithAssociatedConstantInImpl h);

--- a/tests/expectations/tag/transparent.c
+++ b/tests/expectations/tag/transparent.c
@@ -17,9 +17,16 @@ typedef struct DummyStruct TransparentComplexWrapper_i32;
 
 typedef uint32_t TransparentPrimitiveWrapper_i32;
 
+typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
+
+#define TransparentPrimitiveWithAssociatedConstants_ONE 1
+
+#define TransparentPrimitiveWithAssociatedConstants_ZERO 0
+
 void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrappingStructTuple b,
           TransparentComplexWrappingStructure c,
           TransparentPrimitiveWrappingStructure d,
           TransparentComplexWrapper_i32 e,
-          TransparentPrimitiveWrapper_i32 f);
+          TransparentPrimitiveWrapper_i32 f,
+          TransparentPrimitiveWithAssociatedConstants g);

--- a/tests/expectations/transparent.c
+++ b/tests/expectations/transparent.c
@@ -17,9 +17,16 @@ typedef DummyStruct TransparentComplexWrapper_i32;
 
 typedef uint32_t TransparentPrimitiveWrapper_i32;
 
+typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
+
+#define TransparentPrimitiveWithAssociatedConstants_ONE 1
+
+#define TransparentPrimitiveWithAssociatedConstants_ZERO 0
+
 void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrappingStructTuple b,
           TransparentComplexWrappingStructure c,
           TransparentPrimitiveWrappingStructure d,
           TransparentComplexWrapper_i32 e,
-          TransparentPrimitiveWrapper_i32 f);
+          TransparentPrimitiveWrapper_i32 f,
+          TransparentPrimitiveWithAssociatedConstants g);

--- a/tests/expectations/transparent.c
+++ b/tests/expectations/transparent.c
@@ -5,6 +5,8 @@
 
 typedef struct DummyStruct DummyStruct;
 
+typedef struct EnumWithAssociatedConstantInImpl EnumWithAssociatedConstantInImpl;
+
 typedef DummyStruct TransparentComplexWrappingStructTuple;
 
 typedef uint32_t TransparentPrimitiveWrappingStructTuple;
@@ -19,6 +21,8 @@ typedef uint32_t TransparentPrimitiveWrapper_i32;
 
 typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 
+#define EnumWithAssociatedConstantInImpl_TEN 10
+
 #define TransparentPrimitiveWithAssociatedConstants_ONE 1
 
 #define TransparentPrimitiveWithAssociatedConstants_ZERO 0
@@ -29,4 +33,5 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrappingStructure d,
           TransparentComplexWrapper_i32 e,
           TransparentPrimitiveWrapper_i32 f,
-          TransparentPrimitiveWithAssociatedConstants g);
+          TransparentPrimitiveWithAssociatedConstants g,
+          EnumWithAssociatedConstantInImpl h);

--- a/tests/expectations/transparent.cpp
+++ b/tests/expectations/transparent.cpp
@@ -4,6 +4,8 @@
 
 struct DummyStruct;
 
+struct EnumWithAssociatedConstantInImpl;
+
 using TransparentComplexWrappingStructTuple = DummyStruct;
 
 using TransparentPrimitiveWrappingStructTuple = uint32_t;
@@ -20,6 +22,8 @@ using TransparentPrimitiveWrapper = uint32_t;
 
 using TransparentPrimitiveWithAssociatedConstants = uint32_t;
 
+static const TransparentPrimitiveWrappingStructure EnumWithAssociatedConstantInImpl_TEN = 10;
+
 static const TransparentPrimitiveWithAssociatedConstants TransparentPrimitiveWithAssociatedConstants_ONE = 1;
 
 static const TransparentPrimitiveWithAssociatedConstants TransparentPrimitiveWithAssociatedConstants_ZERO = 0;
@@ -32,6 +36,7 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrappingStructure d,
           TransparentComplexWrapper<int32_t> e,
           TransparentPrimitiveWrapper<int32_t> f,
-          TransparentPrimitiveWithAssociatedConstants g);
+          TransparentPrimitiveWithAssociatedConstants g,
+          EnumWithAssociatedConstantInImpl h);
 
 } // extern "C"

--- a/tests/expectations/transparent.cpp
+++ b/tests/expectations/transparent.cpp
@@ -18,6 +18,12 @@ using TransparentComplexWrapper = DummyStruct;
 template<typename T>
 using TransparentPrimitiveWrapper = uint32_t;
 
+using TransparentPrimitiveWithAssociatedConstants = uint32_t;
+
+static const TransparentPrimitiveWithAssociatedConstants TransparentPrimitiveWithAssociatedConstants_ONE = 1;
+
+static const TransparentPrimitiveWithAssociatedConstants TransparentPrimitiveWithAssociatedConstants_ZERO = 0;
+
 extern "C" {
 
 void root(TransparentComplexWrappingStructTuple a,
@@ -25,6 +31,7 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentComplexWrappingStructure c,
           TransparentPrimitiveWrappingStructure d,
           TransparentComplexWrapper<int32_t> e,
-          TransparentPrimitiveWrapper<int32_t> f);
+          TransparentPrimitiveWrapper<int32_t> f,
+          TransparentPrimitiveWithAssociatedConstants g);
 
 } // extern "C"

--- a/tests/rust/transparent.rs
+++ b/tests/rust/transparent.rs
@@ -30,6 +30,24 @@ struct TransparentPrimitiveWrapper<T> {
     marker: PhantomData<T>,
 }
 
+// Associated constant declared before struct declaration.
+impl TransparentPrimitiveWithAssociatedConstants {
+    pub const ZERO: TransparentPrimitiveWithAssociatedConstants = TransparentPrimitiveWithAssociatedConstants {
+        bits: 0
+    };
+}
+
+// Transparent structure wrapping a primitive with associated constants.
+#[repr(transparent)]
+struct TransparentPrimitiveWithAssociatedConstants { bits: u32 }
+
+// Associated constant declared after struct declaration.
+impl TransparentPrimitiveWithAssociatedConstants {
+    pub const ONE: TransparentPrimitiveWithAssociatedConstants = TransparentPrimitiveWithAssociatedConstants {
+        bits: 1
+    };
+}
+
 #[no_mangle]
 pub extern "C" fn root(
     a: TransparentComplexWrappingStructTuple,
@@ -38,4 +56,5 @@ pub extern "C" fn root(
     d: TransparentPrimitiveWrappingStructure,
     e: TransparentComplexWrapper<i32>,
     f: TransparentPrimitiveWrapper<i32>,
+    g: TransparentPrimitiveWithAssociatedConstants,
 ) { }

--- a/tests/rust/transparent.rs
+++ b/tests/rust/transparent.rs
@@ -48,6 +48,12 @@ impl TransparentPrimitiveWithAssociatedConstants {
     };
 }
 
+enum EnumWithAssociatedConstantInImpl { A }
+
+impl EnumWithAssociatedConstantInImpl {
+    pub const TEN: TransparentPrimitiveWrappingStructure = TransparentPrimitiveWrappingStructure { only_field: 10 };
+}
+
 #[no_mangle]
 pub extern "C" fn root(
     a: TransparentComplexWrappingStructTuple,
@@ -57,4 +63,5 @@ pub extern "C" fn root(
     e: TransparentComplexWrapper<i32>,
     f: TransparentPrimitiveWrapper<i32>,
     g: TransparentPrimitiveWithAssociatedConstants,
+    h: EnumWithAssociatedConstantInImpl,
 ) { }


### PR DESCRIPTION
This attempts to fix `repr(transparent)` for associated constants by unwrapping the first field on structs (see https://github.com/eqrion/cbindgen/issues/238#issuecomment-435923997 for more context).

I didn't see obvious ways to infer whether the struct the `impl` block corresponds with is `repr(transparent)`, and the order isn't guaranteed (`impl` prior to `struct`). So we have to parse the struct declaration first, and reference it later, which is why the `impl` blocks are loaded after the regular loop now.

I'm not sure whether the general approach is correct, so any feedback is greatly appreciated, especially ideas to simplify the branching or remove the `Vec` allocation.