### PR TITLE
bindgen: Allow to auto-generate asserted casts for tagged enums.

### DIFF
--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -125,6 +125,13 @@ impl Bindings {
                 out.new_line();
                 out.write("#include <cstdlib>");
                 out.new_line();
+                if self.config.enumeration.cast_assert_name.is_none()
+                    && (self.config.enumeration.derive_mut_casts
+                        || self.config.enumeration.derive_const_casts)
+                {
+                    out.write("#include <cassert>");
+                    out.new_line();
+                }
             }
         }
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -351,7 +351,7 @@ impl StructConfig {
 }
 
 /// Settings to apply to generated enums.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 #[serde(default)]
@@ -366,17 +366,14 @@ pub struct EnumConfig {
     /// Whether to generate static `::X(..)` constructors and `IsX()`
     /// methods for tagged enums.
     pub derive_helper_methods: bool,
-}
-
-impl Default for EnumConfig {
-    fn default() -> EnumConfig {
-        EnumConfig {
-            rename_variants: None,
-            add_sentinel: false,
-            prefix_with_name: false,
-            derive_helper_methods: false,
-        }
-    }
+    /// Whether to generate `AsX() const` methods for tagged enums.
+    pub derive_const_casts: bool,
+    /// Whether to generate `AsX()` methods for tagged enums.
+    pub derive_mut_casts: bool,
+    /// The name of the macro to use for `derive_{const,mut}casts`. If custom, you're
+    /// responsible to provide the necessary header, otherwise `assert` will be
+    /// used, and `<cassert>` will be included.
+    pub cast_assert_name: Option<String>,
 }
 
 impl EnumConfig {
@@ -391,6 +388,18 @@ impl EnumConfig {
             return x;
         }
         self.derive_helper_methods
+    }
+    pub(crate) fn derive_const_casts(&self, annotations: &AnnotationSet) -> bool {
+        if let Some(x) = annotations.bool("derive-const-casts") {
+            return x;
+        }
+        self.derive_const_casts
+    }
+    pub(crate) fn derive_mut_casts(&self, annotations: &AnnotationSet) -> bool {
+        if let Some(x) = annotations.bool("derive-mut-casts") {
+            return x;
+        }
+        self.derive_mut_casts
     }
 }
 

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -204,7 +204,6 @@ pub enum Type {
     ConstPtr(Box<Type>),
     Ptr(Box<Type>),
     Ref(Box<Type>),
-    #[allow(dead_code)] // MutRef is not currently used
     MutRef(Box<Type>),
     Path(GenericPath),
     Primitive(PrimitiveType),

--- a/tests/expectations/asserted-cast.c
+++ b/tests/expectations/asserted-cast.c
@@ -1,0 +1,83 @@
+#define MY_ASSERT(...) do { } while (0)
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct I I;
+
+enum H_Tag {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+};
+typedef uint8_t H_Tag;
+
+typedef struct {
+  int16_t _0;
+} H_Foo_Body;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} H_Bar_Body;
+
+typedef struct {
+  H_Tag tag;
+  union {
+    H_Foo_Body foo;
+    H_Bar_Body bar;
+  };
+} H;
+
+enum J_Tag {
+  J_Foo,
+  J_Bar,
+  J_Baz,
+};
+typedef uint8_t J_Tag;
+
+typedef struct {
+  int16_t _0;
+} J_Foo_Body;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} J_Bar_Body;
+
+typedef struct {
+  J_Tag tag;
+  union {
+    J_Foo_Body foo;
+    J_Bar_Body bar;
+  };
+} J;
+
+enum K_Tag {
+  K_Foo,
+  K_Bar,
+  K_Baz,
+};
+typedef uint8_t K_Tag;
+
+typedef struct {
+  K_Tag tag;
+  int16_t _0;
+} K_Foo_Body;
+
+typedef struct {
+  K_Tag tag;
+  uint8_t x;
+  int16_t y;
+} K_Bar_Body;
+
+typedef union {
+  K_Tag tag;
+  K_Foo_Body foo;
+  K_Bar_Body bar;
+} K;
+
+void foo(H h, I i, J j, K k);

