### PR TITLE
parser: Properly skip associated constants on unsupported types. 

### DIFF
--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -341,7 +341,7 @@ impl Type {
                 }
                 return Err("Tuples are not supported types.".to_owned());
             }
-            _ => return Err("Unsupported type.".to_owned()),
+            _ => return Err(format!("Unsupported type: {:?}", ty)),
         };
 
         return Ok(Some(converted));

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -689,7 +689,13 @@ impl Parse {
     ) where
         I: IntoIterator<Item = &'a syn::ImplItemConst>,
     {
-        let ty = Type::load(&impl_ty).unwrap();
+        let ty = match Type::load(impl_ty) {
+            Ok(ty) => ty,
+            Err(e) => {
+                warn!("Skipping associated constants for {:?}: {:?}", impl_ty, e);
+                return;
+            }
+        };
         if ty.is_none() {
             return;
         }

--- a/tests/expectations/both/style-crash.c
+++ b/tests/expectations/both/style-crash.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/style-crash.c
+++ b/tests/expectations/style-crash.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/style-crash.cpp
+++ b/tests/expectations/style-crash.cpp
@@ -1,0 +1,3 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>

--- a/tests/expectations/tag/style-crash.c
+++ b/tests/expectations/tag/style-crash.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/rust/style-crash.rs
+++ b/tests/rust/style-crash.rs
@@ -1,0 +1,7 @@
+pub trait SpecifiedValueInfo {
+    const SUPPORTED_TYPES: u8 = 0;
+}
+
+impl<T: SpecifiedValueInfo> SpecifiedValueInfo for [T] {
+    const SUPPORTED_TYPES: u8 = T::SUPPORTED_TYPES;
+}


### PR DESCRIPTION
This fixes a crash when running cbindgen 0.7.0 on the style crate.