### PR TITLE
Manually copy arrays

### DIFF
--- a/tests/expectations/array.c
+++ b/tests/expectations/array.c
@@ -1,0 +1,21 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum {
+  A,
+} Foo_Tag;
+
+typedef struct {
+  float _0[20];
+} A_Body;
+
+typedef struct {
+  Foo_Tag tag;
+  union {
+    A_Body a;
+  };
+} Foo;
+
+void root(Foo a);

--- a/tests/expectations/array.cpp
+++ b/tests/expectations/array.cpp
@@ -1,0 +1,35 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+
+struct Foo {
+  enum class Tag {
+    A,
+  };
+
+  struct A_Body {
+    float _0[20];
+  };
+
+  Tag tag;
+  union {
+    A_Body a;
+  };
+
+  static Foo A(const float (&a0)[20]) {
+    Foo result;
+    for (int i = 0; i < 20; i++) {result.a._0[i] = a0[i];}
+    result.tag = Tag::A;
+    return result;
+  }
+
+  bool IsA() const {
+    return tag == Tag::A;
+  }
+};
+
+extern "C" {
+
+void root(Foo a);
+
+} // extern "C"

--- a/tests/expectations/both/array.c
+++ b/tests/expectations/both/array.c
@@ -1,0 +1,21 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum Foo_Tag {
+  A,
+} Foo_Tag;
+
+typedef struct A_Body {
+  float _0[20];
+} A_Body;
+
+typedef struct Foo {
+  Foo_Tag tag;
+  union {
+    A_Body a;
+  };
+} Foo;
+
+void root(Foo a);

--- a/tests/expectations/tag/array.c
+++ b/tests/expectations/tag/array.c
@@ -1,0 +1,21 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum Foo_Tag {
+  A,
+};
+
+struct A_Body {
+  float _0[20];
+};
+
+struct Foo {
+  enum Foo_Tag tag;
+  union {
+    struct A_Body a;
+  };
+};
+
+void root(struct Foo a);

--- a/tests/rust/array.rs
+++ b/tests/rust/array.rs
@@ -1,0 +1,7 @@
+#[repr(C)]
+enum Foo {
+    A([f32; 20])
+}
+
+#[no_mangle]
+pub extern "C" fn root(a: Foo) {}

--- a/tests/rust/array.toml
+++ b/tests/rust/array.toml
@@ -1,0 +1,2 @@
+[enum]
+derive_helper_methods = true


### PR DESCRIPTION
C++ arrays can't be assigned. We detect this situation and manually copy
over the elements.