### PR TITLE
Use placement new for constructing in tagged unions' helper methods.

### DIFF
--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -131,6 +131,8 @@ impl Bindings {
                 out.new_line();
                 out.write("#include <cstdlib>");
                 out.new_line();
+                out.write("#include <new>");
+                out.new_line();
                 if self.config.enumeration.cast_assert_name.is_none()
                     && (self.config.enumeration.derive_mut_casts
                         || self.config.enumeration.derive_const_casts)

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -700,28 +700,28 @@ impl Source for Enum {
                         for &(ref field_name, ref ty, ..) in body.fields.iter().skip(skip_fields) {
                             out.new_line();
                             match ty {
-                                Type::Array(ref _ty, ref length) => {
+                                Type::Array(ref ty, ref length) => {
                                     // arrays are not assignable in C++ so we
                                     // need to manually copy the elements
+                                    write!(out, "for (int i = 0; i < {}; i++)", length.as_str());
+                                    out.open_brace();
                                     write!(
                                         out,
-                                        "for (int i = 0; i < {}; i++) {{\
-                                         result.{}.{}[i] = {}[i];\
-                                         }}",
-                                        length.as_str(),
-                                        variant_name,
-                                        field_name,
-                                        arg_renamer(field_name)
+                                        "::new (&result.{}.{}[i]) (",
+                                        variant_name, field_name
                                     );
+                                    ty.write(config, out);
+                                    write!(out, ")({}[i]);", arg_renamer(field_name));
+                                    out.close_brace(false);
                                 }
-                                _ => {
+                                ref ty => {
                                     write!(
                                         out,
-                                        "result.{}.{} = {};",
-                                        variant_name,
-                                        field_name,
-                                        arg_renamer(field_name)
+                                        "::new (&result.{}.{}) (",
+                                        variant_name, field_name
                                     );
+                                    ty.write(config, out);
+                                    write!(out, ")({});", arg_renamer(field_name));
                                 }
                             }
                         }

--- a/tests/expectations/alias.cpp
+++ b/tests/expectations/alias.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 enum class Status : uint32_t {
   Ok,

--- a/tests/expectations/annotation.cpp
+++ b/tests/expectations/annotation.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 enum class C : uint32_t {
   X = 2,
@@ -53,7 +54,7 @@ union F {
 
   static F Foo(const int16_t &a0) {
     F result;
-    result.foo._0 = a0;
+    ::new (&result.foo._0) (int16_t)(a0);
     result.tag = Tag::Foo;
     return result;
   }
@@ -61,8 +62,8 @@ union F {
   static F Bar(const uint8_t &aX,
                const int16_t &aY) {
     F result;
-    result.bar.x = aX;
-    result.bar.y = aY;
+    ::new (&result.bar.x) (uint8_t)(aX);
+    ::new (&result.bar.y) (int16_t)(aY);
     result.tag = Tag::Bar;
     return result;
   }
@@ -110,7 +111,7 @@ struct H {
 
   static H Hello(const int16_t &a0) {
     H result;
-    result.hello._0 = a0;
+    ::new (&result.hello._0) (int16_t)(a0);
     result.tag = Tag::Hello;
     return result;
   }
@@ -118,8 +119,8 @@ struct H {
   static H There(const uint8_t &aX,
                  const int16_t &aY) {
     H result;
-    result.there.x = aX;
-    result.there.y = aY;
+    ::new (&result.there.x) (uint8_t)(aX);
+    ::new (&result.there.y) (int16_t)(aY);
     result.tag = Tag::There;
     return result;
   }

--- a/tests/expectations/array.cpp
+++ b/tests/expectations/array.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Foo {
   enum class Tag {
@@ -18,7 +19,9 @@ struct Foo {
 
   static Foo A(const float (&a0)[20]) {
     Foo result;
-    for (int i = 0; i < 20; i++) {result.a._0[i] = a0[i];}
+    for (int i = 0; i < 20; i++) {
+      ::new (&result.a._0[i]) (float)(a0[i]);
+    }
     result.tag = Tag::A;
     return result;
   }

--- a/tests/expectations/asserted-cast.cpp
+++ b/tests/expectations/asserted-cast.cpp
@@ -4,6 +4,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct I;
 
@@ -31,7 +32,7 @@ struct H {
 
   static H H_Foo(const int16_t &a0) {
     H result;
-    result.foo._0 = a0;
+    ::new (&result.foo._0) (int16_t)(a0);
     result.tag = Tag::H_Foo;
     return result;
   }
@@ -39,8 +40,8 @@ struct H {
   static H H_Bar(const uint8_t &aX,
                  const int16_t &aY) {
     H result;
-    result.bar.x = aX;
-    result.bar.y = aY;
+    ::new (&result.bar.x) (uint8_t)(aX);
+    ::new (&result.bar.y) (int16_t)(aY);
     result.tag = Tag::H_Bar;
     return result;
   }
@@ -108,7 +109,7 @@ struct J {
 
   static J J_Foo(const int16_t &a0) {
     J result;
-    result.foo._0 = a0;
+    ::new (&result.foo._0) (int16_t)(a0);
     result.tag = Tag::J_Foo;
     return result;
   }
@@ -116,8 +117,8 @@ struct J {
   static J J_Bar(const uint8_t &aX,
                  const int16_t &aY) {
     J result;
-    result.bar.x = aX;
-    result.bar.y = aY;
+    ::new (&result.bar.x) (uint8_t)(aX);
+    ::new (&result.bar.y) (int16_t)(aY);
     result.tag = Tag::J_Bar;
     return result;
   }
@@ -187,7 +188,7 @@ union K {
 
   static K K_Foo(const int16_t &a0) {
     K result;
-    result.foo._0 = a0;
+    ::new (&result.foo._0) (int16_t)(a0);
     result.tag = Tag::K_Foo;
     return result;
   }
@@ -195,8 +196,8 @@ union K {
   static K K_Bar(const uint8_t &aX,
                  const int16_t &aY) {
     K result;
-    result.bar.x = aX;
-    result.bar.y = aY;
+    ::new (&result.bar.x) (uint8_t)(aX);
+    ::new (&result.bar.y) (int16_t)(aY);
     result.tag = Tag::K_Bar;
     return result;
   }

--- a/tests/expectations/assoc_const_conflict.cpp
+++ b/tests/expectations/assoc_const_conflict.cpp
@@ -1,5 +1,6 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 static const uint32_t Foo_FOO = 42;

--- a/tests/expectations/assoc_constant.cpp
+++ b/tests/expectations/assoc_constant.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Foo {
 

--- a/tests/expectations/associated_in_body.cpp
+++ b/tests/expectations/associated_in_body.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 /// Constants shared by multiple CSS Box Alignment properties
 /// These constants match Gecko's `NS_STYLE_ALIGN_*` constants.

--- a/tests/expectations/bitflags.cpp
+++ b/tests/expectations/bitflags.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 /// Constants shared by multiple CSS Box Alignment properties
 /// These constants match Gecko's `NS_STYLE_ALIGN_*` constants.

--- a/tests/expectations/body.cpp
+++ b/tests/expectations/body.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 enum class MyCLikeEnum {
   Foo1,

--- a/tests/expectations/both/transform-op.c
+++ b/tests/expectations/both/transform-op.c
@@ -56,6 +56,7 @@ typedef struct StyleBar1_Body_i32 {
   int32_t x;
   StylePoint_i32 y;
   StylePoint_f32 z;
+  int32_t (*u)(int32_t);
 } StyleBar1_Body_i32;
 
 typedef struct StyleBar2_Body_i32 {
@@ -91,6 +92,7 @@ typedef struct StyleBar1_Body_u32 {
   int32_t x;
   StylePoint_u32 y;
   StylePoint_f32 z;
+  int32_t (*u)(int32_t);
 } StyleBar1_Body_u32;
 
 typedef struct StyleBar2_Body_u32 {

--- a/tests/expectations/cdecl.cpp
+++ b/tests/expectations/cdecl.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 using A = void(*)();
 

--- a/tests/expectations/cfg-2.cpp
+++ b/tests/expectations/cfg-2.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 #if defined(NOT_DEFINED)
 static const int32_t DEFAULT_X = 8;

--- a/tests/expectations/cfg-field.cpp
+++ b/tests/expectations/cfg-field.cpp
@@ -1,3 +1,4 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>

--- a/tests/expectations/cfg.cpp
+++ b/tests/expectations/cfg.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
 enum class BarType : uint32_t {

--- a/tests/expectations/const_conflict.cpp
+++ b/tests/expectations/const_conflict.cpp
@@ -1,5 +1,6 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 static const uint32_t Foo_FOO = 42;

--- a/tests/expectations/const_transparent.cpp
+++ b/tests/expectations/const_transparent.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 using Transparent = uint8_t;
 

--- a/tests/expectations/constant.cpp
+++ b/tests/expectations/constant.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 static const wchar_t DELIMITER = ':';
 

--- a/tests/expectations/derive-eq.cpp
+++ b/tests/expectations/derive-eq.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Foo {
   bool a;

--- a/tests/expectations/destructor.cpp
+++ b/tests/expectations/destructor.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 enum class FillRule : uint8_t {
   A,

--- a/tests/expectations/display_list.cpp
+++ b/tests/expectations/display_list.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Rect {
   float x;

--- a/tests/expectations/docstyle_auto.cpp
+++ b/tests/expectations/docstyle_auto.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 extern "C" {
 

--- a/tests/expectations/docstyle_c99.cpp
+++ b/tests/expectations/docstyle_c99.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 extern "C" {
 

--- a/tests/expectations/docstyle_doxy.cpp
+++ b/tests/expectations/docstyle_doxy.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 extern "C" {
 

--- a/tests/expectations/enum.cpp
+++ b/tests/expectations/enum.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 enum class A : uint32_t {
   a1 = 0,

--- a/tests/expectations/euclid.cpp
+++ b/tests/expectations/euclid.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct LayoutUnit;
 

--- a/tests/expectations/expand.cpp
+++ b/tests/expectations/expand.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Foo {
 

--- a/tests/expectations/expand_default_features.cpp
+++ b/tests/expectations/expand_default_features.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Foo {
 

--- a/tests/expectations/expand_features.cpp
+++ b/tests/expectations/expand_features.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Foo {
 

--- a/tests/expectations/expand_no_default_features.cpp
+++ b/tests/expectations/expand_no_default_features.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Foo {
 

--- a/tests/expectations/extern-2.cpp
+++ b/tests/expectations/extern-2.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 extern "C" {
 

--- a/tests/expectations/extern.cpp
+++ b/tests/expectations/extern.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Normal {
   int32_t x;

--- a/tests/expectations/external_workspace_child.cpp
+++ b/tests/expectations/external_workspace_child.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct ExtType {
   uint32_t data;

--- a/tests/expectations/fns.cpp
+++ b/tests/expectations/fns.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Fns {
   void (*noArgs)();

--- a/tests/expectations/global_attr.cpp
+++ b/tests/expectations/global_attr.cpp
@@ -1,3 +1,4 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>

--- a/tests/expectations/include.cpp
+++ b/tests/expectations/include.cpp
@@ -1,4 +1,5 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 #include <math.h>

--- a/tests/expectations/include_item.cpp
+++ b/tests/expectations/include_item.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct A {
   int32_t x;

--- a/tests/expectations/inner_mod.cpp
+++ b/tests/expectations/inner_mod.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Foo {
   float x;

--- a/tests/expectations/item_types.cpp
+++ b/tests/expectations/item_types.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 enum class OnlyThisShouldBeGenerated : uint8_t {
   Foo,

--- a/tests/expectations/item_types_renamed.cpp
+++ b/tests/expectations/item_types_renamed.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 enum class StyleOnlyThisShouldBeGenerated : uint8_t {
   Foo,

--- a/tests/expectations/lifetime_arg.cpp
+++ b/tests/expectations/lifetime_arg.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct A {
   const int32_t *data;

--- a/tests/expectations/mod_attr.cpp
+++ b/tests/expectations/mod_attr.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 #if defined(BAR)
 static const int32_t BAR = 2;

--- a/tests/expectations/mod_path.cpp
+++ b/tests/expectations/mod_path.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 static const uint8_t EXPORT_ME_TOO = 42;
 

--- a/tests/expectations/monomorph-1.cpp
+++ b/tests/expectations/monomorph-1.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 template<typename T>
 struct Bar;

--- a/tests/expectations/monomorph-2.cpp
+++ b/tests/expectations/monomorph-2.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct A;
 

--- a/tests/expectations/monomorph-3.cpp
+++ b/tests/expectations/monomorph-3.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 template<typename T>
 struct Bar;

--- a/tests/expectations/must-use.cpp
+++ b/tests/expectations/must-use.cpp
@@ -6,6 +6,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 template<typename T>
 struct MUST_USE_STRUCT MaybeOwnedPtr {

--- a/tests/expectations/namespace_constant.cpp
+++ b/tests/expectations/namespace_constant.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 namespace constants {
 

--- a/tests/expectations/namespaces_constant.cpp
+++ b/tests/expectations/namespaces_constant.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 namespace constants {
 namespace test {

--- a/tests/expectations/nested_import.cpp
+++ b/tests/expectations/nested_import.cpp
@@ -1,3 +1,4 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>

--- a/tests/expectations/nonnull.cpp
+++ b/tests/expectations/nonnull.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Opaque;
 

--- a/tests/expectations/prefix.cpp
+++ b/tests/expectations/prefix.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 static const int32_t PREFIX_LEN = 42;
 

--- a/tests/expectations/prefixed_struct_literal.cpp
+++ b/tests/expectations/prefixed_struct_literal.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct PREFIXFoo {
   int32_t a;

--- a/tests/expectations/prefixed_struct_literal_deep.cpp
+++ b/tests/expectations/prefixed_struct_literal_deep.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct PREFIXBar {
   int32_t a;

--- a/tests/expectations/rename-crate.cpp
+++ b/tests/expectations/rename-crate.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 #if !defined(DEFINE_FREEBSD)
 struct NoExternTy {

--- a/tests/expectations/rename.cpp
+++ b/tests/expectations/rename.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 static const int32_t C_H = 10;
 

--- a/tests/expectations/renaming-overrides-prefixing.cpp
+++ b/tests/expectations/renaming-overrides-prefixing.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct StyleA;
 

--- a/tests/expectations/reserved.cpp
+++ b/tests/expectations/reserved.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct A {
   int32_t namespace_;

--- a/tests/expectations/simplify-option-ptr.cpp
+++ b/tests/expectations/simplify-option-ptr.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Opaque;
 

--- a/tests/expectations/static.cpp
+++ b/tests/expectations/static.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Bar;
 

--- a/tests/expectations/std_lib.cpp
+++ b/tests/expectations/std_lib.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 template<typename T>
 struct Option;

--- a/tests/expectations/struct.cpp
+++ b/tests/expectations/struct.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Opaque;
 

--- a/tests/expectations/struct_literal.cpp
+++ b/tests/expectations/struct_literal.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Bar;
 

--- a/tests/expectations/style-crash.cpp
+++ b/tests/expectations/style-crash.cpp
@@ -1,3 +1,4 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>

--- a/tests/expectations/tag/transform-op.c
+++ b/tests/expectations/tag/transform-op.c
@@ -56,6 +56,7 @@ struct StyleBar1_Body_i32 {
   int32_t x;
   struct StylePoint_i32 y;
   struct StylePoint_f32 z;
+  int32_t (*u)(int32_t);
 };
 
 struct StyleBar2_Body_i32 {
@@ -91,6 +92,7 @@ struct StyleBar1_Body_u32 {
   int32_t x;
   struct StylePoint_u32 y;
   struct StylePoint_f32 z;
+  int32_t (*u)(int32_t);
 };
 
 struct StyleBar2_Body_u32 {

--- a/tests/expectations/transform-op.c
+++ b/tests/expectations/transform-op.c
@@ -56,6 +56,7 @@ typedef struct {
   int32_t x;
   StylePoint_i32 y;
   StylePoint_f32 z;
+  int32_t (*u)(int32_t);
 } StyleBar1_Body_i32;
 
 typedef struct {
@@ -91,6 +92,7 @@ typedef struct {
   int32_t x;
   StylePoint_u32 y;
   StylePoint_f32 z;
+  int32_t (*u)(int32_t);
 } StyleBar1_Body_u32;
 
 typedef struct {

--- a/tests/expectations/transform-op.cpp
+++ b/tests/expectations/transform-op.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 #include <cassert>
 
 template<typename T>
@@ -46,23 +47,23 @@ union StyleFoo {
                       const StylePoint<T> &aY,
                       const StylePoint<float> &aZ) {
     StyleFoo result;
-    result.foo.x = aX;
-    result.foo.y = aY;
-    result.foo.z = aZ;
+    ::new (&result.foo.x) (int32_t)(aX);
+    ::new (&result.foo.y) (StylePoint<T>)(aY);
+    ::new (&result.foo.z) (StylePoint<float>)(aZ);
     result.tag = Tag::Foo;
     return result;
   }
 
   static StyleFoo Bar(const T &a0) {
     StyleFoo result;
-    result.bar._0 = a0;
+    ::new (&result.bar._0) (T)(a0);
     result.tag = Tag::Bar;
     return result;
   }
 
   static StyleFoo Baz(const StylePoint<T> &a0) {
     StyleFoo result;
-    result.baz._0 = a0;
+    ::new (&result.baz._0) (StylePoint<T>)(a0);
     result.tag = Tag::Baz;
     return result;
   }
@@ -133,6 +134,7 @@ struct StyleBar {
     int32_t x;
     StylePoint<T> y;
     StylePoint<float> z;
+    int32_t (*u)(int32_t);
   };
 
   struct StyleBar2_Body {
@@ -152,25 +154,27 @@ struct StyleBar {
 
   static StyleBar Bar1(const int32_t &aX,
                        const StylePoint<T> &aY,
-                       const StylePoint<float> &aZ) {
+                       const StylePoint<float> &aZ,
+                       int32_t (*&aU)(int32_t)) {
     StyleBar result;
-    result.bar1.x = aX;
-    result.bar1.y = aY;
-    result.bar1.z = aZ;
+    ::new (&result.bar1.x) (int32_t)(aX);
+    ::new (&result.bar1.y) (StylePoint<T>)(aY);
+    ::new (&result.bar1.z) (StylePoint<float>)(aZ);
+    ::new (&result.bar1.u) (int32_t(*)(int32_t))(aU);
     result.tag = Tag::Bar1;
     return result;
   }
 
   static StyleBar Bar2(const T &a0) {
     StyleBar result;
-    result.bar2._0 = a0;
+    ::new (&result.bar2._0) (T)(a0);
     result.tag = Tag::Bar2;
     return result;
   }
 
   static StyleBar Bar3(const StylePoint<T> &a0) {
     StyleBar result;
-    result.bar3._0 = a0;
+    ::new (&result.bar3._0) (StylePoint<T>)(a0);
     result.tag = Tag::Bar3;
     return result;
   }
@@ -253,14 +257,14 @@ union StyleBaz {
 
   static StyleBaz Baz1(const StyleBar<uint32_t> &a0) {
     StyleBaz result;
-    result.baz1._0 = a0;
+    ::new (&result.baz1._0) (StyleBar<uint32_t>)(a0);
     result.tag = Tag::Baz1;
     return result;
   }
 
   static StyleBaz Baz2(const StylePoint<int32_t> &a0) {
     StyleBaz result;
-    result.baz2._0 = a0;
+    ::new (&result.baz2._0) (StylePoint<int32_t>)(a0);
     result.tag = Tag::Baz2;
     return result;
   }
@@ -327,14 +331,14 @@ struct StyleTaz {
 
   static StyleTaz Taz1(const StyleBar<uint32_t> &a0) {
     StyleTaz result;
-    result.taz1._0 = a0;
+    ::new (&result.taz1._0) (StyleBar<uint32_t>)(a0);
     result.tag = Tag::Taz1;
     return result;
   }
 
   static StyleTaz Taz2(const StyleBaz &a0) {
     StyleTaz result;
-    result.taz2._0 = a0;
+    ::new (&result.taz2._0) (StyleBaz)(a0);
     result.tag = Tag::Taz2;
     return result;
   }

--- a/tests/expectations/transparent.cpp
+++ b/tests/expectations/transparent.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct DummyStruct;
 

--- a/tests/expectations/typedef.cpp
+++ b/tests/expectations/typedef.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 template<typename T, typename U>
 struct Foo {

--- a/tests/expectations/union.cpp
+++ b/tests/expectations/union.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct Opaque;
 

--- a/tests/expectations/va_list.cpp
+++ b/tests/expectations/va_list.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 extern "C" {
 

--- a/tests/expectations/workspace.cpp
+++ b/tests/expectations/workspace.cpp
@@ -1,6 +1,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 struct ExtType {
   uint32_t data;

--- a/tests/rust/transform-op.rs
+++ b/tests/rust/transform-op.rs
@@ -14,7 +14,7 @@ pub enum Foo<T> {
 
 #[repr(C)]
 pub enum Bar<T> {
-    Bar1 { x: i32, y: Point<T>, z: Point<f32>, },
+    Bar1 { x: i32, y: Point<T>, z: Point<f32>, u: unsafe extern "C" fn(i32) -> i32,  },
     Bar2(T),
     Bar3(Point<T>),
     Bar4,


### PR DESCRIPTION
Using operator= is not quite sound in presence of destructors and operator
overloading.

It's perfectly fine to assume that the left-hand-side of an operator= expression
is valid memory, however we're using uninitialized memory here, that may not be
the case.

Use placement new to properly construct tagged unions. I don't need this with
any urgency, but it's the right thing to do in presence of complex types, and
the current code seems a bomb waiting to explode :)