### PR TITLE
Problem: conditional structure members are always present

### DIFF
--- a/tests/expectations/both/cfg.c
+++ b/tests/expectations/both/cfg.c
@@ -21,6 +21,13 @@ enum FooType {
 typedef uint32_t FooType;
 #endif
 
+typedef struct ConditionalField {
+  #if defined(X11)
+  int32_t field
+  #endif
+  ;
+} ConditionalField;
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 typedef struct FooHandle {
   FooType ty;
@@ -36,6 +43,8 @@ typedef struct BarHandle {
   float y;
 } BarHandle;
 #endif
+
+void cond(ConditionalField a);
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(FooHandle a);

--- a/tests/expectations/cfg.c
+++ b/tests/expectations/cfg.c
@@ -21,6 +21,13 @@ enum FooType {
 typedef uint32_t FooType;
 #endif
 
+typedef struct {
+  #if defined(X11)
+  int32_t field
+  #endif
+  ;
+} ConditionalField;
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 typedef struct {
   FooType ty;
@@ -36,6 +43,8 @@ typedef struct {
   float y;
 } BarHandle;
 #endif
+
+void cond(ConditionalField a);
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(FooHandle a);

--- a/tests/expectations/cfg.cpp
+++ b/tests/expectations/cfg.cpp
@@ -18,6 +18,13 @@ enum class FooType : uint32_t {
 };
 #endif
 
+struct ConditionalField {
+  #if defined(X11)
+  int32_t field
+  #endif
+  ;
+};
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 struct FooHandle {
   FooType ty;
@@ -35,6 +42,8 @@ struct BarHandle {
 #endif
 
 extern "C" {
+
+void cond(ConditionalField a);
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(FooHandle a);

--- a/tests/expectations/tag/cfg.c
+++ b/tests/expectations/tag/cfg.c
@@ -21,6 +21,13 @@ enum FooType {
 typedef uint32_t FooType;
 #endif
 
+struct ConditionalField {
+  #if defined(X11)
+  int32_t field
+  #endif
+  ;
+};
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 struct FooHandle {
   FooType ty;
@@ -36,6 +43,8 @@ struct BarHandle {
   float y;
 };
 #endif
+
+void cond(struct ConditionalField a);
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(struct FooHandle a);

--- a/tests/rust/cfg.rs
+++ b/tests/rust/cfg.rs
@@ -30,6 +30,12 @@ struct BarHandle {
     y: f32,
 }
 
+#[repr(C)]
+struct ConditionalField {
+    #[cfg(x11)]
+    field: i32,
+}
+
 #[cfg(all(unix, x11))]
 #[no_mangle]
 pub extern "C" fn root(a: FooHandle)
@@ -38,4 +44,8 @@ pub extern "C" fn root(a: FooHandle)
 #[cfg(any(windows, target_pointer_width="32"))]
 #[no_mangle]
 pub extern "C" fn root(a: BarHandle)
+{ }
+
+#[no_mangle]
+pub extern "C" fn cond(a: ConditionalField)
 { }


### PR DESCRIPTION
Given something like:

```rust
struct Foo {
  #[cfg(unix)]
  bar: i32
}
```

we will always get a structure with `bar` field, regardless of
conditions.

Solution: pass conditional configuration for fields
and generate conditional #ifdef for them as well.

Current solution isn't absolutely perfect as it still inserts
semicolons after the conditions; but at least in the meanwhile this
seems to be an adequate solution.