--- a/tests/expectations/asserted-cast.cpp
+++ b/tests/expectations/asserted-cast.cpp
@@ -1,0 +1,247 @@
+#define MY_ASSERT(...) do { } while (0)
+
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+
+struct I;
+
+struct H {
+  enum class Tag : uint8_t {
+    H_Foo,
+    H_Bar,
+    H_Baz,
+  };
+
+  struct H_Foo_Body {
+    int16_t _0;
+  };
+
+  struct H_Bar_Body {
+    uint8_t x;
+    int16_t y;
+  };
+
+  Tag tag;
+  union {
+    H_Foo_Body foo;
+    H_Bar_Body bar;
+  };
+
+  static H H_Foo(const int16_t &a0) {
+    H result;
+    result.foo._0 = a0;
+    result.tag = Tag::H_Foo;
+    return result;
+  }
+
+  static H H_Bar(const uint8_t &aX,
+                 const int16_t &aY) {
+    H result;
+    result.bar.x = aX;
+    result.bar.y = aY;
+    result.tag = Tag::H_Bar;
+    return result;
+  }
+
+  static H H_Baz() {
+    H result;
+    result.tag = Tag::H_Baz;
+    return result;
+  }
+
+  bool IsH_Foo() const {
+    return tag == Tag::H_Foo;
+  }
+
+  bool IsH_Bar() const {
+    return tag == Tag::H_Bar;
+  }
+
+  bool IsH_Baz() const {
+    return tag == Tag::H_Baz;
+  }
+
+  const int16_t& AsH_Foo() const {
+    MY_ASSERT(IsH_Foo());
+    return foo._0;
+  }
+
+  int16_t& AsH_Foo() {
+    MY_ASSERT(IsH_Foo());
+    return foo._0;
+  }
+
+  const H_Bar_Body& AsH_Bar() const {
+    MY_ASSERT(IsH_Bar());
+    return bar;
+  }
+
+  H_Bar_Body& AsH_Bar() {
+    MY_ASSERT(IsH_Bar());
+    return bar;
+  }
+};
+
+struct J {
+  enum class Tag : uint8_t {
+    J_Foo,
+    J_Bar,
+    J_Baz,
+  };
+
+  struct J_Foo_Body {
+    int16_t _0;
+  };
+
+  struct J_Bar_Body {
+    uint8_t x;
+    int16_t y;
+  };
+
+  Tag tag;
+  union {
+    J_Foo_Body foo;
+    J_Bar_Body bar;
+  };
+
+  static J J_Foo(const int16_t &a0) {
+    J result;
+    result.foo._0 = a0;
+    result.tag = Tag::J_Foo;
+    return result;
+  }
+
+  static J J_Bar(const uint8_t &aX,
+                 const int16_t &aY) {
+    J result;
+    result.bar.x = aX;
+    result.bar.y = aY;
+    result.tag = Tag::J_Bar;
+    return result;
+  }
+
+  static J J_Baz() {
+    J result;
+    result.tag = Tag::J_Baz;
+    return result;
+  }
+
+  bool IsJ_Foo() const {
+    return tag == Tag::J_Foo;
+  }
+
+  bool IsJ_Bar() const {
+    return tag == Tag::J_Bar;
+  }
+
+  bool IsJ_Baz() const {
+    return tag == Tag::J_Baz;
+  }
+
+  const int16_t& AsJ_Foo() const {
+    MY_ASSERT(IsJ_Foo());
+    return foo._0;
+  }
+
+  int16_t& AsJ_Foo() {
+    MY_ASSERT(IsJ_Foo());
+    return foo._0;
+  }
+
+  const J_Bar_Body& AsJ_Bar() const {
+    MY_ASSERT(IsJ_Bar());
+    return bar;
+  }
+
+  J_Bar_Body& AsJ_Bar() {
+    MY_ASSERT(IsJ_Bar());
+    return bar;
+  }
+};
+
+union K {
+  enum class Tag : uint8_t {
+    K_Foo,
+    K_Bar,
+    K_Baz,
+  };
+
+  struct K_Foo_Body {
+    Tag tag;
+    int16_t _0;
+  };
+
+  struct K_Bar_Body {
+    Tag tag;
+    uint8_t x;
+    int16_t y;
+  };
+
+  struct {
+    Tag tag;
+  };
+  K_Foo_Body foo;
+  K_Bar_Body bar;
+
+  static K K_Foo(const int16_t &a0) {
+    K result;
+    result.foo._0 = a0;
+    result.tag = Tag::K_Foo;
+    return result;
+  }
+
+  static K K_Bar(const uint8_t &aX,
+                 const int16_t &aY) {
+    K result;
+    result.bar.x = aX;
+    result.bar.y = aY;
+    result.tag = Tag::K_Bar;
+    return result;
+  }
+
+  static K K_Baz() {
+    K result;
+    result.tag = Tag::K_Baz;
+    return result;
+  }
+
+  bool IsK_Foo() const {
+    return tag == Tag::K_Foo;
+  }
+
+  bool IsK_Bar() const {
+    return tag == Tag::K_Bar;
+  }
+
+  bool IsK_Baz() const {
+    return tag == Tag::K_Baz;
+  }
+
+  const int16_t& AsK_Foo() const {
+    MY_ASSERT(IsK_Foo());
+    return foo._0;
+  }
+
+  int16_t& AsK_Foo() {
+    MY_ASSERT(IsK_Foo());
+    return foo._0;
+  }
+
+  const K_Bar_Body& AsK_Bar() const {
+    MY_ASSERT(IsK_Bar());
+    return bar;
+  }
+
+  K_Bar_Body& AsK_Bar() {
+    MY_ASSERT(IsK_Bar());
+    return bar;
+  }
+};
+
+extern "C" {
+
+void foo(H h, I i, J j, K k);
+
+} // extern "C"

