### PR TITLE
Respect visibility of constants

### DIFF
--- a/src/bindgen/bitflags.rs
+++ b/src/bindgen/bitflags.rs
@@ -90,7 +90,7 @@ impl Flag {
         } = *self;
         quote! {
             #(#attrs)*
-            const #name : #struct_name = #struct_name { bits: #value };
+            pub const #name : #struct_name = #struct_name { bits: #value };
         }
     }
 }

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -691,6 +691,12 @@ impl Parse {
         let impl_path = ty.unwrap().get_root_path().unwrap();
 
         for item in items.into_iter() {
+            if let syn::Visibility::Public(_) = item.vis {
+            } else {
+                warn!("Skip {}::{} - (not `pub`).", crate_name, &item.ident);
+                return;
+            }
+
             let path = Path::new(item.ident.to_string());
             match Constant::load(
                 path,
@@ -736,6 +742,12 @@ impl Parse {
                 "Skip {}::{} - (const's outside of the binding crate are not used).",
                 crate_name, &item.ident
             );
+            return;
+        }
+
+        if let syn::Visibility::Public(_) = item.vis {
+        } else {
+            warn!("Skip {}::{} - (not `pub`).", crate_name, &item.ident);
             return;
         }
 

--- a/tests/rust/assoc_const_conflict.rs
+++ b/tests/rust/assoc_const_conflict.rs
@@ -1,7 +1,7 @@
 #[repr(C)]
 struct Foo {}
 
-const Foo_FOO: u32 = 42;
+pub const Foo_FOO: u32 = 42;
 
 impl Foo {
     const FOO: i32 = 0;

--- a/tests/rust/assoc_constant.rs
+++ b/tests/rust/assoc_constant.rs
@@ -2,9 +2,12 @@
 struct Foo {}
 
 impl Foo {
-    const GA: i32 = 10;
-    const BU: &'static str = "hello world";
-    const ZO: f32 = 3.14;
+    pub const GA: i32 = 10;
+    pub const BU: &'static str = "hello world";
+    pub const ZO: f32 = 3.14;
+
+    pub(crate) const DONT_EXPORT_CRATE: i32 = 20;
+    const DONT_EXPORT_PRIV: i32 = 30;
 }
 
 #[no_mangle]

--- a/tests/rust/const_conflict.rs
+++ b/tests/rust/const_conflict.rs
@@ -5,5 +5,5 @@ impl Foo {
     const FOO: i32 = 0;
 }
 
-const Foo_FOO: u32 = 42;
+pub const Foo_FOO: u32 = 42;
 

--- a/tests/rust/const_transparent.rs
+++ b/tests/rust/const_transparent.rs
@@ -1,4 +1,4 @@
 #[repr(transparent)]
 struct Transparent { field: u8 }
 
-const FOO: Transparent = Transparent { field: 0 };
+pub const FOO: Transparent = Transparent { field: 0 };

--- a/tests/rust/constant.rs
+++ b/tests/rust/constant.rs
@@ -1,12 +1,15 @@
-const FOO: i32 = 10;
-const BAR: &'static str = "hello world";
+pub const FOO: i32 = 10;
+pub const BAR: &'static str = "hello world";
 pub const DELIMITER: char = ':';
 pub const LEFTCURLY: char = '{';
 pub const QUOTE: char = '\'';
 pub const TAB: char = '\t';
 pub const NEWLINE: char = '\n';
 pub const HEART: char = '❤';
-const ZOM: f32 = 3.14;
+pub const ZOM: f32 = 3.14;
+
+pub(crate) const DONT_EXPORT_CRATE: i32 = 20;
+const DONT_EXPORT_PRIV: i32 = 30;
 
 #[repr(C)]
 struct Foo {

--- a/tests/rust/namespace_constant.rs
+++ b/tests/rust/namespace_constant.rs
@@ -1,6 +1,6 @@
-const FOO: i32 = 10;
-const BAR: &'static str = "hello world";
-const ZOM: f32 = 3.14;
+pub const FOO: i32 = 10;
+pub const BAR: &'static str = "hello world";
+pub const ZOM: f32 = 3.14;
 
 #[repr(C)]
 struct Foo {

--- a/tests/rust/namespaces_constant.rs
+++ b/tests/rust/namespaces_constant.rs
@@ -1,6 +1,6 @@
-const FOO: i32 = 10;
-const BAR: &'static str = "hello world";
-const ZOM: f32 = 3.14;
+pub const FOO: i32 = 10;
+pub const BAR: &'static str = "hello world";
+pub const ZOM: f32 = 3.14;
 
 #[repr(C)]
 struct Foo {

--- a/tests/rust/prefix.rs
+++ b/tests/rust/prefix.rs
@@ -1,4 +1,4 @@
-const LEN: i32 = 42;
+pub const LEN: i32 = 42;
 
 pub type NamedLenArray = [i32; LEN];
 pub type ValuedLenArray = [i32; 42];

--- a/tests/rust/prefixed_struct_literal.rs
+++ b/tests/rust/prefixed_struct_literal.rs
@@ -5,10 +5,10 @@ struct Foo {
 }
 
 impl Foo {
-    const FOO: Foo = Foo{ a: 42, b: 47, };
+    pub const FOO: Foo = Foo{ a: 42, b: 47, };
 }
 
-const BAR: Foo = Foo{ a: 42, b: 1337, };
+pub const BAR: Foo = Foo{ a: 42, b: 1337, };
 
 #[no_mangle]
 pub extern "C" fn root(x: Foo) { }

--- a/tests/rust/prefixed_struct_literal_deep.rs
+++ b/tests/rust/prefixed_struct_literal_deep.rs
@@ -10,7 +10,7 @@ struct Bar {
     a: i32,
 }
 
-const VAL: Foo = Foo {
+pub const VAL: Foo = Foo {
     a: 42,
     b: 1337,
     bar: Bar { a: 323 },

--- a/tests/rust/rename.rs
+++ b/tests/rust/rename.rs
@@ -31,7 +31,7 @@ type F = A;
 #[no_mangle]
 pub static G: i32 = 10;
 
-const H: i32 = 10;
+pub const H: i32 = 10;
 
 #[no_mangle]
 pub extern "C" fn root(

--- a/tests/rust/struct_literal.rs
+++ b/tests/rust/struct_literal.rs
@@ -10,14 +10,14 @@ struct Bar {
 }
 
 impl Foo {
-    const FOO: Foo = Foo { a: 42, b: 47, };
-    const FOO2: Self = Foo { a: 42, b: 47, };
-    const FOO3: Self = Self { a: 42, b: 47, };
-    const BAZ: Bar = Bar { a: 42, b: 47, };
+    pub const FOO: Foo = Foo { a: 42, b: 47, };
+    pub const FOO2: Self = Foo { a: 42, b: 47, };
+    pub const FOO3: Self = Self { a: 42, b: 47, };
+    pub const BAZ: Bar = Bar { a: 42, b: 47, };
 }
 
-const BAR: Foo = Foo { a: 42, b: 1337, };
-const BAZZ: Bar = Bar { a: 42, b: 1337, };
+pub const BAR: Foo = Foo { a: 42, b: 1337, };
+pub const BAZZ: Bar = Bar { a: 42, b: 1337, };
 
 #[no_mangle]
 pub extern "C" fn root(x: Foo, bar: Bar) { }


### PR DESCRIPTION
Fixes #123:
 - Adds visibility check for module-level constants.
 - Adds visibility check for associated constants.
 - Fixes bitflags expansion to produce public associated constants (as the real expansion does).

Admittedly, because it's a long-standing issue, it's now a breaking change for users who started to rely on current behaviour :(

[![](https://imgs.xkcd.com/comics/workflow.png)](https://xkcd.com/1172/)

That said, I think this is a right change as current behaviour is not compliant with Rust visibility rules and produces lots of noise for unintentionally exported constants.