### PR TITLE
Add C99 doc comment style

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ language = "[C|C++]"
 style = "[Both|Type|Tag]"
 # How the generated documentation should be commented.
 # C uses /* */; C++ uses //; Doxy is like C but with leading * per line.
-documentation_style = "[C, C++, Doxy]"
+documentation_style = "[C, C99, C++, Doxy]"
 
 
 [defines]

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ language = "[C|C++]"
 # A rule to use to select style of declaration in C, tagname vs typedef
 style = "[Both|Type|Tag]"
 # How the generated documentation should be commented.
-# C uses /* */; C++ uses //; Doxy is like C but with leading * per line.
+# C uses /* */; C99 uses //; C++ uses ///; Doxy is like C but with leading * per line.
 documentation_style = "[C, C99, C++, Doxy]"
 
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -104,6 +104,7 @@ deserialize_enum_str!(Layout);
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub enum DocumentationStyle {
     C,
+    C99,
     Doxy,
     Cxx,
     Auto,
@@ -115,6 +116,7 @@ impl FromStr for DocumentationStyle {
     fn from_str(s: &str) -> Result<DocumentationStyle, Self::Err> {
         match s.to_lowercase().as_ref() {
             "c" => Ok(DocumentationStyle::C),
+            "c99" => Ok(DocumentationStyle::C99),
             "cxx" => Ok(DocumentationStyle::Cxx),
             "c++" => Ok(DocumentationStyle::Cxx),
             "doxy" => Ok(DocumentationStyle::Doxy),

--- a/src/bindgen/ir/documentation.rs
+++ b/src/bindgen/ir/documentation.rs
@@ -67,6 +67,7 @@ impl Source for Documentation {
             match style {
                 DocumentationStyle::C => out.write(""),
                 DocumentationStyle::Doxy => out.write(" *"),
+                DocumentationStyle::C99 => out.write("//"),
                 DocumentationStyle::Cxx => out.write("///"),
                 DocumentationStyle::Auto => unreachable!(), // Auto case should always be covered
             }

--- a/tests/expectations/both/docstyle_c99.c
+++ b/tests/expectations/both/docstyle_c99.c
@@ -1,0 +1,7 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+// The root of all evil.
+void root(void);

--- a/tests/expectations/docstyle_c99.c
+++ b/tests/expectations/docstyle_c99.c
@@ -1,0 +1,7 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+// The root of all evil.
+void root(void);

--- a/tests/expectations/docstyle_c99.cpp
+++ b/tests/expectations/docstyle_c99.cpp
@@ -1,0 +1,10 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+
+extern "C" {
+
+// The root of all evil.
+void root();
+
+} // extern "C"

--- a/tests/expectations/tag/docstyle_c99.c
+++ b/tests/expectations/tag/docstyle_c99.c
@@ -1,0 +1,7 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+// The root of all evil.
+void root(void);

--- a/tests/rust/docstyle_c99.rs
+++ b/tests/rust/docstyle_c99.rs
@@ -1,0 +1,4 @@
+/// The root of all evil.
+#[no_mangle]
+pub extern "C" fn root() {
+}

--- a/tests/rust/docstyle_c99.toml
+++ b/tests/rust/docstyle_c99.toml
@@ -1,0 +1,1 @@
+documentation_style = "c99"


### PR DESCRIPTION
In modern C (post-C99) it's common to just use `// double-slash comments`, but currently cbindgen provides only `/* block-comment */` and `/// triple-slash comment` variants.