--- a/tests/expectations/both/asserted-cast.c
+++ b/tests/expectations/both/asserted-cast.c
@@ -1,0 +1,83 @@
+#define MY_ASSERT(...) do { } while (0)
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct I I;
+
+enum H_Tag {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+};
+typedef uint8_t H_Tag;
+
+typedef struct H_Foo_Body {
+  int16_t _0;
+} H_Foo_Body;
+
+typedef struct H_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} H_Bar_Body;
+
+typedef struct H {
+  H_Tag tag;
+  union {
+    H_Foo_Body foo;
+    H_Bar_Body bar;
+  };
+} H;
+
+enum J_Tag {
+  J_Foo,
+  J_Bar,
+  J_Baz,
+};
+typedef uint8_t J_Tag;
+
+typedef struct J_Foo_Body {
+  int16_t _0;
+} J_Foo_Body;
+
+typedef struct J_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} J_Bar_Body;
+
+typedef struct J {
+  J_Tag tag;
+  union {
+    J_Foo_Body foo;
+    J_Bar_Body bar;
+  };
+} J;
+
+enum K_Tag {
+  K_Foo,
+  K_Bar,
+  K_Baz,
+};
+typedef uint8_t K_Tag;
+
+typedef struct K_Foo_Body {
+  K_Tag tag;
+  int16_t _0;
+} K_Foo_Body;
+
+typedef struct K_Bar_Body {
+  K_Tag tag;
+  uint8_t x;
+  int16_t y;
+} K_Bar_Body;
+
+typedef union K {
+  K_Tag tag;
+  K_Foo_Body foo;
+  K_Bar_Body bar;
+} K;
+
+void foo(H h, I i, J j, K k);

--- a/tests/expectations/both/transform-op.c
+++ b/tests/expectations/both/transform-op.c
@@ -75,4 +75,88 @@ typedef struct StyleBar_i32 {
   };
 } StyleBar_i32;
 
