### PR TITLE
 First implementation of Rust 2018 modules.

### DIFF
--- a/src/bindgen/cargo/cargo.rs
+++ b/src/bindgen/cargo/cargo.rs
@@ -6,21 +6,17 @@ use std::path::{Path, PathBuf};
 
 use bindgen::cargo::cargo_expand;
 use bindgen::cargo::cargo_lock::{self, Lock};
+pub(crate) use bindgen::cargo::cargo_metadata::PackageRef;
 use bindgen::cargo::cargo_metadata::{self, Metadata};
 use bindgen::cargo::cargo_toml;
 use bindgen::error::Error;
+use bindgen::ir::Cfg;
 
 /// Parse a dependency string used in Cargo.lock
 fn parse_dep_string(dep_string: &str) -> (&str, &str) {
     let split: Vec<&str> = dep_string.split_whitespace().collect();
 
     (split[0], split[1])
-}
-
-/// A reference to a package including it's name and the specific version.
-pub(crate) struct PackageRef {
-    pub name: String,
-    pub version: String,
 }
 
 /// A collection of metadata for a library from cargo.
@@ -88,86 +84,62 @@ impl Cargo {
         self.find_pkg_ref(&self.binding_crate_name).unwrap()
     }
 
+    pub(crate) fn dependencies(&self, package: &PackageRef) -> Vec<(PackageRef, Option<Cfg>)> {
+        let lock = self.lock.as_ref().unwrap();
+
+        let mut dependencies = None;
+
+        // Find the dependencies listing in the lockfile
+        if let &Some(ref root) = &lock.root {
+            if root.name == package.name && root.version == package.version {
+                dependencies = root.dependencies.as_ref();
+            }
+        }
+        if dependencies.is_none() {
+            if let Some(ref lock_packages) = lock.package {
+                for lock_package in lock_packages {
+                    if lock_package.name == package.name && lock_package.version == package.version
+                    {
+                        dependencies = lock_package.dependencies.as_ref();
+                        break;
+                    }
+                }
+            }
+        }
+        if dependencies.is_none() {
+            return vec![];
+        }
+
+        dependencies
+            .unwrap()
+            .iter()
+            .map(|dep| {
+                let (dep_name, dep_version) = parse_dep_string(dep);
+
+                // Try to find the cfgs in the Cargo.toml
+                let cfg = self
+                    .metadata
+                    .packages
+                    .get(package)
+                    .and_then(|meta_package| meta_package.dependencies.get(dep_name))
+                    .and_then(|meta_dep| Cfg::load_metadata(meta_dep));
+
+                let package_ref = PackageRef {
+                    name: dep_name.to_owned(),
+                    version: dep_version.to_owned(),
+                };
+
+                (package_ref, cfg)
+            })
+            .collect()
+    }
+
     /// Finds the package reference in `cargo metadata` that has `package_name`
     /// ignoring the version.
     fn find_pkg_ref(&self, package_name: &str) -> Option<PackageRef> {
         for package in &self.metadata.packages {
-            if package.name == package_name {
-                return Some(PackageRef {
-                    name: package_name.to_owned(),
-                    version: package.version.clone(),
-                });
-            }
-        }
-        None
-    }
-
-    /// Finds the package reference for a dependency of a crate using
-    /// `Cargo.lock`.
-    pub(crate) fn find_dep_ref(
-        &self,
-        package: &PackageRef,
-        dependency_name: &str,
-    ) -> Option<PackageRef> {
-        if self.lock.is_none() {
-            return None;
-        }
-        let lock = self.lock.as_ref().unwrap();
-
-        // the name in Cargo.lock could use '-' instead of '_', so we need to
-        // look for that too.
-        let mut dependency_name = dependency_name;
-        let mut replaced_name = dependency_name.replace("_", "-");
-
-        // The Cargo.toml may contain a rename which we need to apply
-        for metadata_package in &self.metadata.packages {
-            if metadata_package.name == package.name {
-                for dep in &metadata_package.dependencies {
-                    if let Some(ref rename) = dep.rename {
-                        if rename == dependency_name || rename == &replaced_name {
-                            dependency_name = &dep.name;
-                            replaced_name = dependency_name.replace("_", "-");
-                        }
-                    }
-                }
-            }
-        }
-
-        if let &Some(ref root) = &lock.root {
-            if root.name == package.name && root.version == package.version {
-                if let Some(ref deps) = root.dependencies {
-                    for dep in deps {
-                        let (name, version) = parse_dep_string(dep);
-
-                        if name == dependency_name || name == &replaced_name {
-                            return Some(PackageRef {
-                                name: name.to_owned(),
-                                version: version.to_owned(),
-                            });
-                        }
-                    }
-                }
-                return None;
-            }
-        }
-
-        if let &Some(ref lock_packages) = &lock.package {
-            for lock_package in lock_packages {
-                if lock_package.name == package.name && lock_package.version == package.version {
-                    if let Some(ref deps) = lock_package.dependencies {
-                        for dep in deps {
-                            let (name, version) = parse_dep_string(dep);
-
-                            if name == dependency_name || name == &replaced_name {
-                                return Some(PackageRef {
-                                    name: name.to_owned(),
-                                    version: version.to_owned(),
-                                });
-                            }
-                        }
-                    }
-                    return None;
-                }
+            if package.name_and_version.name == package_name {
+                return Some(package.name_and_version.clone());
             }
         }
         None
@@ -176,14 +148,14 @@ impl Cargo {
     /// Finds the directory for a specified package reference.
     #[allow(unused)]
     pub(crate) fn find_crate_dir(&self, package: &PackageRef) -> Option<PathBuf> {
-        for meta_package in &self.metadata.packages {
-            if meta_package.name == package.name && meta_package.version == package.version {
-                return Path::new(&meta_package.manifest_path)
+        self.metadata
+            .packages
+            .get(package)
+            .and_then(|meta_package| {
+                Path::new(&meta_package.manifest_path)
                     .parent()
-                    .map(|x| x.to_owned());
-            }
-        }
-        None
+                    .map(|x| x.to_owned())
+            })
     }
 
     /// Finds `src/lib.rs` for a specified package reference.
@@ -194,8 +166,10 @@ impl Cargo {
         let kind_cdylib = String::from("cdylib");
         let kind_dylib = String::from("dylib");
 
-        for meta_package in &self.metadata.packages {
-            if meta_package.name == package.name && meta_package.version == package.version {
+        self.metadata
+            .packages
+            .get(package)
+            .and_then(|meta_package| {
                 for target in &meta_package.targets {
                     if target.kind.contains(&kind_lib)
                         || target.kind.contains(&kind_staticlib)
@@ -206,10 +180,8 @@ impl Cargo {
                         return Some(PathBuf::from(&target.src_path));
                     }
                 }
-                break;
-            }
-        }
-        None
+                None
+            })
     }
 
     pub(crate) fn expand_crate(

--- a/tests/expectations/both/rename-crate.c
+++ b/tests/expectations/both/rename-crate.c
@@ -3,6 +3,24 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#if !defined(DEFINE_FREEBSD)
+typedef struct NoExternTy {
+  uint8_t field;
+} NoExternTy;
+#endif
+
+#if !defined(DEFINE_FREEBSD)
+typedef struct ContainsNoExternTy {
+  NoExternTy field;
+} ContainsNoExternTy;
+#endif
+
+#if defined(DEFINE_FREEBSD)
+typedef struct ContainsNoExternTy {
+  uint64_t field;
+} ContainsNoExternTy;
+#endif
+
 typedef struct RenamedTy {
   uint64_t y;
 } RenamedTy;
@@ -10,6 +28,8 @@ typedef struct RenamedTy {
 typedef struct Foo {
   int32_t x;
 } Foo;
+
+void no_extern_func(ContainsNoExternTy a);
 
 void renamed_func(RenamedTy a);
 

--- a/tests/expectations/rename-crate.c
+++ b/tests/expectations/rename-crate.c
@@ -3,6 +3,24 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#if !defined(DEFINE_FREEBSD)
+typedef struct {
+  uint8_t field;
+} NoExternTy;
+#endif
+
+#if !defined(DEFINE_FREEBSD)
+typedef struct {
+  NoExternTy field;
+} ContainsNoExternTy;
+#endif
+
+#if defined(DEFINE_FREEBSD)
+typedef struct {
+  uint64_t field;
+} ContainsNoExternTy;
+#endif
+
 typedef struct {
   uint64_t y;
 } RenamedTy;
@@ -10,6 +28,8 @@ typedef struct {
 typedef struct {
   int32_t x;
 } Foo;
+
+void no_extern_func(ContainsNoExternTy a);
 
 void renamed_func(RenamedTy a);
 

--- a/tests/expectations/rename-crate.cpp
+++ b/tests/expectations/rename-crate.cpp
@@ -2,6 +2,24 @@
 #include <cstdint>
 #include <cstdlib>
 
+#if !defined(DEFINE_FREEBSD)
+struct NoExternTy {
+  uint8_t field;
+};
+#endif
+
+#if !defined(DEFINE_FREEBSD)
+struct ContainsNoExternTy {
+  NoExternTy field;
+};
+#endif
+
+#if defined(DEFINE_FREEBSD)
+struct ContainsNoExternTy {
+  uint64_t field;
+};
+#endif
+
 struct RenamedTy {
   uint64_t y;
 };
@@ -11,6 +29,8 @@ struct Foo {
 };
 
 extern "C" {
+
+void no_extern_func(ContainsNoExternTy a);
 
 void renamed_func(RenamedTy a);
 

--- a/tests/expectations/tag/rename-crate.c
+++ b/tests/expectations/tag/rename-crate.c
@@ -3,6 +3,24 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#if !defined(DEFINE_FREEBSD)
+struct NoExternTy {
+  uint8_t field;
+};
+#endif
+
+#if !defined(DEFINE_FREEBSD)
+struct ContainsNoExternTy {
+  struct NoExternTy field;
+};
+#endif
+
+#if defined(DEFINE_FREEBSD)
+struct ContainsNoExternTy {
+  uint64_t field;
+};
+#endif
+
 struct RenamedTy {
   uint64_t y;
 };
@@ -10,6 +28,8 @@ struct RenamedTy {
 struct Foo {
   int32_t x;
 };
+
+void no_extern_func(struct ContainsNoExternTy a);
 
 void renamed_func(struct RenamedTy a);
 

--- a/tests/rust/rename-crate/Cargo.lock
+++ b/tests/rust/rename-crate/Cargo.lock
@@ -5,8 +5,15 @@ name = "dependency"
 version = "0.1.0"
 
 [[package]]
+name = "no-extern"
+version = "0.1.0"
+
+[[package]]
 name = "old-dep-name"
 version = "0.1.0"
+dependencies = [
+ "no-extern 0.1.0",
+]
 
 [[package]]
 name = "rename-crate"

--- a/tests/rust/rename-crate/cbindgen.toml
+++ b/tests/rust/rename-crate/cbindgen.toml
@@ -1,2 +1,4 @@
 [parse]
 parse_deps = true
+[defines]
+"target_os = freebsd" = "DEFINE_FREEBSD"

--- a/tests/rust/rename-crate/no-extern/Cargo.lock
+++ b/tests/rust/rename-crate/no-extern/Cargo.lock
@@ -4,10 +4,3 @@
 name = "no-extern"
 version = "0.1.0"
 
-[[package]]
-name = "old-dep-name"
-version = "0.1.0"
-dependencies = [
- "no-extern 0.1.0",
-]
-

--- a/tests/rust/rename-crate/no-extern/Cargo.toml
+++ b/tests/rust/rename-crate/no-extern/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "no-extern"
+version = "0.1.0"
+authors = ["cbindgen"]
+edition = "2018"
+
+[dependencies]

--- a/tests/rust/rename-crate/no-extern/src/lib.rs
+++ b/tests/rust/rename-crate/no-extern/src/lib.rs
@@ -1,0 +1,4 @@
+#[repr(C)]
+pub struct NoExternTy {
+    field: u8,
+}

--- a/tests/rust/rename-crate/old-dep/Cargo.toml
+++ b/tests/rust/rename-crate/old-dep/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 authors = ["cbindgen"]
 edition = "2018"
 
-[dependencies]
+[target.'cfg(not(target_os = "freebsd"))'.dependencies]
+no-extern = { path = "../no-extern/" }

--- a/tests/rust/rename-crate/old-dep/src/lib.rs
+++ b/tests/rust/rename-crate/old-dep/src/lib.rs
@@ -2,3 +2,15 @@
 pub struct RenamedTy {
     y: u64,
 }
+
+#[cfg(not(target_os = "freebsd"))]
+#[repr(C)]
+pub struct ContainsNoExternTy {
+    pub field: no_extern::NoExternTy,
+}
+
+#[cfg(target_os = "freebsd")]
+#[repr(C)]
+pub struct ContainsNoExternTy {
+    pub field: u64,
+}

--- a/tests/rust/rename-crate/src/lib.rs
+++ b/tests/rust/rename-crate/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(unused_variables)]
+
 extern crate dependency as internal_name;
 extern crate renamed_dep;
 
@@ -10,4 +12,9 @@ pub extern "C" fn root(a: Foo) {
 
 #[no_mangle]
 pub extern "C" fn renamed_func(a: RenamedTy) {
+}
+
+
+#[no_mangle]
+pub extern "C" fn no_extern_func(a: ContainsNoExternTy) {
 }


### PR DESCRIPTION
This changes our implementation to always ignore `extern crates`, favouring
collecting metadata from `cargo metadata` (the Cargo.toml) and `Cargo.lock`.

Future work might be needed to make this more robust.

Closes #331 