### PR TITLE
ir: Add the possibility to auto-generate destructors of tagged unions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ derive_gte = false
 [enum]
 # A rule to use to rename enum variants
 rename_variants = "[None|GeckoCase|LowerCase|UpperCase|PascalCase|CamelCase|SnakeCase|ScreamingSnakeCase|QualifiedScreamingSnakeCase]"
+# Whether tagged enums should generate destructors. This makes them dangerous to
+# pass by value.
+derive_tagged_enum_destructor = false
 
 ```
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -398,6 +398,8 @@ pub struct EnumConfig {
     pub cast_assert_name: Option<String>,
     /// The way to annotation this enum as #[must_use].
     pub must_use: Option<String>,
+    /// Whether to generate destructors of tagged enums.
+    pub derive_tagged_enum_destructor: bool,
 }
 
 impl EnumConfig {
@@ -424,6 +426,12 @@ impl EnumConfig {
             return x;
         }
         self.derive_mut_casts
+    }
+    pub(crate) fn derive_tagged_enum_destructor(&self, annotations: &AnnotationSet) -> bool {
+        if let Some(x) = annotations.bool("derive-tagged-enum-destructor") {
+            return x;
+        }
+        self.derive_tagged_enum_destructor
     }
 }
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -873,7 +873,9 @@ impl Source for Enum {
             }
 
             if config.language == Language::Cxx
-                && self.annotations.bool("destructor").unwrap_or(false)
+                && config
+                    .enumeration
+                    .derive_tagged_enum_destructor(&self.annotations)
             {
                 out.new_line();
                 out.new_line();

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -872,6 +872,33 @@ impl Source for Enum {
                 }
             }
 
+            if config.language == Language::Cxx
+                && self.annotations.bool("destructor").unwrap_or(false)
+            {
+                out.new_line();
+                out.new_line();
+                write!(out, "~{}()", self.export_name);
+                out.open_brace();
+                write!(out, "switch (tag)");
+                out.open_brace();
+                for variant in &self.variants {
+                    if let Some((ref variant_name, ref item)) = variant.body {
+                        write!(
+                            out,
+                            "case {}::{}: {}.~{}(); break;",
+                            self.tag.as_ref().unwrap(),
+                            variant.export_name,
+                            variant_name,
+                            item.export_name(),
+                        );
+                        out.new_line();
+                    }
+                }
+                write!(out, "default: break;");
+                out.close_brace(false);
+                out.close_brace(false);
+            }
+
             if let Some(body) = config.export.extra_body(&self.path) {
                 out.write_raw_block(body);
             }

--- a/tests/expectations/both/destructor.c
+++ b/tests/expectations/both/destructor.c
@@ -75,4 +75,55 @@ typedef struct Foo_u32 {
   };
 } Foo_u32;
 
-void root(const Foo_u32 *p);
+typedef struct Polygon_i32 {
+  FillRule fill;
+  OwnedSlice_i32 coordinates;
+} Polygon_i32;
+
+enum Baz_i32_Tag {
+  Bar2_i32,
+  Polygon21_i32,
+  Slice21_i32,
+  Slice22_i32,
+  Slice23_i32,
+  Slice24_i32,
+};
+typedef uint8_t Baz_i32_Tag;
+
+typedef struct Polygon21_Body_i32 {
+  Baz_i32_Tag tag;
+  Polygon_i32 _0;
+} Polygon21_Body_i32;
+
+typedef struct Slice21_Body_i32 {
+  Baz_i32_Tag tag;
+  OwnedSlice_i32 _0;
+} Slice21_Body_i32;
+
+typedef struct Slice22_Body_i32 {
+  Baz_i32_Tag tag;
+  OwnedSlice_i32 _0;
+} Slice22_Body_i32;
+
+typedef struct Slice23_Body_i32 {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice23_Body_i32;
+
+typedef struct Slice24_Body_i32 {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice24_Body_i32;
+
+typedef union Baz_i32 {
+  Baz_i32_Tag tag;
+  Polygon21_Body_i32 polygon21;
+  Slice21_Body_i32 slice21;
+  Slice22_Body_i32 slice22;
+  Slice23_Body_i32 slice23;
+  Slice24_Body_i32 slice24;
+} Baz_i32;
+
+void root(const Foo_u32 *a, const Baz_i32 *b);

--- a/tests/expectations/both/destructor.c
+++ b/tests/expectations/both/destructor.c
@@ -1,0 +1,78 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum FillRule {
+  A,
+  B,
+};
+typedef uint8_t FillRule;
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+typedef struct OwnedSlice_u32 {
+  uintptr_t len;
+  uint32_t *ptr;
+} OwnedSlice_u32;
+
+typedef struct Polygon_u32 {
+  FillRule fill;
+  OwnedSlice_u32 coordinates;
+} Polygon_u32;
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+typedef struct OwnedSlice_i32 {
+  uintptr_t len;
+  int32_t *ptr;
+} OwnedSlice_i32;
+
+enum Foo_u32_Tag {
+  Bar_u32,
+  Polygon1_u32,
+  Slice1_u32,
+  Slice2_u32,
+  Slice3_u32,
+  Slice4_u32,
+};
+typedef uint8_t Foo_u32_Tag;
+
+typedef struct Polygon1_Body_u32 {
+  Polygon_u32 _0;
+} Polygon1_Body_u32;
+
+typedef struct Slice1_Body_u32 {
+  OwnedSlice_u32 _0;
+} Slice1_Body_u32;
+
+typedef struct Slice2_Body_u32 {
+  OwnedSlice_i32 _0;
+} Slice2_Body_u32;
+
+typedef struct Slice3_Body_u32 {
+  FillRule fill;
+  OwnedSlice_u32 coords;
+} Slice3_Body_u32;
+
+typedef struct Slice4_Body_u32 {
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice4_Body_u32;
+
+typedef struct Foo_u32 {
+  Foo_u32_Tag tag;
+  union {
+    Polygon1_Body_u32 polygon1;
+    Slice1_Body_u32 slice1;
+    Slice2_Body_u32 slice2;
+    Slice3_Body_u32 slice3;
+    Slice4_Body_u32 slice4;
+  };
+} Foo_u32;
+
+void root(const Foo_u32 *p);

--- a/tests/expectations/both/destructor.c
+++ b/tests/expectations/both/destructor.c
@@ -126,4 +126,36 @@ typedef union Baz_i32 {
   Slice24_Body_i32 slice24;
 } Baz_i32;
 
-void root(const Foo_u32 *a, const Baz_i32 *b);
+enum Taz_Tag {
+  Bar3,
+  Taz1,
+};
+typedef uint8_t Taz_Tag;
+
+typedef struct Taz1_Body {
+  Taz_Tag tag;
+  int32_t _0;
+} Taz1_Body;
+
+typedef union Taz {
+  Taz_Tag tag;
+  Taz1_Body taz1;
+} Taz;
+
+enum Tazz_Tag {
+  Bar4,
+  Taz2,
+};
+typedef uint8_t Tazz_Tag;
+
+typedef struct Taz2_Body {
+  Tazz_Tag tag;
+  int32_t _0;
+} Taz2_Body;
+
+typedef union Tazz {
+  Tazz_Tag tag;
+  Taz2_Body taz2;
+} Tazz;
+
+void root(const Foo_u32 *a, const Baz_i32 *b, const Taz *c, Tazz d);

--- a/tests/expectations/destructor.c
+++ b/tests/expectations/destructor.c
@@ -75,4 +75,55 @@ typedef struct {
   };
 } Foo_u32;
 
-void root(const Foo_u32 *p);
+typedef struct {
+  FillRule fill;
+  OwnedSlice_i32 coordinates;
+} Polygon_i32;
+
+enum Baz_i32_Tag {
+  Bar2_i32,
+  Polygon21_i32,
+  Slice21_i32,
+  Slice22_i32,
+  Slice23_i32,
+  Slice24_i32,
+};
+typedef uint8_t Baz_i32_Tag;
+
+typedef struct {
+  Baz_i32_Tag tag;
+  Polygon_i32 _0;
+} Polygon21_Body_i32;
+
+typedef struct {
+  Baz_i32_Tag tag;
+  OwnedSlice_i32 _0;
+} Slice21_Body_i32;
+
+typedef struct {
+  Baz_i32_Tag tag;
+  OwnedSlice_i32 _0;
+} Slice22_Body_i32;
+
+typedef struct {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice23_Body_i32;
+
+typedef struct {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice24_Body_i32;
+
+typedef union {
+  Baz_i32_Tag tag;
+  Polygon21_Body_i32 polygon21;
+  Slice21_Body_i32 slice21;
+  Slice22_Body_i32 slice22;
+  Slice23_Body_i32 slice23;
+  Slice24_Body_i32 slice24;
+} Baz_i32;
+
+void root(const Foo_u32 *a, const Baz_i32 *b);

--- a/tests/expectations/destructor.c
+++ b/tests/expectations/destructor.c
@@ -126,4 +126,36 @@ typedef union {
   Slice24_Body_i32 slice24;
 } Baz_i32;
 
-void root(const Foo_u32 *a, const Baz_i32 *b);
+enum Taz_Tag {
+  Bar3,
+  Taz1,
+};
+typedef uint8_t Taz_Tag;
+
+typedef struct {
+  Taz_Tag tag;
+  int32_t _0;
+} Taz1_Body;
+
+typedef union {
+  Taz_Tag tag;
+  Taz1_Body taz1;
+} Taz;
+
+enum Tazz_Tag {
+  Bar4,
+  Taz2,
+};
+typedef uint8_t Tazz_Tag;
+
+typedef struct {
+  Tazz_Tag tag;
+  int32_t _0;
+} Taz2_Body;
+
+typedef union {
+  Tazz_Tag tag;
+  Taz2_Body taz2;
+} Tazz;
+
+void root(const Foo_u32 *a, const Baz_i32 *b, const Taz *c, Tazz d);

--- a/tests/expectations/destructor.c
+++ b/tests/expectations/destructor.c
@@ -1,0 +1,78 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum FillRule {
+  A,
+  B,
+};
+typedef uint8_t FillRule;
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+typedef struct {
+  uintptr_t len;
+  uint32_t *ptr;
+} OwnedSlice_u32;
+
+typedef struct {
+  FillRule fill;
+  OwnedSlice_u32 coordinates;
+} Polygon_u32;
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+typedef struct {
+  uintptr_t len;
+  int32_t *ptr;
+} OwnedSlice_i32;
+
+enum Foo_u32_Tag {
+  Bar_u32,
+  Polygon1_u32,
+  Slice1_u32,
+  Slice2_u32,
+  Slice3_u32,
+  Slice4_u32,
+};
+typedef uint8_t Foo_u32_Tag;
+
+typedef struct {
+  Polygon_u32 _0;
+} Polygon1_Body_u32;
+
+typedef struct {
+  OwnedSlice_u32 _0;
+} Slice1_Body_u32;
+
+typedef struct {
+  OwnedSlice_i32 _0;
+} Slice2_Body_u32;
+
+typedef struct {
+  FillRule fill;
+  OwnedSlice_u32 coords;
+} Slice3_Body_u32;
+
+typedef struct {
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice4_Body_u32;
+
+typedef struct {
+  Foo_u32_Tag tag;
+  union {
+    Polygon1_Body_u32 polygon1;
+    Slice1_Body_u32 slice1;
+    Slice2_Body_u32 slice2;
+    Slice3_Body_u32 slice3;
+    Slice4_Body_u32 slice4;
+  };
+} Foo_u32;
+
+void root(const Foo_u32 *p);

--- a/tests/expectations/destructor.cpp
+++ b/tests/expectations/destructor.cpp
@@ -1,0 +1,82 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+
+enum class FillRule : uint8_t {
+  A,
+  B,
+};
+
+/// This will have a destructor manually implemented via variant_body, and
+/// similarly a Drop impl in Rust.
+template<typename T>
+struct OwnedSlice {
+  uintptr_t len;
+  T *ptr;
+};
+
+template<typename LengthPercentage>
+struct Polygon {
+  FillRule fill;
+  OwnedSlice<LengthPercentage> coordinates;
+};
+
+template<typename T>
+struct Foo {
+  enum class Tag : uint8_t {
+    Bar,
+    Polygon1,
+    Slice1,
+    Slice2,
+    Slice3,
+    Slice4,
+  };
+
+  struct Polygon1_Body {
+    Polygon<T> _0;
+  };
+
+  struct Slice1_Body {
+    OwnedSlice<T> _0;
+  };
+
+  struct Slice2_Body {
+    OwnedSlice<int32_t> _0;
+  };
+
+  struct Slice3_Body {
+    FillRule fill;
+    OwnedSlice<T> coords;
+  };
+
+  struct Slice4_Body {
+    FillRule fill;
+    OwnedSlice<int32_t> coords;
+  };
+
+  Tag tag;
+  union {
+    Polygon1_Body polygon1;
+    Slice1_Body slice1;
+    Slice2_Body slice2;
+    Slice3_Body slice3;
+    Slice4_Body slice4;
+  };
+
+  ~Foo() {
+    switch (tag) {
+      case Tag::Polygon1: polygon1.~Polygon1_Body(); break;
+      case Tag::Slice1: slice1.~Slice1_Body(); break;
+      case Tag::Slice2: slice2.~Slice2_Body(); break;
+      case Tag::Slice3: slice3.~Slice3_Body(); break;
+      case Tag::Slice4: slice4.~Slice4_Body(); break;
+      default: break;
+    }
+  }
+};
+
+extern "C" {
+
+void root(const Foo<uint32_t> *p);
+
+} // extern "C"

--- a/tests/expectations/destructor.cpp
+++ b/tests/expectations/destructor.cpp
@@ -75,8 +75,67 @@ struct Foo {
   }
 };
 
+template<typename T>
+union Baz {
+  enum class Tag : uint8_t {
+    Bar2,
+    Polygon21,
+    Slice21,
+    Slice22,
+    Slice23,
+    Slice24,
+  };
+
+  struct Polygon21_Body {
+    Tag tag;
+    Polygon<T> _0;
+  };
+
+  struct Slice21_Body {
+    Tag tag;
+    OwnedSlice<T> _0;
+  };
+
+  struct Slice22_Body {
+    Tag tag;
+    OwnedSlice<int32_t> _0;
+  };
+
+  struct Slice23_Body {
+    Tag tag;
+    FillRule fill;
+    OwnedSlice<T> coords;
+  };
+
+  struct Slice24_Body {
+    Tag tag;
+    FillRule fill;
+    OwnedSlice<int32_t> coords;
+  };
+
+  struct {
+    Tag tag;
+  };
+  Polygon21_Body polygon21;
+  Slice21_Body slice21;
+  Slice22_Body slice22;
+  Slice23_Body slice23;
+  Slice24_Body slice24;
+
+  ~Baz() {
+    switch (tag) {
+      case Tag::Polygon21: polygon21.~Polygon21_Body(); break;
+      case Tag::Slice21: slice21.~Slice21_Body(); break;
+      case Tag::Slice22: slice22.~Slice22_Body(); break;
+      case Tag::Slice23: slice23.~Slice23_Body(); break;
+      case Tag::Slice24: slice24.~Slice24_Body(); break;
+      default: break;
+    }
+  }
+};
+
 extern "C" {
 
-void root(const Foo<uint32_t> *p);
+void root(const Foo<uint32_t> *a, const Baz<int32_t> *b);
 
 } // extern "C"

--- a/tests/expectations/destructor.cpp
+++ b/tests/expectations/destructor.cpp
@@ -134,8 +134,49 @@ union Baz {
   }
 };
 
+union Taz {
+  enum class Tag : uint8_t {
+    Bar3,
+    Taz1,
+  };
+
+  struct Taz1_Body {
+    Tag tag;
+    int32_t _0;
+  };
+
+  struct {
+    Tag tag;
+  };
+  Taz1_Body taz1;
+
+  ~Taz() {
+    switch (tag) {
+      case Tag::Taz1: taz1.~Taz1_Body(); break;
+      default: break;
+    }
+  }
+};
+
+union Tazz {
+  enum class Tag : uint8_t {
+    Bar4,
+    Taz2,
+  };
+
+  struct Taz2_Body {
+    Tag tag;
+    int32_t _0;
+  };
+
+  struct {
+    Tag tag;
+  };
+  Taz2_Body taz2;
+};
+
 extern "C" {
 
-void root(const Foo<uint32_t> *a, const Baz<int32_t> *b);
+void root(const Foo<uint32_t> *a, const Baz<int32_t> *b, const Taz *c, Tazz d);
 
 } // extern "C"

--- a/tests/expectations/tag/destructor.c
+++ b/tests/expectations/tag/destructor.c
@@ -75,4 +75,55 @@ struct Foo_u32 {
   };
 };
 
-void root(const struct Foo_u32 *p);
+struct Polygon_i32 {
+  FillRule fill;
+  struct OwnedSlice_i32 coordinates;
+};
+
+enum Baz_i32_Tag {
+  Bar2_i32,
+  Polygon21_i32,
+  Slice21_i32,
+  Slice22_i32,
+  Slice23_i32,
+  Slice24_i32,
+};
+typedef uint8_t Baz_i32_Tag;
+
+struct Polygon21_Body_i32 {
+  Baz_i32_Tag tag;
+  struct Polygon_i32 _0;
+};
+
+struct Slice21_Body_i32 {
+  Baz_i32_Tag tag;
+  struct OwnedSlice_i32 _0;
+};
+
+struct Slice22_Body_i32 {
+  Baz_i32_Tag tag;
+  struct OwnedSlice_i32 _0;
+};
+
+struct Slice23_Body_i32 {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  struct OwnedSlice_i32 coords;
+};
+
+struct Slice24_Body_i32 {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  struct OwnedSlice_i32 coords;
+};
+
+union Baz_i32 {
+  enum Baz_i32_Tag tag;
+  struct Polygon21_Body_i32 polygon21;
+  struct Slice21_Body_i32 slice21;
+  struct Slice22_Body_i32 slice22;
+  struct Slice23_Body_i32 slice23;
+  struct Slice24_Body_i32 slice24;
+};
+
+void root(const struct Foo_u32 *a, const union Baz_i32 *b);

--- a/tests/expectations/tag/destructor.c
+++ b/tests/expectations/tag/destructor.c
@@ -1,0 +1,78 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum FillRule {
+  A,
+  B,
+};
+typedef uint8_t FillRule;
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+struct OwnedSlice_u32 {
+  uintptr_t len;
+  uint32_t *ptr;
+};
+
+struct Polygon_u32 {
+  FillRule fill;
+  struct OwnedSlice_u32 coordinates;
+};
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+struct OwnedSlice_i32 {
+  uintptr_t len;
+  int32_t *ptr;
+};
+
+enum Foo_u32_Tag {
+  Bar_u32,
+  Polygon1_u32,
+  Slice1_u32,
+  Slice2_u32,
+  Slice3_u32,
+  Slice4_u32,
+};
+typedef uint8_t Foo_u32_Tag;
+
+struct Polygon1_Body_u32 {
+  struct Polygon_u32 _0;
+};
+
+struct Slice1_Body_u32 {
+  struct OwnedSlice_u32 _0;
+};
+
+struct Slice2_Body_u32 {
+  struct OwnedSlice_i32 _0;
+};
+
+struct Slice3_Body_u32 {
+  FillRule fill;
+  struct OwnedSlice_u32 coords;
+};
+
+struct Slice4_Body_u32 {
+  FillRule fill;
+  struct OwnedSlice_i32 coords;
+};
+
+struct Foo_u32 {
+  enum Foo_u32_Tag tag;
+  union {
+    struct Polygon1_Body_u32 polygon1;
+    struct Slice1_Body_u32 slice1;
+    struct Slice2_Body_u32 slice2;
+    struct Slice3_Body_u32 slice3;
+    struct Slice4_Body_u32 slice4;
+  };
+};
+
+void root(const struct Foo_u32 *p);

--- a/tests/expectations/tag/destructor.c
+++ b/tests/expectations/tag/destructor.c
@@ -126,4 +126,36 @@ union Baz_i32 {
   struct Slice24_Body_i32 slice24;
 };
 
-void root(const struct Foo_u32 *a, const union Baz_i32 *b);
+enum Taz_Tag {
+  Bar3,
+  Taz1,
+};
+typedef uint8_t Taz_Tag;
+
+struct Taz1_Body {
+  Taz_Tag tag;
+  int32_t _0;
+};
+
+union Taz {
+  enum Taz_Tag tag;
+  struct Taz1_Body taz1;
+};
+
+enum Tazz_Tag {
+  Bar4,
+  Taz2,
+};
+typedef uint8_t Tazz_Tag;
+
+struct Taz2_Body {
+  Tazz_Tag tag;
+  int32_t _0;
+};
+
+union Tazz {
+  enum Tazz_Tag tag;
+  struct Taz2_Body taz2;
+};
+
+void root(const struct Foo_u32 *a, const union Baz_i32 *b, const union Taz *c, union Tazz d);

--- a/tests/rust/destructor.rs
+++ b/tests/rust/destructor.rs
@@ -1,0 +1,36 @@
+/// This will have a destructor manually implemented via variant_body, and
+/// similarly a Drop impl in Rust.
+#[repr(C)]
+pub struct OwnedSlice<T> {
+    len: usize,
+    ptr: NonNull<T>,
+}
+
+#[repr(u8)]
+pub enum FillRule { A, B }
+
+#[repr(C)]
+pub struct Polygon<LengthPercentage> {
+    pub fill: FillRule,
+    pub coordinates: OwnedSlice<LengthPercentage>,
+}
+
+/// cbindgen:destructor
+#[repr(C, u8)]
+pub enum Foo<T> {
+    Bar,
+    Polygon1(Polygon<T>),
+    Slice1(OwnedSlice<T>),
+    Slice2(OwnedSlice<i32>),
+    Slice3 {
+        fill: FillRule,
+        coords: OwnedSlice<T>,
+    },
+    Slice4 {
+        fill: FillRule,
+        coords: OwnedSlice<i32>,
+    },
+}
+
+#[no_mangle]
+pub extern "C" fn root(p: &Foo<u32>) {}

--- a/tests/rust/destructor.rs
+++ b/tests/rust/destructor.rs
@@ -1,3 +1,5 @@
+use std::ptr::NonNull;
+
 /// This will have a destructor manually implemented via variant_body, and
 /// similarly a Drop impl in Rust.
 #[repr(C)]
@@ -32,5 +34,23 @@ pub enum Foo<T> {
     },
 }
 
+/// cbindgen:destructor
+#[repr(u8)]
+pub enum Baz<T> {
+    Bar2,
+    Polygon21(Polygon<T>),
+    Slice21(OwnedSlice<T>),
+    Slice22(OwnedSlice<i32>),
+    Slice23 {
+        fill: FillRule,
+        coords: OwnedSlice<T>,
+    },
+    Slice24 {
+        fill: FillRule,
+        coords: OwnedSlice<i32>,
+    },
+}
+
+
 #[no_mangle]
-pub extern "C" fn root(p: &Foo<u32>) {}
+pub extern "C" fn root(a: &Foo<u32>, b: &Baz<i32>) {}

--- a/tests/rust/destructor.rs
+++ b/tests/rust/destructor.rs
@@ -17,7 +17,6 @@ pub struct Polygon<LengthPercentage> {
     pub coordinates: OwnedSlice<LengthPercentage>,
 }
 
-/// cbindgen:destructor
 #[repr(C, u8)]
 pub enum Foo<T> {
     Bar,
@@ -34,7 +33,6 @@ pub enum Foo<T> {
     },
 }
 
-/// cbindgen:destructor
 #[repr(u8)]
 pub enum Baz<T> {
     Bar2,
@@ -51,6 +49,18 @@ pub enum Baz<T> {
     },
 }
 
+#[repr(u8)]
+pub enum Taz {
+    Bar3,
+    Taz1(i32),
+}
+
+/// cbindgen:derive-tagged-enum-destructor=false
+#[repr(u8)]
+pub enum Tazz {
+    Bar4,
+    Taz2(i32),
+}
 
 #[no_mangle]
-pub extern "C" fn root(a: &Foo<u32>, b: &Baz<i32>) {}
+pub extern "C" fn root(a: &Foo<u32>, b: &Baz<i32>, c: &Taz, d: Tazz) {}

--- a/tests/rust/destructor.toml
+++ b/tests/rust/destructor.toml
@@ -1,0 +1,2 @@
+[enum]
+derive_tagged_enum_destructor = true


### PR DESCRIPTION
This trades the ABI-safety (making the struct potentially unsafe to pass by
value), thus the opt-in rather than auto-generating it.

The TL;DR is that I need a way to share types that contain boxed slices from the
style system. That's fine when they're inside regular structs, since C++ does
the right thing, but for unions you need to make it explicit like this.

The actual Gecko setup will hook into the leak logging machinery to avoid silly
leaks and such of course.