### PR TITLE
Test crates

### DIFF
--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -251,7 +251,7 @@ impl Constant {
         };
 
         if !can_handle(&ty, expr) {
-            return Err("Unhanded const definition".to_owned());
+            return Err("Unhandled const definition".to_owned());
         }
 
         let mut lit = Literal::load(&expr)?;

--- a/test_crates/constant/Cargo.lock
+++ b/test_crates/constant/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "test"
+version = "0.0.1"
+

--- a/test_crates/constant/Cargo.toml
+++ b/test_crates/constant/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test"
+version = "0.0.1"
+authors = ["Jeff Muizelaar <jmuizelaar@mozilla.com>",
+           "Kartikaya Gupta <kats@mozilla.com>",
+           "Ryan Hunt <rhunt@eqrion.net>"]
+license = "MPL-2.0"
+description = "A tool for generating C bindings to Rust code."
+keywords = ["bindings", "ffi", "code-generation"]
+categories = ["external-ffi-bindings", "development-tools::ffi"]
+repository = "https://github.com/eqrion/cbindgen/"
+
+[lib]
+name = "constant"
+path = "./constant.rs"

--- a/test_crates/constant/constant.c
+++ b/test_crates/constant/constant.c
@@ -1,0 +1,14 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define FOO 10
+
+#define ZOM 3.14
+
+typedef struct {
+  int32_t x[FOO];
+} Foo;
+
+void root(Foo x);

--- a/test_crates/constant/constant.cpp
+++ b/test_crates/constant/constant.cpp
@@ -1,0 +1,17 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+
+static const uintptr_t FOO = 10;
+
+static const float ZOM = 3.14;
+
+struct Foo {
+  int32_t x[FOO];
+};
+
+extern "C" {
+
+void root(Foo x);
+
+} // extern "C"

--- a/test_crates/constant/constant.rs
+++ b/test_crates/constant/constant.rs
@@ -8,4 +8,4 @@ pub struct Foo {
 }
 
 #[no_mangle]
-pub extern "C" fn root(x: Foo) { }
+pub extern "C" fn root(x: Foo) {}

--- a/test_crates/constant/constant.rs
+++ b/test_crates/constant/constant.rs
@@ -1,9 +1,9 @@
-const FOO: i32 = 10;
+const FOO: usize = 10;
 const BAR: &'static str = "hello world";
 const ZOM: f32 = 3.14;
 
 #[repr(C)]
-struct Foo {
+pub struct Foo {
     x: [i32; FOO],
 }
 

--- a/tests/constants.rs
+++ b/tests/constants.rs
@@ -1,0 +1,20 @@
+
+extern crate cbindgen;
+
+mod utils;
+
+mod constant {
+    use cbindgen::Language;
+    use utils::test_a_crate::test_a_crate;
+
+
+    #[test]
+    fn test_c() {
+        test_a_crate("constant", Language::C);
+    }
+
+    #[test]
+    fn test_cxx() {
+        test_a_crate("constant", Language::Cxx);
+    }
+}

--- a/tests/constants.rs
+++ b/tests/constants.rs
@@ -1,4 +1,3 @@
-
 extern crate cbindgen;
 
 mod utils;
@@ -6,7 +5,6 @@ mod utils;
 mod constant {
     use cbindgen::Language;
     use utils::test_a_crate::test_a_crate;
-
 
     #[test]
     fn test_c() {

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,0 +1,2 @@
+
+pub mod test_a_crate;

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,2 +1,1 @@
-
 pub mod test_a_crate;

--- a/tests/utils/test_a_crate.rs
+++ b/tests/utils/test_a_crate.rs
@@ -1,6 +1,6 @@
+use std::fs;
 use std::fs::File;
 use std::io::Read;
-use std::fs;
 
 use cbindgen::Language;
 
@@ -22,7 +22,7 @@ pub fn test_a_crate(crate_to_test: &str, language: Language) {
 
     let ext = match language {
         Language::C => "c",
-        Language::Cxx => "cpp"
+        Language::Cxx => "cpp",
     };
 
     let mut old_file_contents = Vec::new();
@@ -33,4 +33,3 @@ pub fn test_a_crate(crate_to_test: &str, language: Language) {
 
     assert!(old_file_contents == new_file_contents);
 }
-

--- a/tests/utils/test_a_crate.rs
+++ b/tests/utils/test_a_crate.rs
@@ -1,0 +1,36 @@
+use std::fs::File;
+use std::io::Read;
+use std::fs;
+
+use cbindgen::Language;
+
+const TEST_CRATES: &str = "test_crates";
+
+pub fn test_a_crate(crate_to_test: &str, language: Language) {
+    let mut libdir = fs::canonicalize(".").unwrap();
+    libdir.push(TEST_CRATES);
+    libdir.push(crate_to_test);
+
+    let mut new_file_contents = Vec::new();
+
+    cbindgen::Builder::new()
+        .with_crate(&libdir)
+        .with_language(language.clone())
+        .generate()
+        .expect(&format!("Unable to generate bindings {}", crate_to_test))
+        .write(&mut new_file_contents);
+
+    let ext = match language {
+        Language::C => "c",
+        Language::Cxx => "cpp"
+    };
+
+    let mut old_file_contents = Vec::new();
+    {
+        let mut old_file = File::open(libdir.join(format!("{}.{}", crate_to_test, ext))).unwrap();
+        old_file.read_to_end(&mut old_file_contents).unwrap();
+    }
+
+    assert!(old_file_contents == new_file_contents);
+}
+


### PR DESCRIPTION
How about creating small test creates for all the integration tests and moving tests out of test.py.
So, in the end the integration tests can be done with usual `cargo test` instead of needing test.py

Doing this for all integration tests is work but it is mostly reshuffling files