### PR TITLE
Problem: Doxygen not picking up documentation

### DIFF
--- a/src/bindgen/ir/documentation.rs
+++ b/src/bindgen/ir/documentation.rs
@@ -69,12 +69,12 @@ impl Source for Documentation {
         }
 
         if config.language == Language::C {
-            out.write("/*");
+            out.write("/**");
             out.new_line();
         }
         for line in &self.doc_comment {
             if config.language != Language::C {
-                out.write("//");
+                out.write("///");
             } else {
                 out.write(" *");
             }


### PR DESCRIPTION
Documentation generated by cbindgen is not displayed in Doxygen's
output.

Solution: use comment styles supported by Doxygen

For C, this will be

```
/**
 * ...
 */
```

For C++, this will be

```
///
/// ...
///
```

as described at http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html

I've contemplating adding an option to cbindgen.toml for enabling this style but decided to go for a simpler route of making it the only style as it is still a valid comment and is not going to break anything. However, if it is better to put it behind a config flag, I'll gladly update this patch to do so.