-void foo(const StyleFoo_i32 *foo, const StyleBar_i32 *bar);
+typedef struct StylePoint_u32 {
+  uint32_t x;
+  uint32_t y;
+} StylePoint_u32;
+
+typedef enum StyleBar_u32_Tag {
+  Bar1_u32,
+  Bar2_u32,
+  Bar3_u32,
+  Bar4_u32,
+} StyleBar_u32_Tag;
+
+typedef struct StyleBar1_Body_u32 {
+  int32_t x;
+  StylePoint_u32 y;
+  StylePoint_f32 z;
+} StyleBar1_Body_u32;
+
+typedef struct StyleBar2_Body_u32 {
+  uint32_t _0;
+} StyleBar2_Body_u32;
+
+typedef struct StyleBar3_Body_u32 {
+  StylePoint_u32 _0;
+} StyleBar3_Body_u32;
+
+typedef struct StyleBar_u32 {
+  StyleBar_u32_Tag tag;
+  union {
+    StyleBar1_Body_u32 bar1;
+    StyleBar2_Body_u32 bar2;
+    StyleBar3_Body_u32 bar3;
+  };
+} StyleBar_u32;
+
+enum StyleBaz_Tag {
+  Baz1,
+  Baz2,
+  Baz3,
+};
+typedef uint8_t StyleBaz_Tag;
+
+typedef struct StyleBaz1_Body {
+  StyleBaz_Tag tag;
+  StyleBar_u32 _0;
+} StyleBaz1_Body;
+
+typedef struct StyleBaz2_Body {
+  StyleBaz_Tag tag;
+  StylePoint_i32 _0;
+} StyleBaz2_Body;
+
+typedef union StyleBaz {
+  StyleBaz_Tag tag;
+  StyleBaz1_Body baz1;
+  StyleBaz2_Body baz2;
+} StyleBaz;
+
+enum StyleTaz_Tag {
+  Taz1,
+  Taz2,
+  Taz3,
+};
+typedef uint8_t StyleTaz_Tag;
+
+typedef struct StyleTaz1_Body {
+  StyleBar_u32 _0;
+} StyleTaz1_Body;
+
+typedef struct StyleTaz2_Body {
+  StyleBaz _0;
+} StyleTaz2_Body;
+
+typedef struct StyleTaz {
+  StyleTaz_Tag tag;
+  union {
+    StyleTaz1_Body taz1;
+    StyleTaz2_Body taz2;
+  };
+} StyleTaz;
+
+void foo(const StyleFoo_i32 *foo,
+         const StyleBar_i32 *bar,
+         const StyleBaz *baz,
+         const StyleTaz *taz);

--- a/tests/expectations/tag/asserted-cast.c
+++ b/tests/expectations/tag/asserted-cast.c
@@ -1,0 +1,83 @@
+#define MY_ASSERT(...) do { } while (0)
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct I;
+
+enum H_Tag {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+};
+typedef uint8_t H_Tag;
+
+struct H_Foo_Body {
+  int16_t _0;
+};
+
+struct H_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct H {
+  enum H_Tag tag;
+  union {
+    struct H_Foo_Body foo;
+    struct H_Bar_Body bar;
+  };
+};
+
+enum J_Tag {
+  J_Foo,
+  J_Bar,
+  J_Baz,
+};
+typedef uint8_t J_Tag;
+
+struct J_Foo_Body {
+  int16_t _0;
+};
+
+struct J_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct J {
+  enum J_Tag tag;
+  union {
+    struct J_Foo_Body foo;
+    struct J_Bar_Body bar;
+  };
+};
+
+enum K_Tag {
+  K_Foo,
+  K_Bar,
+  K_Baz,
+};
+typedef uint8_t K_Tag;
+
+struct K_Foo_Body {
+  K_Tag tag;
+  int16_t _0;
+};
+
+struct K_Bar_Body {
+  K_Tag tag;
+  uint8_t x;
+  int16_t y;
+};
+
+union K {
+  enum K_Tag tag;
+  struct K_Foo_Body foo;
+  struct K_Bar_Body bar;
+};
+
+void foo(struct H h, struct I i, struct J j, union K k);

