### PR TITLE
Properly propagate const into arrays.

### DIFF
--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -124,7 +124,7 @@ impl CDecl {
             &Type::Array(ref t, ref constant) => {
                 let len = constant.as_str().to_owned();
                 self.declarators.push(CDeclarator::Array(len));
-                self.build_type(t, false);
+                self.build_type(t, is_const);
             }
             &Type::FuncPtr(ref ret, ref args) => {
                 let args = args

--- a/tests/expectations/both/cdecl.c
+++ b/tests/expectations/both/cdecl.c
@@ -10,7 +10,7 @@ typedef bool (*C)(int32_t, int32_t);
 
 typedef bool (*(*D)(int32_t))(float);
 
-typedef int32_t (*(*E)())[16];
+typedef const int32_t (*(*E)())[16];
 
 typedef const int32_t *F;
 
@@ -18,7 +18,7 @@ typedef const int32_t *const *G;
 
 typedef int32_t *const *H;
 
-typedef int32_t (*I)[16];
+typedef const int32_t (*I)[16];
 
 typedef double (**J)(float);
 

--- a/tests/expectations/cdecl.c
+++ b/tests/expectations/cdecl.c
@@ -10,7 +10,7 @@ typedef bool (*C)(int32_t, int32_t);
 
 typedef bool (*(*D)(int32_t))(float);
 
-typedef int32_t (*(*E)())[16];
+typedef const int32_t (*(*E)())[16];
 
 typedef const int32_t *F;
 
@@ -18,7 +18,7 @@ typedef const int32_t *const *G;
 
 typedef int32_t *const *H;
 
-typedef int32_t (*I)[16];
+typedef const int32_t (*I)[16];
 
 typedef double (**J)(float);
 

--- a/tests/expectations/cdecl.cpp
+++ b/tests/expectations/cdecl.cpp
@@ -9,7 +9,7 @@ using C = bool(*)(int32_t, int32_t);
 
 using D = bool(*(*)(int32_t))(float);
 
-using E = int32_t(*(*)())[16];
+using E = const int32_t(*(*)())[16];
 
 using F = const int32_t*;
 
@@ -17,7 +17,7 @@ using G = const int32_t*const *;
 
 using H = int32_t*const *;
 
-using I = int32_t(*)[16];
+using I = const int32_t(*)[16];
 
 using J = double(**)(float);
 

--- a/tests/expectations/tag/cdecl.c
+++ b/tests/expectations/tag/cdecl.c
@@ -10,7 +10,7 @@ typedef bool (*C)(int32_t, int32_t);
 
 typedef bool (*(*D)(int32_t))(float);
 
-typedef int32_t (*(*E)())[16];
+typedef const int32_t (*(*E)())[16];
 
 typedef const int32_t *F;
 
@@ -18,7 +18,7 @@ typedef const int32_t *const *G;
 
 typedef int32_t *const *H;
 
-typedef int32_t (*I)[16];
+typedef const int32_t (*I)[16];
 
 typedef double (**J)(float);
 


### PR DESCRIPTION
i.e. 'type I = *const [i32; 16]' should map to 'typedef const int32_t (*I)[16]'
instead of 'typedef int32_t (*I)[16]'