### PR TITLE
parser: Make bitflags expansion opt-in.

### DIFF
--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -295,7 +295,7 @@ impl Builder {
         }
 
         for x in &self.srcs {
-            result.extend_with(&parser::parse_src(x)?);
+            result.extend_with(&parser::parse_src(x, &self.config.macro_expansion)?);
         }
 
         if let Some((lib_dir, binding_lib_name)) = self.lib.clone() {
@@ -321,6 +321,7 @@ impl Builder {
 
             result.extend_with(&parser::parse_lib(
                 cargo,
+                &self.config.macro_expansion,
                 self.config.parse.parse_deps,
                 &self.config.parse.include,
                 &self.config.parse.exclude,
@@ -332,6 +333,7 @@ impl Builder {
         } else if let Some(cargo) = self.lib_cargo.clone() {
             result.extend_with(&parser::parse_lib(
                 cargo,
+                &self.config.macro_expansion,
                 self.config.parse.parse_deps,
                 &self.config.parse.include,
                 &self.config.parse.exclude,

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -412,6 +412,16 @@ impl Default for ConstantConfig {
     }
 }
 
+/// Settings for custom macro expansion.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
+pub struct MacroExpansionConfig {
+    /// Whether the `bitflags` macro should be expanded.
+    pub bitflags: bool,
+}
+
 /// Settings to apply when running `rustc --pretty=expanded`
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -560,6 +570,8 @@ pub struct Config {
     pub parse: ParseConfig,
     /// The configuration options for exporting
     pub export: ExportConfig,
+    /// The configuration options for macros.
+    pub macro_expansion: MacroExpansionConfig,
     /// The configuration options for functions
     #[serde(rename = "fn")]
     pub function: FunctionConfig,
@@ -596,6 +608,7 @@ impl Default for Config {
             tab_width: 2,
             language: Language::Cxx,
             style: Style::Type,
+            macro_expansion: Default::default(),
             parse: ParseConfig::default(),
             export: ExportConfig::default(),
             function: FunctionConfig::default(),

--- a/tests/rust/associated_in_body.toml
+++ b/tests/rust/associated_in_body.toml
@@ -1,5 +1,8 @@
 [struct]
 associated_constants_in_body = true
 
+[macro_expansion]
+bitflags = true
+
 [export]
 prefix = "Style" # Just ensuring they play well together :)

--- a/tests/rust/bitflags.toml
+++ b/tests/rust/bitflags.toml
@@ -1,0 +1,2 @@
+[macro_expansion]
+bitflags = true


### PR DESCRIPTION
Otherwise we may break code that does its own bitflags parsing.

In particular, this will prevent Gecko builds from breaking due to:

  https://searchfox.org/mozilla-central/rev/92d11a33250a8e368c8ca3e962e15ca67117f765/gfx/webrender_bindings/webrender_ffi.h#67

(Which should go away once we start opting-in).