--- a/tests/expectations/tag/transform-op.c
+++ b/tests/expectations/tag/transform-op.c
@@ -75,4 +75,88 @@ struct StyleBar_i32 {
   };
 };
 
-void foo(const union StyleFoo_i32 *foo, const struct StyleBar_i32 *bar);
+struct StylePoint_u32 {
+  uint32_t x;
+  uint32_t y;
+};
+
+enum StyleBar_u32_Tag {
+  Bar1_u32,
+  Bar2_u32,
+  Bar3_u32,
+  Bar4_u32,
+};
+
+struct StyleBar1_Body_u32 {
+  int32_t x;
+  struct StylePoint_u32 y;
+  struct StylePoint_f32 z;
+};
+
+struct StyleBar2_Body_u32 {
+  uint32_t _0;
+};
+
+struct StyleBar3_Body_u32 {
+  struct StylePoint_u32 _0;
+};
+
+struct StyleBar_u32 {
+  enum StyleBar_u32_Tag tag;
+  union {
+    struct StyleBar1_Body_u32 bar1;
+    struct StyleBar2_Body_u32 bar2;
+    struct StyleBar3_Body_u32 bar3;
+  };
+};
+
+enum StyleBaz_Tag {
+  Baz1,
+  Baz2,
+  Baz3,
+};
+typedef uint8_t StyleBaz_Tag;
+
+struct StyleBaz1_Body {
+  StyleBaz_Tag tag;
+  struct StyleBar_u32 _0;
+};
+
+struct StyleBaz2_Body {
+  StyleBaz_Tag tag;
+  struct StylePoint_i32 _0;
+};
+
+union StyleBaz {
+  enum StyleBaz_Tag tag;
+  struct StyleBaz1_Body baz1;
+  struct StyleBaz2_Body baz2;
+};
+
+enum StyleTaz_Tag {
+  Taz1,
+  Taz2,
+  Taz3,
+};
+typedef uint8_t StyleTaz_Tag;
+
+struct StyleTaz1_Body {
+  struct StyleBar_u32 _0;
+};
+
+struct StyleTaz2_Body {
+  union StyleBaz _0;
+};
+
+struct StyleTaz {
+  enum StyleTaz_Tag tag;
+  union {
+    struct StyleTaz1_Body taz1;
+    struct StyleTaz2_Body taz2;
+  };
+};
+
+void foo(const union StyleFoo_i32 *foo,
+         const struct StyleBar_i32 *bar,
+         const union StyleBaz *baz,
+         const struct StyleTaz *taz);

--- a/tests/expectations/transform-op.c
+++ b/tests/expectations/transform-op.c
@@ -75,4 +75,88 @@ typedef struct {
   };
 } StyleBar_i32;
 
-void foo(const StyleFoo_i32 *foo, const StyleBar_i32 *bar);
+typedef struct {
+  uint32_t x;
+  uint32_t y;
+} StylePoint_u32;
+
+typedef enum {
+  Bar1_u32,
+  Bar2_u32,
+  Bar3_u32,
+  Bar4_u32,
+} StyleBar_u32_Tag;
+
+typedef struct {
+  int32_t x;
+  StylePoint_u32 y;
+  StylePoint_f32 z;
+} StyleBar1_Body_u32;
+
+typedef struct {
+  uint32_t _0;
+} StyleBar2_Body_u32;
+
+typedef struct {
+  StylePoint_u32 _0;
+} StyleBar3_Body_u32;
+
+typedef struct {
+  StyleBar_u32_Tag tag;
+  union {
+    StyleBar1_Body_u32 bar1;
+    StyleBar2_Body_u32 bar2;
+    StyleBar3_Body_u32 bar3;
+  };
+} StyleBar_u32;
+
+enum StyleBaz_Tag {
+  Baz1,
+  Baz2,
+  Baz3,
+};
+typedef uint8_t StyleBaz_Tag;
+
+typedef struct {
+  StyleBaz_Tag tag;
+  StyleBar_u32 _0;
+} StyleBaz1_Body;
+
+typedef struct {
+  StyleBaz_Tag tag;
+  StylePoint_i32 _0;
+} StyleBaz2_Body;
+
+typedef union {
+  StyleBaz_Tag tag;
+  StyleBaz1_Body baz1;
+  StyleBaz2_Body baz2;
+} StyleBaz;
+
+enum StyleTaz_Tag {
+  Taz1,
+  Taz2,
+  Taz3,
+};
+typedef uint8_t StyleTaz_Tag;
+
+typedef struct {
+  StyleBar_u32 _0;
+} StyleTaz1_Body;
+
+typedef struct {
+  StyleBaz _0;
+} StyleTaz2_Body;
+
+typedef struct {
+  StyleTaz_Tag tag;
+  union {
+    StyleTaz1_Body taz1;
+    StyleTaz2_Body taz2;
+  };
+} StyleTaz;
+
+void foo(const StyleFoo_i32 *foo,
+         const StyleBar_i32 *bar,
+         const StyleBaz *baz,
+         const StyleTaz *taz);

