### PR TITLE
Embed custom files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project can be used to generate C bindings for Rust code. It is currently b
   * Support for generating `#ifdef`'s for `#[cfg]` attributes
   * Support for `#[repr(sized)]` tagged enum's
 
-## Installation  
+## Installation
 
 ```
 cargo install cbindgen
@@ -139,6 +139,12 @@ default_features = true
 # being expanded. The crate's `Cargo.toml` must take care of enabling the
 # appropriate features in its dependencies
 features = ["cbindgen"]
+
+[embed]
+# A file that will be embedded into the generated output. It will be embedded
+# before any generated declarions, but after the common includes and guards. The
+# file is loaded from the directory containing `cbindgen.toml`.
+before = "file.h"
 
 [export]
 # A list of additional items not used by exported functions to include in

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -16,6 +16,7 @@ use bindgen::parser::{self, Parse};
 pub struct Builder {
     config: Config,
     srcs: Vec<path::PathBuf>,
+    root: Option<path::PathBuf>,
     lib: Option<(path::PathBuf, Option<String>)>,
     lib_cargo: Option<Cargo>,
     std_types: bool,
@@ -27,6 +28,7 @@ impl Builder {
         Builder {
             config: Config::default(),
             srcs: Vec::new(),
+            root: None,
             lib: None,
             lib_cargo: None,
             std_types: true,
@@ -149,6 +151,12 @@ impl Builder {
             .export
             .rename
             .insert(String::from(from.as_ref()), String::from(to.as_ref()));
+        self
+    }
+
+    #[allow(unused)]
+    pub fn with_root<S: AsRef<path::Path>>(mut self, root: S) -> Builder {
+        self.root = Some(root.as_ref().to_path_buf());
         self
     }
 
@@ -346,6 +354,7 @@ impl Builder {
 
         Library::new(
             self.config,
+            self.root,
             result.constants,
             result.globals,
             result.enums,

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -14,10 +14,12 @@ use bindgen::ir::{Constant, Enum, Function, Item, ItemContainer, ItemMap};
 use bindgen::ir::{OpaqueItem, Path, Static, Struct, Typedef, Union};
 use bindgen::monomorph::Monomorphs;
 use bindgen::ItemType;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct Library {
     config: Config,
+    root: Option<PathBuf>,
     constants: ItemMap<Constant>,
     globals: ItemMap<Static>,
     enums: ItemMap<Enum>,
@@ -31,6 +33,7 @@ pub struct Library {
 impl Library {
     pub fn new(
         config: Config,
+        root: Option<PathBuf>,
         constants: ItemMap<Constant>,
         globals: ItemMap<Static>,
         enums: ItemMap<Enum>,
@@ -42,6 +45,7 @@ impl Library {
     ) -> Library {
         Library {
             config: config,
+            root: root,
             constants: constants,
             globals: globals,
             enums: enums,
@@ -115,6 +119,7 @@ impl Library {
 
         Ok(Bindings::new(
             self.config,
+            self.root,
             self.structs,
             constants,
             globals,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,19 +23,22 @@ use std::path::Path;
 /// A utility function for build scripts to generate bindings for a crate, using
 /// a `cbindgen.toml` if it exists.
 pub fn generate<P: AsRef<Path>>(crate_dir: P) -> Result<Bindings, Error> {
-    let config = Config::from_root_or_default(crate_dir.as_ref());
+    let config = ConfigLoader::from_root_or_default(crate_dir.as_ref());
+    let root = config.root().clone();
 
-    generate_with_config(crate_dir, config)
+    generate_with_config(crate_dir.as_ref(), &root, config.into())
 }
 
 /// A utility function for build scripts to generate bindings for a crate with a
 /// custom config.
 pub fn generate_with_config<P: AsRef<Path>>(
     crate_dir: P,
+    config_root: P,
     config: Config,
 ) -> Result<Bindings, Error> {
     Builder::new()
         .with_config(config)
+        .with_root(config_root)
         .with_crate(crate_dir)
         .generate()
 }

--- a/tests/expectations/both/embed.c
+++ b/tests/expectations/both/embed.c
@@ -1,0 +1,12 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef MY_PLATFORM
+#define API __declspec(dllimport)
+#else
+#define API
+#endif
+
+API void root(uint32_t x);

--- a/tests/expectations/embed.c
+++ b/tests/expectations/embed.c
@@ -1,0 +1,12 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef MY_PLATFORM
+#define API __declspec(dllimport)
+#else
+#define API
+#endif
+
+API void root(uint32_t x);

--- a/tests/expectations/embed.cpp
+++ b/tests/expectations/embed.cpp
@@ -1,0 +1,15 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+
+#ifdef MY_PLATFORM
+#define API __declspec(dllimport)
+#else
+#define API
+#endif
+
+extern "C" {
+
+API void root(uint32_t x);
+
+} // extern "C"

--- a/tests/expectations/tag/embed.c
+++ b/tests/expectations/tag/embed.c
@@ -1,0 +1,12 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef MY_PLATFORM
+#define API __declspec(dllimport)
+#else
+#define API
+#endif
+
+API void root(uint32_t x);

--- a/tests/rust/embed.h
+++ b/tests/rust/embed.h
@@ -1,0 +1,5 @@
+#ifdef MY_PLATFORM
+#define API __declspec(dllimport)
+#else
+#define API
+#endif

--- a/tests/rust/embed.rs
+++ b/tests/rust/embed.rs
@@ -1,0 +1,3 @@
+
+#[no_mangle]
+pub extern "C" fn root(x: u32) { }

--- a/tests/rust/embed.toml
+++ b/tests/rust/embed.toml
@@ -1,0 +1,6 @@
+[embed]
+before = "embed.h"
+
+[fn]
+prefix = "API"
+


### PR DESCRIPTION
Addresses #303. 

Note that this is a breaking change, as `generate_with_config` now requires a `config_root` to be passed, which specifies relative to what embed requests should be loaded.

It could theoretically be done without breaking that call, but then either

- `config` would have to contain implementation details about where it was loaded from, or
- `[embed]` is likely to break when used as it doesn't know where to get files from

