### PR TITLE
config: Add an option to make explicit renaming override the prefix setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ exclude = ["Bad"]
 prefix = "CAPI_"
 # Types of items that we'll generate.
 item_types = ["constants", "globals", "enums", "structs", "unions", "typedefs", "opaque", "functions"]
+# Whether applying rules in export.rename prevent export.prefix from applying.
+renaming_overrides_prefixing = true # default: false
 
 # Table of name conversions to apply to item names
 [export.rename]

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -223,6 +223,8 @@ pub struct ExportConfig {
     pub prefix: Option<String>,
     /// Types of items to generate.
     pub item_types: Vec<ItemType>,
+    /// Whether renaming overrides or extends prefixing.
+    pub renaming_overrides_prefixing: bool,
 }
 
 impl ExportConfig {
@@ -237,6 +239,9 @@ impl ExportConfig {
     pub(crate) fn rename(&self, item_name: &mut String) {
         if let Some(name) = self.rename.get(item_name) {
             *item_name = name.clone();
+            if self.renaming_overrides_prefixing {
+                return;
+            }
         }
         if let Some(ref prefix) = self.prefix {
             item_name.insert_str(0, &prefix);

--- a/tests/expectations/both/renaming-overrides-prefixing.c
+++ b/tests/expectations/both/renaming-overrides-prefixing.c
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct StyleA StyleA;
+
+typedef struct B {
+  int32_t x;
+  float y;
+} B;
+
+void root(const StyleA *a, B b);

--- a/tests/expectations/renaming-overrides-prefixing.c
+++ b/tests/expectations/renaming-overrides-prefixing.c
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct StyleA StyleA;
+
+typedef struct {
+  int32_t x;
+  float y;
+} B;
+
+void root(const StyleA *a, B b);

--- a/tests/expectations/renaming-overrides-prefixing.cpp
+++ b/tests/expectations/renaming-overrides-prefixing.cpp
@@ -1,0 +1,16 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+
+struct StyleA;
+
+struct B {
+  int32_t x;
+  float y;
+};
+
+extern "C" {
+
+void root(const StyleA *a, B b);
+
+} // extern "C"

--- a/tests/expectations/tag/renaming-overrides-prefixing.c
+++ b/tests/expectations/tag/renaming-overrides-prefixing.c
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct StyleA;
+
+struct B {
+  int32_t x;
+  float y;
+};
+
+void root(const struct StyleA *a, struct B b);

--- a/tests/rust/renaming-overrides-prefixing.rs
+++ b/tests/rust/renaming-overrides-prefixing.rs
@@ -1,0 +1,13 @@
+struct A {
+    x: i32,
+    y: f32,
+}
+
+#[repr(C)]
+struct B {
+    x: i32,
+    y: f32,
+}
+
+#[no_mangle]
+pub extern "C" fn root(a: *const A, b: B) {}

--- a/tests/rust/renaming-overrides-prefixing.toml
+++ b/tests/rust/renaming-overrides-prefixing.toml
@@ -1,0 +1,6 @@
+[export]
+prefix = "Style"
+renaming_overrides_prefixing = true
+
+[export.rename]
+"B" = "B" # B should remain unprefixed.


### PR DESCRIPTION
This is useful for opaque types or other types cbindgen doesn't otherwise understand.