--- a/tests/expectations/transform-op.cpp
+++ b/tests/expectations/transform-op.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <cassert>
 
 template<typename T>
 struct StylePoint {
@@ -40,6 +41,83 @@ union StyleFoo {
   Foo_Body foo;
   Bar_Body bar;
   Baz_Body baz;
+
+  static StyleFoo Foo(const int32_t &aX,
+                      const StylePoint<T> &aY,
+                      const StylePoint<float> &aZ) {
+    StyleFoo result;
+    result.foo.x = aX;
+    result.foo.y = aY;
+    result.foo.z = aZ;
+    result.tag = Tag::Foo;
+    return result;
+  }
+
+  static StyleFoo Bar(const T &a0) {
+    StyleFoo result;
+    result.bar._0 = a0;
+    result.tag = Tag::Bar;
+    return result;
+  }
+
+  static StyleFoo Baz(const StylePoint<T> &a0) {
+    StyleFoo result;
+    result.baz._0 = a0;
+    result.tag = Tag::Baz;
+    return result;
+  }
+
+  static StyleFoo Bazz() {
+    StyleFoo result;
+    result.tag = Tag::Bazz;
+    return result;
+  }
+
+  bool IsFoo() const {
+    return tag == Tag::Foo;
+  }
+
+  bool IsBar() const {
+    return tag == Tag::Bar;
+  }
+
+  bool IsBaz() const {
+    return tag == Tag::Baz;
+  }
+
+  bool IsBazz() const {
+    return tag == Tag::Bazz;
+  }
+
+  const Foo_Body& AsFoo() const {
+    assert(IsFoo());
+    return foo;
+  }
+
+  Foo_Body& AsFoo() {
+    assert(IsFoo());
+    return foo;
+  }
+
+  const T& AsBar() const {
+    assert(IsBar());
+    return bar._0;
+  }
+
+  T& AsBar() {
+    assert(IsBar());
+    return bar._0;
+  }
+
+  const StylePoint<T>& AsBaz() const {
+    assert(IsBaz());
+    return baz._0;
+  }
+
+  StylePoint<T>& AsBaz() {
+    assert(IsBaz());
+    return baz._0;
+  }
 };
 
 template<typename T>
@@ -71,10 +149,240 @@ struct StyleBar {
     StyleBar2_Body bar2;
     StyleBar3_Body bar3;
   };
+
+  static StyleBar Bar1(const int32_t &aX,
+                       const StylePoint<T> &aY,
+                       const StylePoint<float> &aZ) {
+    StyleBar result;
+    result.bar1.x = aX;
+    result.bar1.y = aY;
+    result.bar1.z = aZ;
+    result.tag = Tag::Bar1;
+    return result;
+  }
+
+  static StyleBar Bar2(const T &a0) {
+    StyleBar result;
+    result.bar2._0 = a0;
+    result.tag = Tag::Bar2;
+    return result;
+  }
+
+  static StyleBar Bar3(const StylePoint<T> &a0) {
+    StyleBar result;
+    result.bar3._0 = a0;
+    result.tag = Tag::Bar3;
+    return result;
+  }
+
+  static StyleBar Bar4() {
+    StyleBar result;
+    result.tag = Tag::Bar4;
+    return result;
+  }
+
+  bool IsBar1() const {
+    return tag == Tag::Bar1;
+  }
+
+  bool IsBar2() const {
+    return tag == Tag::Bar2;
+  }
+
+  bool IsBar3() const {
+    return tag == Tag::Bar3;
+  }
+
+  bool IsBar4() const {
+    return tag == Tag::Bar4;
+  }
+
+  const StyleBar1_Body& AsBar1() const {
+    assert(IsBar1());
+    return bar1;
+  }
+
+  StyleBar1_Body& AsBar1() {
+    assert(IsBar1());
+    return bar1;
+  }
+
+  const T& AsBar2() const {
+    assert(IsBar2());
+    return bar2._0;
+  }
+
+  T& AsBar2() {
+    assert(IsBar2());
+    return bar2._0;
+  }
+
+  const StylePoint<T>& AsBar3() const {
+    assert(IsBar3());
+    return bar3._0;
+  }
+
+  StylePoint<T>& AsBar3() {
+    assert(IsBar3());
+    return bar3._0;
+  }
+};
+
+union StyleBaz {
+  enum class Tag : uint8_t {
+    Baz1,
+    Baz2,
+    Baz3,
+  };
+
+  struct Baz1_Body {
+    Tag tag;
+    StyleBar<uint32_t> _0;
+  };
+
+  struct Baz2_Body {
+    Tag tag;
+    StylePoint<int32_t> _0;
+  };
+
+  struct {
+    Tag tag;
+  };
+  Baz1_Body baz1;
+  Baz2_Body baz2;
+
+  static StyleBaz Baz1(const StyleBar<uint32_t> &a0) {
+    StyleBaz result;
+    result.baz1._0 = a0;
+    result.tag = Tag::Baz1;
+    return result;
+  }
+
+  static StyleBaz Baz2(const StylePoint<int32_t> &a0) {
+    StyleBaz result;
+    result.baz2._0 = a0;
+    result.tag = Tag::Baz2;
+    return result;
+  }
+
+  static StyleBaz Baz3() {
+    StyleBaz result;
+    result.tag = Tag::Baz3;
+    return result;
+  }
+
+  bool IsBaz1() const {
+    return tag == Tag::Baz1;
+  }
+
+  bool IsBaz2() const {
+    return tag == Tag::Baz2;
+  }
+
+  bool IsBaz3() const {
+    return tag == Tag::Baz3;
+  }
+
+  const StyleBar<uint32_t>& AsBaz1() const {
+    assert(IsBaz1());
+    return baz1._0;
+  }
+
+  StyleBar<uint32_t>& AsBaz1() {
+    assert(IsBaz1());
+    return baz1._0;
+  }
+
+  const StylePoint<int32_t>& AsBaz2() const {
+    assert(IsBaz2());
+    return baz2._0;
+  }
+
+  StylePoint<int32_t>& AsBaz2() {
+    assert(IsBaz2());
+    return baz2._0;
+  }
+};
+
+struct StyleTaz {
+  enum class Tag : uint8_t {
+    Taz1,
+    Taz2,
+    Taz3,
+  };
+
+  struct StyleTaz1_Body {
+    StyleBar<uint32_t> _0;
+  };
+
+  struct StyleTaz2_Body {
+    StyleBaz _0;
+  };
+
+  Tag tag;
+  union {
+    StyleTaz1_Body taz1;
+    StyleTaz2_Body taz2;
+  };
+
+  static StyleTaz Taz1(const StyleBar<uint32_t> &a0) {
+    StyleTaz result;
+    result.taz1._0 = a0;
+    result.tag = Tag::Taz1;
+    return result;
+  }
+
+  static StyleTaz Taz2(const StyleBaz &a0) {
+    StyleTaz result;
+    result.taz2._0 = a0;
+    result.tag = Tag::Taz2;
+    return result;
+  }
+
+  static StyleTaz Taz3() {
+    StyleTaz result;
+    result.tag = Tag::Taz3;
+    return result;
+  }
+
+  bool IsTaz1() const {
+    return tag == Tag::Taz1;
+  }
+
+  bool IsTaz2() const {
+    return tag == Tag::Taz2;
+  }
+
+  bool IsTaz3() const {
+    return tag == Tag::Taz3;
+  }
+
+  const StyleBar<uint32_t>& AsTaz1() const {
+    assert(IsTaz1());
+    return taz1._0;
+  }
+
+  StyleBar<uint32_t>& AsTaz1() {
+    assert(IsTaz1());
+    return taz1._0;
+  }
+
+  const StyleBaz& AsTaz2() const {
+    assert(IsTaz2());
+    return taz2._0;
+  }
+
+  StyleBaz& AsTaz2() {
+    assert(IsTaz2());
+    return taz2._0;
+  }
 };
 
 extern "C" {
 
-void foo(const StyleFoo<int32_t> *foo, const StyleBar<int32_t> *bar);
+void foo(const StyleFoo<int32_t> *foo,
+         const StyleBar<int32_t> *bar,
+         const StyleBaz *baz,
+         const StyleTaz *taz);
 
 } // extern "C"

--- a/tests/rust/asserted-cast.rs
+++ b/tests/rust/asserted-cast.rs
@@ -1,0 +1,39 @@
+/// cbindgen:prefix-with-name
+#[repr(C, u8)]
+pub enum H {
+    Foo(i16),
+    Bar { x: u8, y: i16 },
+    Baz
+}
+
+/// cbindgen:prefix-with-name
+#[repr(C, u8, u16)]
+pub enum I {
+    Foo(i16),
+    Bar { x: u8, y: i16 },
+    Baz
+}
+
+/// cbindgen:prefix-with-name
+#[repr(C, u8)]
+pub enum J {
+    Foo(i16),
+    Bar { x: u8, y: i16 },
+    Baz
+}
+
+/// cbindgen:prefix-with-name
+#[repr(u8)]
+pub enum K {
+    Foo(i16),
+    Bar { x: u8, y: i16 },
+    Baz
+}
+
+#[no_mangle]
+pub extern "C" fn foo(
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+) {}

--- a/tests/rust/asserted-cast.toml
+++ b/tests/rust/asserted-cast.toml
@@ -1,0 +1,10 @@
+# This is a bit of an abuse of the warning config...
+autogen_warning = """
+#define MY_ASSERT(...) do { } while (0)
+"""
+
+[enum]
+derive_helper_methods = true
+derive_const_casts = true
+derive_mut_casts = true
+cast_assert_name = "MY_ASSERT"

--- a/tests/rust/transform-op.rs
+++ b/tests/rust/transform-op.rs
@@ -20,5 +20,24 @@ pub enum Bar<T> {
     Bar4,
 }
 
+#[repr(u8)]
+pub enum Baz {
+    Baz1(Bar<u32>),
+    Baz2(Point<i32>),
+    Baz3,
+}
+
+#[repr(C, u8)]
+pub enum Taz {
+    Taz1(Bar<u32>),
+    Taz2(Baz),
+    Taz3,
+}
+
 #[no_mangle]
-pub extern "C" fn foo(foo: *const Foo<i32>, bar: *const Bar<i32>) {}
+pub extern "C" fn foo(
+    foo: *const Foo<i32>,
+    bar: *const Bar<i32>,
+    baz: *const Baz,
+    taz: *const Taz,
+) {}

--- a/tests/rust/transform-op.toml
+++ b/tests/rust/transform-op.toml
@@ -1,2 +1,7 @@
 [export]
 prefix = "Style"
+
+[enum]
+derive_helper_methods = true
+derive_const_casts = true
+derive_mut_casts = true


### PR DESCRIPTION
This fixes one of my pet-peeves. Without this patch, I need to add them manually
using the raw body stuff, or along the code that accesses the struct member,
none of those being ideal.