### PR TITLE
Added generation of header files that support both C and C++ compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ line_length = 80
 tab_width = 2
 # The language to output bindings in
 language = "[C|C++]"
+# Include preprocessor defines in C bindings to ensure C++ compatibility
+cpp_compat = true
 # A rule to use to select style of declaration in C, tagname vs typedef
 style = "[Both|Type|Tag]"
 # How the generated documentation should be commented.

--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -211,17 +211,15 @@ impl Bindings {
             if self.config.language == Language::C && self.config.cpp_compat {
                 out.new_line_if_not_start();
                 out.write("#ifdef __cplusplus");
-                out.new_line();
             }
 
             if self.config.language == Language::Cxx || self.config.cpp_compat {
-                out.new_line_if_not_start();
+                out.new_line();
                 out.write("extern \"C\" {");
                 out.new_line();
             }
 
             if self.config.language == Language::C && self.config.cpp_compat {
-                out.new_line();
                 out.write("#endif // __cplusplus");
                 out.new_line();
             }
@@ -241,7 +239,6 @@ impl Bindings {
             if self.config.language == Language::C && self.config.cpp_compat {
                 out.new_line();
                 out.write("#ifdef __cplusplus");
-                out.new_line();
             }
 
             if self.config.language == Language::Cxx || self.config.cpp_compat {
@@ -251,7 +248,6 @@ impl Bindings {
             }
 
             if self.config.language == Language::C && self.config.cpp_compat {
-                out.new_line_if_not_start();
                 out.write("#endif // __cplusplus");
                 out.new_line();
             }

--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -208,9 +208,21 @@ impl Bindings {
         }
 
         if !self.functions.is_empty() || !self.globals.is_empty() {
-            if self.config.language == Language::Cxx {
+            if self.config.language == Language::C && self.config.cpp_compat {
+                out.new_line_if_not_start();
+                out.write("#ifdef __cplusplus");
+                out.new_line();
+            }
+
+            if self.config.language == Language::Cxx || self.config.cpp_compat {
                 out.new_line_if_not_start();
                 out.write("extern \"C\" {");
+                out.new_line();
+            }
+
+            if self.config.language == Language::C && self.config.cpp_compat {
+                out.new_line();
+                out.write("#endif // __cplusplus");
                 out.new_line();
             }
 
@@ -226,9 +238,21 @@ impl Bindings {
                 out.new_line();
             }
 
-            if self.config.language == Language::Cxx {
-                out.new_line_if_not_start();
+            if self.config.language == Language::C && self.config.cpp_compat {
+                out.new_line();
+                out.write("#ifdef __cplusplus");
+                out.new_line();
+            }
+
+            if self.config.language == Language::Cxx || self.config.cpp_compat {
+                out.new_line();
                 out.write("} // extern \"C\"");
+                out.new_line();
+            }
+
+            if self.config.language == Language::C && self.config.cpp_compat {
+                out.new_line_if_not_start();
+                out.write("#endif // __cplusplus");
                 out.new_line();
             }
         }

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -613,6 +613,8 @@ pub struct Config {
     pub tab_width: usize,
     /// The language to output bindings for
     pub language: Language,
+    /// Include preprocessor defines in C bindings to ensure C++ compatibility
+    pub cpp_compat: bool,
     /// The style to declare structs, enums and unions in for C
     pub style: Style,
     /// The configuration options for parsing
@@ -658,6 +660,7 @@ impl Default for Config {
             line_length: 100,
             tab_width: 2,
             language: Language::Cxx,
+            cpp_compat: false,
             style: Style::Type,
             macro_expansion: Default::default(),
             parse: ParseConfig::default(),

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -587,21 +587,19 @@ impl Source for Enum {
         }
 
         if config.language == Language::C {
-            if config.cpp_compat {
-                out.new_line_if_not_start();
-                out.write("#ifndef __cplusplus");
-                out.new_line();
-            }
-
             if let Some(prim) = size {
+                if config.cpp_compat {
+                    out.new_line_if_not_start();
+                    out.write("#ifndef __cplusplus");
+                }
+
                 out.new_line();
                 write!(out, "typedef {} {};", prim, enum_name);
-            }
 
-            if config.cpp_compat {
-                out.new_line_if_not_start();
-                out.write("#endif // __cplusplus");
-                out.new_line();
+                if config.cpp_compat {
+                    out.new_line_if_not_start();
+                    out.write("#endif // __cplusplus");
+                }
             }
         }
         // Done emitting the enum

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -540,6 +540,18 @@ impl Source for Enum {
             if !size.is_none() || config.style.generate_tag() {
                 write!(out, " {}", enum_name);
             }
+
+            if config.cpp_compat {
+                if let Some(prim) = size {
+                    out.new_line();
+                    out.write("#ifdef __cplusplus");
+                    out.new_line();
+                    write!(out, "  : {}", prim);
+                    out.new_line();
+                    out.write("#endif // __cplusplus");
+                    out.new_line();
+                }
+            }
         } else {
             out.write("enum class");
 
@@ -575,9 +587,21 @@ impl Source for Enum {
         }
 
         if config.language == Language::C {
+            if config.cpp_compat {
+                out.new_line_if_not_start();
+                out.write("#ifndef __cplusplus");
+                out.new_line();
+            }
+
             if let Some(prim) = size {
                 out.new_line();
                 write!(out, "typedef {} {};", prim, enum_name);
+            }
+
+            if config.cpp_compat {
+                out.new_line_if_not_start();
+                out.write("#endif // __cplusplus");
+                out.new_line();
             }
         }
         // Done emitting the enum

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,10 @@ fn apply_config_overrides<'a>(config: &mut Config, matches: &ArgMatches<'a>) {
         };
     }
 
+    if matches.is_present("cpp-compat") {
+        config.cpp_compat = true;
+    }
+
     if let Some(style) = matches.value_of("style") {
         config.style = match style {
             "Both" => Style::Both,
@@ -140,6 +144,11 @@ fn main() {
                 .value_name("LANGUAGE")
                 .help("Specify the language to output bindings in")
                 .possible_values(&["c++", "C++", "c", "C"]),
+        )
+        .arg(
+            Arg::with_name("cpp-compat")
+                .long("cpp-compat")
+                .help("Whether to add C++ compatibility to generated C bindings")
         )
         .arg(
             Arg::with_name("style")

--- a/tests/expectations/alias.compat.c
+++ b/tests/expectations/alias.compat.c
@@ -12,10 +12,8 @@ enum Status
   Err,
 };
 #ifndef __cplusplus
-
 typedef uint32_t Status;
 #endif // __cplusplus
-
 
 typedef struct {
   int32_t a;
@@ -43,15 +41,11 @@ typedef int32_t Unit;
 typedef Status SpecialStatus;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(IntFoo x, DoubleFoo y, Unit z, SpecialStatus w);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/alias.compat.c
+++ b/tests/expectations/alias.compat.c
@@ -1,0 +1,57 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum Status
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  Ok,
+  Err,
+};
+#ifndef __cplusplus
+
+typedef uint32_t Status;
+#endif // __cplusplus
+
+
+typedef struct {
+  int32_t a;
+  float b;
+} Dep;
+
+typedef struct {
+  int32_t a;
+  int32_t b;
+  Dep c;
+} Foo_i32;
+
+typedef Foo_i32 IntFoo;
+
+typedef struct {
+  double a;
+  double b;
+  Dep c;
+} Foo_f64;
+
+typedef Foo_f64 DoubleFoo;
+
+typedef int32_t Unit;
+
+typedef Status SpecialStatus;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(IntFoo x, DoubleFoo y, Unit z, SpecialStatus w);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/annotation.compat.c
+++ b/tests/expectations/annotation.compat.c
@@ -12,10 +12,8 @@ enum C
   Y,
 };
 #ifndef __cplusplus
-
 typedef uint32_t C;
 #endif // __cplusplus
-
 
 typedef struct {
   int32_t m0;
@@ -36,10 +34,8 @@ enum F_Tag
   Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t F_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   F_Tag tag;
@@ -68,10 +64,8 @@ enum H_Tag
   Everyone,
 };
 #ifndef __cplusplus
-
 typedef uint8_t H_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   int16_t _0;
@@ -91,15 +85,11 @@ typedef struct {
 } H;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(A x, B y, C z, F f, H h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/annotation.compat.c
+++ b/tests/expectations/annotation.compat.c
@@ -1,0 +1,105 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum C
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  X = 2,
+  Y,
+};
+#ifndef __cplusplus
+
+typedef uint32_t C;
+#endif // __cplusplus
+
+
+typedef struct {
+  int32_t m0;
+} A;
+
+typedef struct {
+  int32_t x;
+  float y;
+} B;
+
+enum F_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+  Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t F_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  F_Tag tag;
+  int16_t _0;
+} Foo_Body;
+
+typedef struct {
+  F_Tag tag;
+  uint8_t x;
+  int16_t y;
+} Bar_Body;
+
+typedef union {
+  F_Tag tag;
+  Foo_Body foo;
+  Bar_Body bar;
+} F;
+
+enum H_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Hello,
+  There,
+  Everyone,
+};
+#ifndef __cplusplus
+
+typedef uint8_t H_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  int16_t _0;
+} Hello_Body;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} There_Body;
+
+typedef struct {
+  H_Tag tag;
+  union {
+    Hello_Body hello;
+    There_Body there;
+  };
+} H;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(A x, B y, C z, F f, H h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/array.compat.c
+++ b/tests/expectations/array.compat.c
@@ -1,0 +1,37 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum {
+  A,
+} Foo_Tag;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct {
+  float _0[20];
+} A_Body;
+
+typedef struct {
+  Foo_Tag tag;
+  union {
+    A_Body a;
+  };
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/array.compat.c
+++ b/tests/expectations/array.compat.c
@@ -6,10 +6,6 @@
 typedef enum {
   A,
 } Foo_Tag;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct {
   float _0[20];
@@ -23,15 +19,11 @@ typedef struct {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/asserted-cast.compat.c
+++ b/tests/expectations/asserted-cast.compat.c
@@ -18,10 +18,8 @@ enum H_Tag
   H_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t H_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   int16_t _0;
@@ -50,10 +48,8 @@ enum J_Tag
   J_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t J_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   int16_t _0;
@@ -82,10 +78,8 @@ enum K_Tag
   K_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t K_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   K_Tag tag;
@@ -105,15 +99,11 @@ typedef union {
 } K;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void foo(H h, I i, J j, K k);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/asserted-cast.compat.c
+++ b/tests/expectations/asserted-cast.compat.c
@@ -1,0 +1,119 @@
+#define MY_ASSERT(...) do { } while (0)
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct I I;
+
+enum H_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t H_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  int16_t _0;
+} H_Foo_Body;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} H_Bar_Body;
+
+typedef struct {
+  H_Tag tag;
+  union {
+    H_Foo_Body foo;
+    H_Bar_Body bar;
+  };
+} H;
+
+enum J_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  J_Foo,
+  J_Bar,
+  J_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t J_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  int16_t _0;
+} J_Foo_Body;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} J_Bar_Body;
+
+typedef struct {
+  J_Tag tag;
+  union {
+    J_Foo_Body foo;
+    J_Bar_Body bar;
+  };
+} J;
+
+enum K_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  K_Foo,
+  K_Bar,
+  K_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t K_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  K_Tag tag;
+  int16_t _0;
+} K_Foo_Body;
+
+typedef struct {
+  K_Tag tag;
+  uint8_t x;
+  int16_t y;
+} K_Bar_Body;
+
+typedef union {
+  K_Tag tag;
+  K_Foo_Body foo;
+  K_Bar_Body bar;
+} K;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void foo(H h, I i, J j, K k);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/assoc_const_conflict.compat.c
+++ b/tests/expectations/assoc_const_conflict.compat.c
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define Foo_FOO 42

--- a/tests/expectations/assoc_constant.compat.c
+++ b/tests/expectations/assoc_constant.compat.c
@@ -10,15 +10,11 @@ typedef struct {
 #define Foo_ZO 3.14
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/assoc_constant.compat.c
+++ b/tests/expectations/assoc_constant.compat.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+
+} Foo;
+#define Foo_GA 10
+#define Foo_ZO 3.14
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/associated_in_body.compat.c
+++ b/tests/expectations/associated_in_body.compat.c
@@ -17,15 +17,11 @@ typedef struct {
 #define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = 1 << 3 }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(StyleAlignFlags flags);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/associated_in_body.compat.c
+++ b/tests/expectations/associated_in_body.compat.c
@@ -1,0 +1,31 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Constants shared by multiple CSS Box Alignment properties
+ * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
+ */
+typedef struct {
+  uint8_t bits;
+} StyleAlignFlags;
+#define StyleAlignFlags_AUTO (StyleAlignFlags){ .bits = 0 }
+#define StyleAlignFlags_NORMAL (StyleAlignFlags){ .bits = 1 }
+#define StyleAlignFlags_START (StyleAlignFlags){ .bits = 1 << 1 }
+#define StyleAlignFlags_END (StyleAlignFlags){ .bits = 1 << 2 }
+#define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = 1 << 3 }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(StyleAlignFlags flags);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/bitflags.compat.c
+++ b/tests/expectations/bitflags.compat.c
@@ -17,15 +17,11 @@ typedef struct {
 #define AlignFlags_FLEX_START (AlignFlags){ .bits = 1 << 3 }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(AlignFlags flags);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/bitflags.compat.c
+++ b/tests/expectations/bitflags.compat.c
@@ -1,0 +1,31 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Constants shared by multiple CSS Box Alignment properties
+ * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
+ */
+typedef struct {
+  uint8_t bits;
+} AlignFlags;
+#define AlignFlags_AUTO (AlignFlags){ .bits = 0 }
+#define AlignFlags_NORMAL (AlignFlags){ .bits = 1 }
+#define AlignFlags_START (AlignFlags){ .bits = 1 << 1 }
+#define AlignFlags_END (AlignFlags){ .bits = 1 << 2 }
+#define AlignFlags_FLEX_START (AlignFlags){ .bits = 1 << 3 }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(AlignFlags flags);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/body.compat.c
+++ b/tests/expectations/body.compat.c
@@ -8,10 +8,6 @@ typedef enum {
   Bar1,
   Baz1,
 } MyCLikeEnum;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct {
   int32_t i;
@@ -25,10 +21,6 @@ typedef enum {
   Bar,
   Baz,
 } MyFancyEnum_Tag;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct {
   int32_t _0;
@@ -56,15 +48,11 @@ typedef union {
 } MyUnion;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(MyFancyStruct s, MyFancyEnum e, MyCLikeEnum c, MyUnion u);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/body.compat.c
+++ b/tests/expectations/body.compat.c
@@ -1,0 +1,70 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum {
+  Foo1,
+  Bar1,
+  Baz1,
+} MyCLikeEnum;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct {
+  int32_t i;
+#ifdef __cplusplus
+  inline void foo();
+#endif
+} MyFancyStruct;
+
+typedef enum {
+  Foo,
+  Bar,
+  Baz,
+} MyFancyEnum_Tag;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct {
+  int32_t _0;
+} Bar_Body;
+
+typedef struct {
+  int32_t _0;
+} Baz_Body;
+
+typedef struct {
+  MyFancyEnum_Tag tag;
+  union {
+    Bar_Body bar;
+    Baz_Body baz;
+  };
+#ifdef __cplusplus
+  inline void wohoo();
+#endif
+} MyFancyEnum;
+
+typedef union {
+  float f;
+  uint32_t u;
+  int32_t extra_member; // yolo
+} MyUnion;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(MyFancyStruct s, MyFancyEnum e, MyCLikeEnum c, MyUnion u);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/alias.compat.c
+++ b/tests/expectations/both/alias.compat.c
@@ -12,10 +12,8 @@ enum Status
   Err,
 };
 #ifndef __cplusplus
-
 typedef uint32_t Status;
 #endif // __cplusplus
-
 
 typedef struct Dep {
   int32_t a;
@@ -43,15 +41,11 @@ typedef int32_t Unit;
 typedef Status SpecialStatus;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(IntFoo x, DoubleFoo y, Unit z, SpecialStatus w);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/alias.compat.c
+++ b/tests/expectations/both/alias.compat.c
@@ -1,0 +1,57 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum Status
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  Ok,
+  Err,
+};
+#ifndef __cplusplus
+
+typedef uint32_t Status;
+#endif // __cplusplus
+
+
+typedef struct Dep {
+  int32_t a;
+  float b;
+} Dep;
+
+typedef struct Foo_i32 {
+  int32_t a;
+  int32_t b;
+  Dep c;
+} Foo_i32;
+
+typedef Foo_i32 IntFoo;
+
+typedef struct Foo_f64 {
+  double a;
+  double b;
+  Dep c;
+} Foo_f64;
+
+typedef Foo_f64 DoubleFoo;
+
+typedef int32_t Unit;
+
+typedef Status SpecialStatus;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(IntFoo x, DoubleFoo y, Unit z, SpecialStatus w);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/annotation.compat.c
+++ b/tests/expectations/both/annotation.compat.c
@@ -1,0 +1,105 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum C
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  X = 2,
+  Y,
+};
+#ifndef __cplusplus
+
+typedef uint32_t C;
+#endif // __cplusplus
+
+
+typedef struct A {
+  int32_t m0;
+} A;
+
+typedef struct B {
+  int32_t x;
+  float y;
+} B;
+
+enum F_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+  Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t F_Tag;
+#endif // __cplusplus
+
+
+typedef struct Foo_Body {
+  F_Tag tag;
+  int16_t _0;
+} Foo_Body;
+
+typedef struct Bar_Body {
+  F_Tag tag;
+  uint8_t x;
+  int16_t y;
+} Bar_Body;
+
+typedef union F {
+  F_Tag tag;
+  Foo_Body foo;
+  Bar_Body bar;
+} F;
+
+enum H_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Hello,
+  There,
+  Everyone,
+};
+#ifndef __cplusplus
+
+typedef uint8_t H_Tag;
+#endif // __cplusplus
+
+
+typedef struct Hello_Body {
+  int16_t _0;
+} Hello_Body;
+
+typedef struct There_Body {
+  uint8_t x;
+  int16_t y;
+} There_Body;
+
+typedef struct H {
+  H_Tag tag;
+  union {
+    Hello_Body hello;
+    There_Body there;
+  };
+} H;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(A x, B y, C z, F f, H h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/annotation.compat.c
+++ b/tests/expectations/both/annotation.compat.c
@@ -12,10 +12,8 @@ enum C
   Y,
 };
 #ifndef __cplusplus
-
 typedef uint32_t C;
 #endif // __cplusplus
-
 
 typedef struct A {
   int32_t m0;
@@ -36,10 +34,8 @@ enum F_Tag
   Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t F_Tag;
 #endif // __cplusplus
-
 
 typedef struct Foo_Body {
   F_Tag tag;
@@ -68,10 +64,8 @@ enum H_Tag
   Everyone,
 };
 #ifndef __cplusplus
-
 typedef uint8_t H_Tag;
 #endif // __cplusplus
-
 
 typedef struct Hello_Body {
   int16_t _0;
@@ -91,15 +85,11 @@ typedef struct H {
 } H;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(A x, B y, C z, F f, H h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/array.compat.c
+++ b/tests/expectations/both/array.compat.c
@@ -6,10 +6,6 @@
 typedef enum Foo_Tag {
   A,
 } Foo_Tag;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct A_Body {
   float _0[20];
@@ -23,15 +19,11 @@ typedef struct Foo {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/array.compat.c
+++ b/tests/expectations/both/array.compat.c
@@ -1,0 +1,37 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum Foo_Tag {
+  A,
+} Foo_Tag;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct A_Body {
+  float _0[20];
+} A_Body;
+
+typedef struct Foo {
+  Foo_Tag tag;
+  union {
+    A_Body a;
+  };
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/asserted-cast.compat.c
+++ b/tests/expectations/both/asserted-cast.compat.c
@@ -18,10 +18,8 @@ enum H_Tag
   H_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t H_Tag;
 #endif // __cplusplus
-
 
 typedef struct H_Foo_Body {
   int16_t _0;
@@ -50,10 +48,8 @@ enum J_Tag
   J_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t J_Tag;
 #endif // __cplusplus
-
 
 typedef struct J_Foo_Body {
   int16_t _0;
@@ -82,10 +78,8 @@ enum K_Tag
   K_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t K_Tag;
 #endif // __cplusplus
-
 
 typedef struct K_Foo_Body {
   K_Tag tag;
@@ -105,15 +99,11 @@ typedef union K {
 } K;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void foo(H h, I i, J j, K k);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/asserted-cast.compat.c
+++ b/tests/expectations/both/asserted-cast.compat.c
@@ -1,0 +1,119 @@
+#define MY_ASSERT(...) do { } while (0)
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct I I;
+
+enum H_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t H_Tag;
+#endif // __cplusplus
+
+
+typedef struct H_Foo_Body {
+  int16_t _0;
+} H_Foo_Body;
+
+typedef struct H_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} H_Bar_Body;
+
+typedef struct H {
+  H_Tag tag;
+  union {
+    H_Foo_Body foo;
+    H_Bar_Body bar;
+  };
+} H;
+
+enum J_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  J_Foo,
+  J_Bar,
+  J_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t J_Tag;
+#endif // __cplusplus
+
+
+typedef struct J_Foo_Body {
+  int16_t _0;
+} J_Foo_Body;
+
+typedef struct J_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} J_Bar_Body;
+
+typedef struct J {
+  J_Tag tag;
+  union {
+    J_Foo_Body foo;
+    J_Bar_Body bar;
+  };
+} J;
+
+enum K_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  K_Foo,
+  K_Bar,
+  K_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t K_Tag;
+#endif // __cplusplus
+
+
+typedef struct K_Foo_Body {
+  K_Tag tag;
+  int16_t _0;
+} K_Foo_Body;
+
+typedef struct K_Bar_Body {
+  K_Tag tag;
+  uint8_t x;
+  int16_t y;
+} K_Bar_Body;
+
+typedef union K {
+  K_Tag tag;
+  K_Foo_Body foo;
+  K_Bar_Body bar;
+} K;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void foo(H h, I i, J j, K k);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/assoc_const_conflict.compat.c
+++ b/tests/expectations/both/assoc_const_conflict.compat.c
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define Foo_FOO 42

--- a/tests/expectations/both/assoc_constant.compat.c
+++ b/tests/expectations/both/assoc_constant.compat.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo {
+
+} Foo;
+#define Foo_GA 10
+#define Foo_ZO 3.14
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/assoc_constant.compat.c
+++ b/tests/expectations/both/assoc_constant.compat.c
@@ -10,15 +10,11 @@ typedef struct Foo {
 #define Foo_ZO 3.14
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/associated_in_body.compat.c
+++ b/tests/expectations/both/associated_in_body.compat.c
@@ -1,0 +1,31 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Constants shared by multiple CSS Box Alignment properties
+ * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
+ */
+typedef struct StyleAlignFlags {
+  uint8_t bits;
+} StyleAlignFlags;
+#define StyleAlignFlags_AUTO (StyleAlignFlags){ .bits = 0 }
+#define StyleAlignFlags_NORMAL (StyleAlignFlags){ .bits = 1 }
+#define StyleAlignFlags_START (StyleAlignFlags){ .bits = 1 << 1 }
+#define StyleAlignFlags_END (StyleAlignFlags){ .bits = 1 << 2 }
+#define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = 1 << 3 }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(StyleAlignFlags flags);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/associated_in_body.compat.c
+++ b/tests/expectations/both/associated_in_body.compat.c
@@ -17,15 +17,11 @@ typedef struct StyleAlignFlags {
 #define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = 1 << 3 }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(StyleAlignFlags flags);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/bitflags.compat.c
+++ b/tests/expectations/both/bitflags.compat.c
@@ -17,15 +17,11 @@ typedef struct AlignFlags {
 #define AlignFlags_FLEX_START (AlignFlags){ .bits = 1 << 3 }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(AlignFlags flags);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/bitflags.compat.c
+++ b/tests/expectations/both/bitflags.compat.c
@@ -1,0 +1,31 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Constants shared by multiple CSS Box Alignment properties
+ * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
+ */
+typedef struct AlignFlags {
+  uint8_t bits;
+} AlignFlags;
+#define AlignFlags_AUTO (AlignFlags){ .bits = 0 }
+#define AlignFlags_NORMAL (AlignFlags){ .bits = 1 }
+#define AlignFlags_START (AlignFlags){ .bits = 1 << 1 }
+#define AlignFlags_END (AlignFlags){ .bits = 1 << 2 }
+#define AlignFlags_FLEX_START (AlignFlags){ .bits = 1 << 3 }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(AlignFlags flags);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/body.compat.c
+++ b/tests/expectations/both/body.compat.c
@@ -8,10 +8,6 @@ typedef enum MyCLikeEnum {
   Bar1,
   Baz1,
 } MyCLikeEnum;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct MyFancyStruct {
   int32_t i;
@@ -25,10 +21,6 @@ typedef enum MyFancyEnum_Tag {
   Bar,
   Baz,
 } MyFancyEnum_Tag;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct Bar_Body {
   int32_t _0;
@@ -56,15 +48,11 @@ typedef union MyUnion {
 } MyUnion;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(MyFancyStruct s, MyFancyEnum e, MyCLikeEnum c, MyUnion u);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/body.compat.c
+++ b/tests/expectations/both/body.compat.c
@@ -1,0 +1,70 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum MyCLikeEnum {
+  Foo1,
+  Bar1,
+  Baz1,
+} MyCLikeEnum;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct MyFancyStruct {
+  int32_t i;
+#ifdef __cplusplus
+  inline void foo();
+#endif
+} MyFancyStruct;
+
+typedef enum MyFancyEnum_Tag {
+  Foo,
+  Bar,
+  Baz,
+} MyFancyEnum_Tag;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct Bar_Body {
+  int32_t _0;
+} Bar_Body;
+
+typedef struct Baz_Body {
+  int32_t _0;
+} Baz_Body;
+
+typedef struct MyFancyEnum {
+  MyFancyEnum_Tag tag;
+  union {
+    Bar_Body bar;
+    Baz_Body baz;
+  };
+#ifdef __cplusplus
+  inline void wohoo();
+#endif
+} MyFancyEnum;
+
+typedef union MyUnion {
+  float f;
+  uint32_t u;
+  int32_t extra_member; // yolo
+} MyUnion;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(MyFancyStruct s, MyFancyEnum e, MyCLikeEnum c, MyUnion u);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/cdecl.compat.c
+++ b/tests/expectations/both/cdecl.compat.c
@@ -34,9 +34,7 @@ typedef void (*N[16])(int32_t, int32_t);
 typedef void (*P)(int32_t named1st, bool, bool named3rd, int32_t _);
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void (*O(void))(void);
@@ -44,7 +42,5 @@ void (*O(void))(void);
 void root(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m, N n, P p);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/cdecl.compat.c
+++ b/tests/expectations/both/cdecl.compat.c
@@ -1,0 +1,50 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef void (*A)();
+
+typedef void (*B)();
+
+typedef bool (*C)(int32_t, int32_t);
+
+typedef bool (*(*D)(int32_t))(float);
+
+typedef const int32_t (*(*E)())[16];
+
+typedef const int32_t *F;
+
+typedef const int32_t *const *G;
+
+typedef int32_t *const *H;
+
+typedef const int32_t (*I)[16];
+
+typedef double (**J)(float);
+
+typedef int32_t K[16];
+
+typedef const int32_t *L[16];
+
+typedef bool (*M[16])(int32_t, int32_t);
+
+typedef void (*N[16])(int32_t, int32_t);
+
+typedef void (*P)(int32_t named1st, bool, bool named3rd, int32_t _);
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void (*O(void))(void);
+
+void root(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m, N n, P p);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/cfg-2.compat.c
+++ b/tests/expectations/both/cfg-2.compat.c
@@ -34,15 +34,11 @@ typedef struct Root {
 } Root;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Root a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/cfg-2.compat.c
+++ b/tests/expectations/both/cfg-2.compat.c
@@ -1,0 +1,48 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if defined(NOT_DEFINED)
+#define DEFAULT_X 8
+#endif
+
+#if defined(DEFINED)
+#define DEFAULT_X 42
+#endif
+
+#if (defined(NOT_DEFINED) || defined(DEFINED))
+typedef struct Foo {
+  int32_t x;
+} Foo;
+#endif
+
+#if defined(NOT_DEFINED)
+typedef struct Bar {
+  Foo y;
+} Bar;
+#endif
+
+#if defined(DEFINED)
+typedef struct Bar {
+  Foo z;
+} Bar;
+#endif
+
+typedef struct Root {
+  Bar w;
+} Root;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Root a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/cfg-field.compat.c
+++ b/tests/expectations/both/cfg-field.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/both/cfg.compat.c
+++ b/tests/expectations/both/cfg.compat.c
@@ -14,10 +14,8 @@ enum BarType
   C,
 };
 #ifndef __cplusplus
-
 typedef uint32_t BarType;
 #endif // __cplusplus
-
 #endif
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
@@ -31,10 +29,8 @@ enum FooType
   C,
 };
 #ifndef __cplusplus
-
 typedef uint32_t FooType;
 #endif // __cplusplus
-
 #endif
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
@@ -54,9 +50,7 @@ typedef struct BarHandle {
 #endif
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
@@ -68,7 +62,5 @@ void root(BarHandle a);
 #endif
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/cfg.compat.c
+++ b/tests/expectations/both/cfg.compat.c
@@ -1,0 +1,74 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+enum BarType
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  A,
+  B,
+  C,
+};
+#ifndef __cplusplus
+
+typedef uint32_t BarType;
+#endif // __cplusplus
+
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+enum FooType
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  A,
+  B,
+  C,
+};
+#ifndef __cplusplus
+
+typedef uint32_t FooType;
+#endif // __cplusplus
+
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+typedef struct FooHandle {
+  FooType ty;
+  int32_t x;
+  float y;
+} FooHandle;
+#endif
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+typedef struct BarHandle {
+  BarType ty;
+  int32_t x;
+  float y;
+} BarHandle;
+#endif
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+void root(FooHandle a);
+#endif
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+void root(BarHandle a);
+#endif
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/const_conflict.compat.c
+++ b/tests/expectations/both/const_conflict.compat.c
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define Foo_FOO 42

--- a/tests/expectations/both/const_transparent.compat.c
+++ b/tests/expectations/both/const_transparent.compat.c
@@ -1,0 +1,8 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef uint8_t Transparent;
+
+#define FOO 0

--- a/tests/expectations/both/constant.compat.c
+++ b/tests/expectations/both/constant.compat.c
@@ -1,0 +1,42 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define DELIMITER ':'
+
+#define FOO 10
+
+#define HEART L'\u2764'
+
+#define LEFTCURLY '{'
+
+#define NEG_ONE -1
+
+#define NEWLINE '\n'
+
+#define POS_ONE 1
+
+#define QUOTE '\''
+
+#define TAB '\t'
+
+#define ZOM 3.14
+
+typedef struct Foo {
+  int32_t x[FOO];
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/constant.compat.c
+++ b/tests/expectations/both/constant.compat.c
@@ -28,15 +28,11 @@ typedef struct Foo {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/derive-eq.compat.c
+++ b/tests/expectations/both/derive-eq.compat.c
@@ -19,10 +19,8 @@ enum Bar_Tag
   FooParen,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Bar_Tag;
 #endif // __cplusplus
-
 
 typedef struct Bazz_Body {
   Bar_Tag tag;
@@ -49,15 +47,11 @@ typedef union Bar {
 } Bar;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 Foo root(Bar aBar);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/derive-eq.compat.c
+++ b/tests/expectations/both/derive-eq.compat.c
@@ -1,0 +1,63 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo {
+  bool a;
+  int32_t b;
+} Foo;
+
+enum Bar_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Baz,
+  Bazz,
+  FooNamed,
+  FooParen,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Bar_Tag;
+#endif // __cplusplus
+
+
+typedef struct Bazz_Body {
+  Bar_Tag tag;
+  Foo named;
+} Bazz_Body;
+
+typedef struct FooNamed_Body {
+  Bar_Tag tag;
+  int32_t different;
+  uint32_t fields;
+} FooNamed_Body;
+
+typedef struct FooParen_Body {
+  Bar_Tag tag;
+  int32_t _0;
+  Foo _1;
+} FooParen_Body;
+
+typedef union Bar {
+  Bar_Tag tag;
+  Bazz_Body bazz;
+  FooNamed_Body foo_named;
+  FooParen_Body foo_paren;
+} Bar;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+Foo root(Bar aBar);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/both/destructor-and-copy-ctor.compat.c
@@ -1,0 +1,213 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum FillRule
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  A,
+  B,
+};
+#ifndef __cplusplus
+
+typedef uint8_t FillRule;
+#endif // __cplusplus
+
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+typedef struct OwnedSlice_u32 {
+  uintptr_t len;
+  uint32_t *ptr;
+} OwnedSlice_u32;
+
+typedef struct Polygon_u32 {
+  FillRule fill;
+  OwnedSlice_u32 coordinates;
+} Polygon_u32;
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+typedef struct OwnedSlice_i32 {
+  uintptr_t len;
+  int32_t *ptr;
+} OwnedSlice_i32;
+
+enum Foo_u32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar_u32,
+  Polygon1_u32,
+  Slice1_u32,
+  Slice2_u32,
+  Slice3_u32,
+  Slice4_u32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Foo_u32_Tag;
+#endif // __cplusplus
+
+
+typedef struct Polygon1_Body_u32 {
+  Polygon_u32 _0;
+} Polygon1_Body_u32;
+
+typedef struct Slice1_Body_u32 {
+  OwnedSlice_u32 _0;
+} Slice1_Body_u32;
+
+typedef struct Slice2_Body_u32 {
+  OwnedSlice_i32 _0;
+} Slice2_Body_u32;
+
+typedef struct Slice3_Body_u32 {
+  FillRule fill;
+  OwnedSlice_u32 coords;
+} Slice3_Body_u32;
+
+typedef struct Slice4_Body_u32 {
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice4_Body_u32;
+
+typedef struct Foo_u32 {
+  Foo_u32_Tag tag;
+  union {
+    Polygon1_Body_u32 polygon1;
+    Slice1_Body_u32 slice1;
+    Slice2_Body_u32 slice2;
+    Slice3_Body_u32 slice3;
+    Slice4_Body_u32 slice4;
+  };
+} Foo_u32;
+
+typedef struct Polygon_i32 {
+  FillRule fill;
+  OwnedSlice_i32 coordinates;
+} Polygon_i32;
+
+enum Baz_i32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar2_i32,
+  Polygon21_i32,
+  Slice21_i32,
+  Slice22_i32,
+  Slice23_i32,
+  Slice24_i32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Baz_i32_Tag;
+#endif // __cplusplus
+
+
+typedef struct Polygon21_Body_i32 {
+  Baz_i32_Tag tag;
+  Polygon_i32 _0;
+} Polygon21_Body_i32;
+
+typedef struct Slice21_Body_i32 {
+  Baz_i32_Tag tag;
+  OwnedSlice_i32 _0;
+} Slice21_Body_i32;
+
+typedef struct Slice22_Body_i32 {
+  Baz_i32_Tag tag;
+  OwnedSlice_i32 _0;
+} Slice22_Body_i32;
+
+typedef struct Slice23_Body_i32 {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice23_Body_i32;
+
+typedef struct Slice24_Body_i32 {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice24_Body_i32;
+
+typedef union Baz_i32 {
+  Baz_i32_Tag tag;
+  Polygon21_Body_i32 polygon21;
+  Slice21_Body_i32 slice21;
+  Slice22_Body_i32 slice22;
+  Slice23_Body_i32 slice23;
+  Slice24_Body_i32 slice24;
+} Baz_i32;
+
+enum Taz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar3,
+  Taz1,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Taz_Tag;
+#endif // __cplusplus
+
+
+typedef struct Taz1_Body {
+  Taz_Tag tag;
+  int32_t _0;
+} Taz1_Body;
+
+typedef union Taz {
+  Taz_Tag tag;
+  Taz1_Body taz1;
+} Taz;
+
+enum Tazz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar4,
+  Taz2,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Tazz_Tag;
+#endif // __cplusplus
+
+
+typedef struct Taz2_Body {
+  Tazz_Tag tag;
+  int32_t _0;
+} Taz2_Body;
+
+typedef union Tazz {
+  Tazz_Tag tag;
+  Taz2_Body taz2;
+} Tazz;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const Foo_u32 *a, const Baz_i32 *b, const Taz *c, Tazz d);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/both/destructor-and-copy-ctor.compat.c
@@ -12,10 +12,8 @@ enum FillRule
   B,
 };
 #ifndef __cplusplus
-
 typedef uint8_t FillRule;
 #endif // __cplusplus
-
 
 /**
  * This will have a destructor manually implemented via variant_body, and
@@ -53,10 +51,8 @@ enum Foo_u32_Tag
   Slice4_u32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Foo_u32_Tag;
 #endif // __cplusplus
-
 
 typedef struct Polygon1_Body_u32 {
   Polygon_u32 _0;
@@ -109,10 +105,8 @@ enum Baz_i32_Tag
   Slice24_i32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Baz_i32_Tag;
 #endif // __cplusplus
-
 
 typedef struct Polygon21_Body_i32 {
   Baz_i32_Tag tag;
@@ -159,10 +153,8 @@ enum Taz_Tag
   Taz1,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Taz_Tag;
 #endif // __cplusplus
-
 
 typedef struct Taz1_Body {
   Taz_Tag tag;
@@ -183,10 +175,8 @@ enum Tazz_Tag
   Taz2,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Tazz_Tag;
 #endif // __cplusplus
-
 
 typedef struct Taz2_Body {
   Tazz_Tag tag;
@@ -199,15 +189,11 @@ typedef union Tazz {
 } Tazz;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const Foo_u32 *a, const Baz_i32 *b, const Taz *c, Tazz d);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/display_list.compat.c
+++ b/tests/expectations/both/display_list.compat.c
@@ -27,10 +27,8 @@ enum DisplayItem_Tag
   ClearScreen,
 };
 #ifndef __cplusplus
-
 typedef uint8_t DisplayItem_Tag;
 #endif // __cplusplus
-
 
 typedef struct Fill_Body {
   DisplayItem_Tag tag;
@@ -51,15 +49,11 @@ typedef union DisplayItem {
 } DisplayItem;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 bool push_item(DisplayItem item);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/display_list.compat.c
+++ b/tests/expectations/both/display_list.compat.c
@@ -1,0 +1,65 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Rect {
+  float x;
+  float y;
+  float w;
+  float h;
+} Rect;
+
+typedef struct Color {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+  uint8_t a;
+} Color;
+
+enum DisplayItem_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Fill,
+  Image,
+  ClearScreen,
+};
+#ifndef __cplusplus
+
+typedef uint8_t DisplayItem_Tag;
+#endif // __cplusplus
+
+
+typedef struct Fill_Body {
+  DisplayItem_Tag tag;
+  Rect _0;
+  Color _1;
+} Fill_Body;
+
+typedef struct Image_Body {
+  DisplayItem_Tag tag;
+  uint32_t id;
+  Rect bounds;
+} Image_Body;
+
+typedef union DisplayItem {
+  DisplayItem_Tag tag;
+  Fill_Body fill;
+  Image_Body image;
+} DisplayItem;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+bool push_item(DisplayItem item);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/docstyle_auto.compat.c
+++ b/tests/expectations/both/docstyle_auto.compat.c
@@ -1,0 +1,21 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+/**
+ * The root of all evil.
+ */
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/docstyle_auto.compat.c
+++ b/tests/expectations/both/docstyle_auto.compat.c
@@ -4,9 +4,7 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 /**
@@ -15,7 +13,5 @@ extern "C" {
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/docstyle_c99.compat.c
+++ b/tests/expectations/both/docstyle_c99.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+// The root of all evil.
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/docstyle_c99.compat.c
+++ b/tests/expectations/both/docstyle_c99.compat.c
@@ -4,16 +4,12 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 // The root of all evil.
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/docstyle_doxy.compat.c
+++ b/tests/expectations/both/docstyle_doxy.compat.c
@@ -1,0 +1,21 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+/**
+ * The root of all evil.
+ */
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/docstyle_doxy.compat.c
+++ b/tests/expectations/both/docstyle_doxy.compat.c
@@ -4,9 +4,7 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 /**
@@ -15,7 +13,5 @@ extern "C" {
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/enum.compat.c
+++ b/tests/expectations/both/enum.compat.c
@@ -14,10 +14,8 @@ enum A
   a4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uint32_t A;
 #endif // __cplusplus
-
 
 enum B
 #ifdef __cplusplus
@@ -30,10 +28,8 @@ enum B
   b4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uint16_t B;
 #endif // __cplusplus
-
 
 enum C
 #ifdef __cplusplus
@@ -46,10 +42,8 @@ enum C
   c4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uint8_t C;
 #endif // __cplusplus
-
 
 enum D
 #ifdef __cplusplus
@@ -62,10 +56,8 @@ enum D
   d4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uintptr_t D;
 #endif // __cplusplus
-
 
 enum E
 #ifdef __cplusplus
@@ -78,10 +70,8 @@ enum E
   e4 = 5,
 };
 #ifndef __cplusplus
-
 typedef intptr_t E;
 #endif // __cplusplus
-
 
 typedef enum K {
   k1,
@@ -89,10 +79,6 @@ typedef enum K {
   k3,
   k4,
 } K;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 enum L
 #ifdef __cplusplus
@@ -104,10 +90,8 @@ enum L
   l3 = 1,
 };
 #ifndef __cplusplus
-
 typedef int8_t L;
 #endif // __cplusplus
-
 
 typedef struct I I;
 
@@ -125,10 +109,8 @@ enum F_Tag
   Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t F_Tag;
 #endif // __cplusplus
-
 
 typedef struct Foo_Body {
   F_Tag tag;
@@ -152,10 +134,6 @@ typedef enum G_Tag {
   G_Bar,
   G_Baz,
 } G_Tag;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct G_Foo_Body {
   int16_t _0;
@@ -184,10 +162,8 @@ enum H_Tag
   H_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t H_Tag;
 #endif // __cplusplus
-
 
 typedef struct H_Foo_Body {
   int16_t _0;
@@ -207,15 +183,11 @@ typedef struct H {
 } H;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/enum.compat.c
+++ b/tests/expectations/both/enum.compat.c
@@ -1,0 +1,221 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum A
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  a1 = 0,
+  a2 = 2,
+  a3,
+  a4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uint32_t A;
+#endif // __cplusplus
+
+
+enum B
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  b1 = 0,
+  b2 = 2,
+  b3,
+  b4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uint16_t B;
+#endif // __cplusplus
+
+
+enum C
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  c1 = 0,
+  c2 = 2,
+  c3,
+  c4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uint8_t C;
+#endif // __cplusplus
+
+
+enum D
+#ifdef __cplusplus
+  : uintptr_t
+#endif // __cplusplus
+ {
+  d1 = 0,
+  d2 = 2,
+  d3,
+  d4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uintptr_t D;
+#endif // __cplusplus
+
+
+enum E
+#ifdef __cplusplus
+  : intptr_t
+#endif // __cplusplus
+ {
+  e1 = 0,
+  e2 = 2,
+  e3,
+  e4 = 5,
+};
+#ifndef __cplusplus
+
+typedef intptr_t E;
+#endif // __cplusplus
+
+
+typedef enum K {
+  k1,
+  k2,
+  k3,
+  k4,
+} K;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+enum L
+#ifdef __cplusplus
+  : int8_t
+#endif // __cplusplus
+ {
+  l1 = -1,
+  l2 = 0,
+  l3 = 1,
+};
+#ifndef __cplusplus
+
+typedef int8_t L;
+#endif // __cplusplus
+
+
+typedef struct I I;
+
+typedef struct J J;
+
+typedef struct Opaque Opaque;
+
+enum F_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+  Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t F_Tag;
+#endif // __cplusplus
+
+
+typedef struct Foo_Body {
+  F_Tag tag;
+  int16_t _0;
+} Foo_Body;
+
+typedef struct Bar_Body {
+  F_Tag tag;
+  uint8_t x;
+  int16_t y;
+} Bar_Body;
+
+typedef union F {
+  F_Tag tag;
+  Foo_Body foo;
+  Bar_Body bar;
+} F;
+
+typedef enum G_Tag {
+  G_Foo,
+  G_Bar,
+  G_Baz,
+} G_Tag;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct G_Foo_Body {
+  int16_t _0;
+} G_Foo_Body;
+
+typedef struct G_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} G_Bar_Body;
+
+typedef struct G {
+  G_Tag tag;
+  union {
+    G_Foo_Body foo;
+    G_Bar_Body bar;
+  };
+} G;
+
+enum H_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t H_Tag;
+#endif // __cplusplus
+
+
+typedef struct H_Foo_Body {
+  int16_t _0;
+} H_Foo_Body;
+
+typedef struct H_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} H_Bar_Body;
+
+typedef struct H {
+  H_Tag tag;
+  union {
+    H_Foo_Body foo;
+    H_Bar_Body bar;
+  };
+} H;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/euclid.compat.c
+++ b/tests/expectations/both/euclid.compat.c
@@ -1,0 +1,129 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct TypedLength_f32__UnknownUnit {
+  float _0;
+} TypedLength_f32__UnknownUnit;
+
+typedef struct TypedLength_f32__LayoutUnit {
+  float _0;
+} TypedLength_f32__LayoutUnit;
+
+typedef TypedLength_f32__UnknownUnit Length_f32;
+
+typedef TypedLength_f32__LayoutUnit LayoutLength;
+
+typedef struct TypedSideOffsets2D_f32__UnknownUnit {
+  float top;
+  float right;
+  float bottom;
+  float left;
+} TypedSideOffsets2D_f32__UnknownUnit;
+
+typedef struct TypedSideOffsets2D_f32__LayoutUnit {
+  float top;
+  float right;
+  float bottom;
+  float left;
+} TypedSideOffsets2D_f32__LayoutUnit;
+
+typedef TypedSideOffsets2D_f32__UnknownUnit SideOffsets2D_f32;
+
+typedef TypedSideOffsets2D_f32__LayoutUnit LayoutSideOffsets2D;
+
+typedef struct TypedSize2D_f32__UnknownUnit {
+  float width;
+  float height;
+} TypedSize2D_f32__UnknownUnit;
+
+typedef struct TypedSize2D_f32__LayoutUnit {
+  float width;
+  float height;
+} TypedSize2D_f32__LayoutUnit;
+
+typedef TypedSize2D_f32__UnknownUnit Size2D_f32;
+
+typedef TypedSize2D_f32__LayoutUnit LayoutSize2D;
+
+typedef struct TypedPoint2D_f32__UnknownUnit {
+  float x;
+  float y;
+} TypedPoint2D_f32__UnknownUnit;
+
+typedef struct TypedPoint2D_f32__LayoutUnit {
+  float x;
+  float y;
+} TypedPoint2D_f32__LayoutUnit;
+
+typedef TypedPoint2D_f32__UnknownUnit Point2D_f32;
+
+typedef TypedPoint2D_f32__LayoutUnit LayoutPoint2D;
+
+typedef struct TypedRect_f32__UnknownUnit {
+  TypedPoint2D_f32__UnknownUnit origin;
+  TypedSize2D_f32__UnknownUnit size;
+} TypedRect_f32__UnknownUnit;
+
+typedef struct TypedRect_f32__LayoutUnit {
+  TypedPoint2D_f32__LayoutUnit origin;
+  TypedSize2D_f32__LayoutUnit size;
+} TypedRect_f32__LayoutUnit;
+
+typedef TypedRect_f32__UnknownUnit Rect_f32;
+
+typedef TypedRect_f32__LayoutUnit LayoutRect;
+
+typedef struct TypedTransform2D_f32__UnknownUnit__LayoutUnit {
+  float m11;
+  float m12;
+  float m21;
+  float m22;
+  float m31;
+  float m32;
+} TypedTransform2D_f32__UnknownUnit__LayoutUnit;
+
+typedef struct TypedTransform2D_f32__LayoutUnit__UnknownUnit {
+  float m11;
+  float m12;
+  float m21;
+  float m22;
+  float m31;
+  float m32;
+} TypedTransform2D_f32__LayoutUnit__UnknownUnit;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(TypedLength_f32__UnknownUnit length_a,
+          TypedLength_f32__LayoutUnit length_b,
+          Length_f32 length_c,
+          LayoutLength length_d,
+          TypedSideOffsets2D_f32__UnknownUnit side_offsets_a,
+          TypedSideOffsets2D_f32__LayoutUnit side_offsets_b,
+          SideOffsets2D_f32 side_offsets_c,
+          LayoutSideOffsets2D side_offsets_d,
+          TypedSize2D_f32__UnknownUnit size_a,
+          TypedSize2D_f32__LayoutUnit size_b,
+          Size2D_f32 size_c,
+          LayoutSize2D size_d,
+          TypedPoint2D_f32__UnknownUnit point_a,
+          TypedPoint2D_f32__LayoutUnit point_b,
+          Point2D_f32 point_c,
+          LayoutPoint2D point_d,
+          TypedRect_f32__UnknownUnit rect_a,
+          TypedRect_f32__LayoutUnit rect_b,
+          Rect_f32 rect_c,
+          LayoutRect rect_d,
+          TypedTransform2D_f32__UnknownUnit__LayoutUnit transform_a,
+          TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/euclid.compat.c
+++ b/tests/expectations/both/euclid.compat.c
@@ -94,9 +94,7 @@ typedef struct TypedTransform2D_f32__LayoutUnit__UnknownUnit {
 } TypedTransform2D_f32__LayoutUnit__UnknownUnit;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(TypedLength_f32__UnknownUnit length_a,
@@ -123,7 +121,5 @@ void root(TypedLength_f32__UnknownUnit length_a,
           TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/expand.compat.c
+++ b/tests/expectations/both/expand.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo {
+
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/expand.compat.c
+++ b/tests/expectations/both/expand.compat.c
@@ -8,15 +8,11 @@ typedef struct Foo {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/expand_default_features.compat.c
+++ b/tests/expectations/both/expand_default_features.compat.c
@@ -8,9 +8,7 @@ typedef struct Foo {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void extra_debug_fn(void);
@@ -18,7 +16,5 @@ void extra_debug_fn(void);
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/expand_default_features.compat.c
+++ b/tests/expectations/both/expand_default_features.compat.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo {
+
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void extra_debug_fn(void);
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/expand_features.compat.c
+++ b/tests/expectations/both/expand_features.compat.c
@@ -8,9 +8,7 @@ typedef struct Foo {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void cbindgen(void);
@@ -20,7 +18,5 @@ void extra_debug_fn(void);
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/expand_features.compat.c
+++ b/tests/expectations/both/expand_features.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo {
+
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void cbindgen(void);
+
+void extra_debug_fn(void);
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/expand_no_default_features.compat.c
+++ b/tests/expectations/both/expand_no_default_features.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo {
+
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/expand_no_default_features.compat.c
+++ b/tests/expectations/both/expand_no_default_features.compat.c
@@ -8,15 +8,11 @@ typedef struct Foo {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/extern-2.compat.c
+++ b/tests/expectations/both/extern-2.compat.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void first(void);
+
+void second(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/extern-2.compat.c
+++ b/tests/expectations/both/extern-2.compat.c
@@ -4,9 +4,7 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void first(void);
@@ -14,7 +12,5 @@ void first(void);
 void second(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/extern.compat.c
+++ b/tests/expectations/both/extern.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Normal {
+  int32_t x;
+  float y;
+} Normal;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+extern void bar(Normal a);
+
+extern int32_t foo(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/extern.compat.c
+++ b/tests/expectations/both/extern.compat.c
@@ -9,9 +9,7 @@ typedef struct Normal {
 } Normal;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 extern void bar(Normal a);
@@ -19,7 +17,5 @@ extern void bar(Normal a);
 extern int32_t foo(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/external_workspace_child.compat.c
+++ b/tests/expectations/both/external_workspace_child.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct ExtType {
+  uint32_t data;
+} ExtType;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void consume_ext(ExtType _ext);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/external_workspace_child.compat.c
+++ b/tests/expectations/both/external_workspace_child.compat.c
@@ -8,15 +8,11 @@ typedef struct ExtType {
 } ExtType;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void consume_ext(ExtType _ext);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/fns.compat.c
+++ b/tests/expectations/both/fns.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Fns {
+  void (*noArgs)();
+  void (*anonymousArg)(int32_t);
+  int32_t (*returnsNumber)();
+  int8_t (*namedArgs)(int32_t first, int16_t snd);
+  int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
+} Fns;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Fns _fns);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/fns.compat.c
+++ b/tests/expectations/both/fns.compat.c
@@ -12,15 +12,11 @@ typedef struct Fns {
 } Fns;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Fns _fns);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/global_attr.compat.c
+++ b/tests/expectations/both/global_attr.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/both/include.compat.c
+++ b/tests/expectations/both/include.compat.c
@@ -1,0 +1,5 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>

--- a/tests/expectations/both/include_item.compat.c
+++ b/tests/expectations/both/include_item.compat.c
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct A {
+  int32_t x;
+  float y;
+} A;
+
+typedef struct B {
+  A data;
+} B;

--- a/tests/expectations/both/include_specific.compat.c
+++ b/tests/expectations/both/include_specific.compat.c
@@ -1,0 +1,1 @@
+#include <math.h>

--- a/tests/expectations/both/inner_mod.compat.c
+++ b/tests/expectations/both/inner_mod.compat.c
@@ -8,15 +8,11 @@ typedef struct Foo {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/inner_mod.compat.c
+++ b/tests/expectations/both/inner_mod.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo {
+  float x;
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/item_types.compat.c
+++ b/tests/expectations/both/item_types.compat.c
@@ -12,7 +12,5 @@ enum OnlyThisShouldBeGenerated
   Bar,
 };
 #ifndef __cplusplus
-
 typedef uint8_t OnlyThisShouldBeGenerated;
 #endif // __cplusplus
-

--- a/tests/expectations/both/item_types.compat.c
+++ b/tests/expectations/both/item_types.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum OnlyThisShouldBeGenerated
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+};
+#ifndef __cplusplus
+
+typedef uint8_t OnlyThisShouldBeGenerated;
+#endif // __cplusplus
+

--- a/tests/expectations/both/item_types_renamed.compat.c
+++ b/tests/expectations/both/item_types_renamed.compat.c
@@ -12,7 +12,5 @@ enum StyleOnlyThisShouldBeGenerated
   Bar,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleOnlyThisShouldBeGenerated;
 #endif // __cplusplus
-

--- a/tests/expectations/both/item_types_renamed.compat.c
+++ b/tests/expectations/both/item_types_renamed.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum StyleOnlyThisShouldBeGenerated
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleOnlyThisShouldBeGenerated;
+#endif // __cplusplus
+

--- a/tests/expectations/both/lifetime_arg.compat.c
+++ b/tests/expectations/both/lifetime_arg.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct A {
+  const int32_t *data;
+} A;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(A _a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/lifetime_arg.compat.c
+++ b/tests/expectations/both/lifetime_arg.compat.c
@@ -8,15 +8,11 @@ typedef struct A {
 } A;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(A _a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/mod_attr.compat.c
+++ b/tests/expectations/both/mod_attr.compat.c
@@ -24,9 +24,7 @@ typedef struct Foo {
 #endif
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 #if defined(BAR)
@@ -38,7 +36,5 @@ void foo(const Foo *foo);
 #endif
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/mod_attr.compat.c
+++ b/tests/expectations/both/mod_attr.compat.c
@@ -1,0 +1,44 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if defined(BAR)
+#define BAR 2
+#endif
+
+#if defined(FOO)
+#define FOO 1
+#endif
+
+#if defined(BAR)
+typedef struct Bar {
+
+} Bar;
+#endif
+
+#if defined(FOO)
+typedef struct Foo {
+
+} Foo;
+#endif
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+#if defined(BAR)
+void bar(const Bar *bar);
+#endif
+
+#if defined(FOO)
+void foo(const Foo *foo);
+#endif
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/mod_path.compat.c
+++ b/tests/expectations/both/mod_path.compat.c
@@ -10,15 +10,11 @@ typedef struct ExportMe {
 } ExportMe;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void export_me(ExportMe *val);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/mod_path.compat.c
+++ b/tests/expectations/both/mod_path.compat.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define EXPORT_ME_TOO 42
+
+typedef struct ExportMe {
+  uint64_t val;
+} ExportMe;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void export_me(ExportMe *val);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/monomorph-1.compat.c
+++ b/tests/expectations/both/monomorph-1.compat.c
@@ -34,9 +34,7 @@ typedef struct Tuple_f32__f32 {
 typedef Tuple_f32__f32 Indirection_f32;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo_i32 a,
@@ -49,7 +47,5 @@ void root(Foo_i32 a,
           Indirection_f32 h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/monomorph-1.compat.c
+++ b/tests/expectations/both/monomorph-1.compat.c
@@ -1,0 +1,55 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Bar_Bar_f32 Bar_Bar_f32;
+
+typedef struct Bar_Foo_f32 Bar_Foo_f32;
+
+typedef struct Bar_f32 Bar_f32;
+
+typedef struct Foo_i32 {
+  const int32_t *data;
+} Foo_i32;
+
+typedef struct Foo_f32 {
+  const float *data;
+} Foo_f32;
+
+typedef struct Foo_Bar_f32 {
+  const Bar_f32 *data;
+} Foo_Bar_f32;
+
+typedef struct Tuple_Foo_f32_____f32 {
+  const Foo_f32 *a;
+  const float *b;
+} Tuple_Foo_f32_____f32;
+
+typedef struct Tuple_f32__f32 {
+  const float *a;
+  const float *b;
+} Tuple_f32__f32;
+
+typedef Tuple_f32__f32 Indirection_f32;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo_i32 a,
+          Foo_f32 b,
+          Bar_f32 c,
+          Foo_Bar_f32 d,
+          Bar_Foo_f32 e,
+          Bar_Bar_f32 f,
+          Tuple_Foo_f32_____f32 g,
+          Indirection_f32 h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/monomorph-2.compat.c
+++ b/tests/expectations/both/monomorph-2.compat.c
@@ -18,9 +18,7 @@ typedef struct List_A {
 } List_A;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void bar(List_B b);
@@ -28,7 +26,5 @@ void bar(List_B b);
 void foo(List_A a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/monomorph-2.compat.c
+++ b/tests/expectations/both/monomorph-2.compat.c
@@ -1,0 +1,34 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct A A;
+
+typedef struct B B;
+
+typedef struct List_B {
+  B *members;
+  uintptr_t count;
+} List_B;
+
+typedef struct List_A {
+  A *members;
+  uintptr_t count;
+} List_A;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void bar(List_B b);
+
+void foo(List_A a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/monomorph-3.compat.c
+++ b/tests/expectations/both/monomorph-3.compat.c
@@ -1,0 +1,55 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Bar_Bar_f32 Bar_Bar_f32;
+
+typedef struct Bar_Foo_f32 Bar_Foo_f32;
+
+typedef struct Bar_f32 Bar_f32;
+
+typedef union Foo_i32 {
+  const int32_t *data;
+} Foo_i32;
+
+typedef union Foo_f32 {
+  const float *data;
+} Foo_f32;
+
+typedef union Foo_Bar_f32 {
+  const Bar_f32 *data;
+} Foo_Bar_f32;
+
+typedef union Tuple_Foo_f32_____f32 {
+  const Foo_f32 *a;
+  const float *b;
+} Tuple_Foo_f32_____f32;
+
+typedef union Tuple_f32__f32 {
+  const float *a;
+  const float *b;
+} Tuple_f32__f32;
+
+typedef Tuple_f32__f32 Indirection_f32;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo_i32 a,
+          Foo_f32 b,
+          Bar_f32 c,
+          Foo_Bar_f32 d,
+          Bar_Foo_f32 e,
+          Bar_Bar_f32 f,
+          Tuple_Foo_f32_____f32 g,
+          Indirection_f32 h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/monomorph-3.compat.c
+++ b/tests/expectations/both/monomorph-3.compat.c
@@ -34,9 +34,7 @@ typedef union Tuple_f32__f32 {
 typedef Tuple_f32__f32 Indirection_f32;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo_i32 a,
@@ -49,7 +47,5 @@ void root(Foo_i32 a,
           Indirection_f32 h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/must-use.compat.c
+++ b/tests/expectations/both/must-use.compat.c
@@ -1,0 +1,52 @@
+#define MUST_USE_FUNC __attribute__((warn_unused_result))
+#define MUST_USE_STRUCT __attribute__((warn_unused))
+#define MUST_USE_ENUM /* nothing */
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum MaybeOwnedPtr_i32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Owned_i32,
+  None_i32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t MaybeOwnedPtr_i32_Tag;
+#endif // __cplusplus
+
+
+typedef struct Owned_Body_i32 {
+  int32_t *_0;
+} Owned_Body_i32;
+
+typedef struct MaybeOwnedPtr_i32 {
+  MaybeOwnedPtr_i32_Tag tag;
+  union {
+    Owned_Body_i32 owned;
+  };
+} MaybeOwnedPtr_i32;
+
+typedef struct MUST_USE_STRUCT OwnedPtr_i32 {
+  int32_t *ptr;
+} OwnedPtr_i32;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+MUST_USE_FUNC MaybeOwnedPtr_i32 maybe_consume(OwnedPtr_i32 input);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/must-use.compat.c
+++ b/tests/expectations/both/must-use.compat.c
@@ -17,10 +17,8 @@ enum MaybeOwnedPtr_i32_Tag
   None_i32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
 #endif // __cplusplus
-
 
 typedef struct Owned_Body_i32 {
   int32_t *_0;
@@ -38,15 +36,11 @@ typedef struct MUST_USE_STRUCT OwnedPtr_i32 {
 } OwnedPtr_i32;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 MUST_USE_FUNC MaybeOwnedPtr_i32 maybe_consume(OwnedPtr_i32 input);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/namespace_constant.compat.c
+++ b/tests/expectations/both/namespace_constant.compat.c
@@ -12,15 +12,11 @@ typedef struct Foo {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/namespace_constant.compat.c
+++ b/tests/expectations/both/namespace_constant.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define FOO 10
+
+#define ZOM 3.14
+
+typedef struct Foo {
+  int32_t x[FOO];
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/namespaces_constant.compat.c
+++ b/tests/expectations/both/namespaces_constant.compat.c
@@ -12,15 +12,11 @@ typedef struct Foo {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/namespaces_constant.compat.c
+++ b/tests/expectations/both/namespaces_constant.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define FOO 10
+
+#define ZOM 3.14
+
+typedef struct Foo {
+  int32_t x[FOO];
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/nested_import.compat.c
+++ b/tests/expectations/both/nested_import.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/both/no_includes.compat.c
+++ b/tests/expectations/both/no_includes.compat.c
@@ -1,13 +1,9 @@
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/no_includes.compat.c
+++ b/tests/expectations/both/no_includes.compat.c
@@ -1,0 +1,13 @@
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/nonnull.compat.c
+++ b/tests/expectations/both/nonnull.compat.c
@@ -1,0 +1,32 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct Foo_u64 {
+  float *a;
+  uint64_t *b;
+  Opaque *c;
+  uint64_t **d;
+  float **e;
+  Opaque **f;
+  uint64_t *g;
+  int32_t *h;
+  int32_t **i;
+} Foo_u64;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(int32_t *arg, Foo_u64 *foo, Opaque **d);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/nonnull.compat.c
+++ b/tests/expectations/both/nonnull.compat.c
@@ -18,15 +18,11 @@ typedef struct Foo_u64 {
 } Foo_u64;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(int32_t *arg, Foo_u64 *foo, Opaque **d);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/prefix.compat.c
+++ b/tests/expectations/both/prefix.compat.c
@@ -19,10 +19,8 @@ enum PREFIX_AbsoluteFontWeight_Tag
   Bold,
 };
 #ifndef __cplusplus
-
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 #endif // __cplusplus
-
 
 typedef struct PREFIX_Weight_Body {
   PREFIX_AbsoluteFontWeight_Tag tag;
@@ -35,15 +33,11 @@ typedef union PREFIX_AbsoluteFontWeight {
 } PREFIX_AbsoluteFontWeight;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/prefix.compat.c
+++ b/tests/expectations/both/prefix.compat.c
@@ -1,0 +1,49 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define PREFIX_LEN 42
+
+typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
+
+typedef int32_t PREFIX_ValuedLenArray[42];
+
+enum PREFIX_AbsoluteFontWeight_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Weight,
+  Normal,
+  Bold,
+};
+#ifndef __cplusplus
+
+typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+#endif // __cplusplus
+
+
+typedef struct PREFIX_Weight_Body {
+  PREFIX_AbsoluteFontWeight_Tag tag;
+  float _0;
+} PREFIX_Weight_Body;
+
+typedef union PREFIX_AbsoluteFontWeight {
+  PREFIX_AbsoluteFontWeight_Tag tag;
+  PREFIX_Weight_Body weight;
+} PREFIX_AbsoluteFontWeight;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/prefixed_struct_literal.compat.c
+++ b/tests/expectations/both/prefixed_struct_literal.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct PREFIXFoo {
+  int32_t a;
+  uint32_t b;
+} PREFIXFoo;
+#define PREFIXFoo_FOO (PREFIXFoo){ .a = 42, .b = 47 }
+
+#define PREFIXBAR (PREFIXFoo){ .a = 42, .b = 1337 }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(PREFIXFoo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/prefixed_struct_literal.compat.c
+++ b/tests/expectations/both/prefixed_struct_literal.compat.c
@@ -12,15 +12,11 @@ typedef struct PREFIXFoo {
 #define PREFIXBAR (PREFIXFoo){ .a = 42, .b = 1337 }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(PREFIXFoo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/prefixed_struct_literal_deep.compat.c
+++ b/tests/expectations/both/prefixed_struct_literal_deep.compat.c
@@ -16,15 +16,11 @@ typedef struct PREFIXFoo {
 #define PREFIXVAL (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(PREFIXFoo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/prefixed_struct_literal_deep.compat.c
+++ b/tests/expectations/both/prefixed_struct_literal_deep.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct PREFIXBar {
+  int32_t a;
+} PREFIXBar;
+
+typedef struct PREFIXFoo {
+  int32_t a;
+  uint32_t b;
+  PREFIXBar bar;
+} PREFIXFoo;
+
+#define PREFIXVAL (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(PREFIXFoo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/rename-crate.compat.c
+++ b/tests/expectations/both/rename-crate.compat.c
@@ -30,9 +30,7 @@ typedef struct Foo {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void no_extern_func(ContainsNoExternTy a);
@@ -42,7 +40,5 @@ void renamed_func(RenamedTy a);
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/rename-crate.compat.c
+++ b/tests/expectations/both/rename-crate.compat.c
@@ -1,0 +1,48 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if !defined(DEFINE_FREEBSD)
+typedef struct NoExternTy {
+  uint8_t field;
+} NoExternTy;
+#endif
+
+#if !defined(DEFINE_FREEBSD)
+typedef struct ContainsNoExternTy {
+  NoExternTy field;
+} ContainsNoExternTy;
+#endif
+
+#if defined(DEFINE_FREEBSD)
+typedef struct ContainsNoExternTy {
+  uint64_t field;
+} ContainsNoExternTy;
+#endif
+
+typedef struct RenamedTy {
+  uint64_t y;
+} RenamedTy;
+
+typedef struct Foo {
+  int32_t x;
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void no_extern_func(ContainsNoExternTy a);
+
+void renamed_func(RenamedTy a);
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/rename.compat.c
+++ b/tests/expectations/both/rename.compat.c
@@ -14,10 +14,8 @@ enum C_E
   y = 1,
 };
 #ifndef __cplusplus
-
 typedef uint8_t C_E;
 #endif // __cplusplus
-
 
 typedef struct C_A C_A;
 
@@ -36,9 +34,7 @@ typedef union C_D {
 typedef C_A C_F;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 extern const int32_t G;
@@ -46,7 +42,5 @@ extern const int32_t G;
 void root(const C_A *a, C_AwesomeB b, C_C c, C_D d, C_E e, C_F f);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/rename.compat.c
+++ b/tests/expectations/both/rename.compat.c
@@ -1,0 +1,52 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define C_H 10
+
+enum C_E
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  x = 0,
+  y = 1,
+};
+#ifndef __cplusplus
+
+typedef uint8_t C_E;
+#endif // __cplusplus
+
+
+typedef struct C_A C_A;
+
+typedef struct C_C C_C;
+
+typedef struct C_AwesomeB {
+  int32_t x;
+  float y;
+} C_AwesomeB;
+
+typedef union C_D {
+  int32_t x;
+  float y;
+} C_D;
+
+typedef C_A C_F;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+extern const int32_t G;
+
+void root(const C_A *a, C_AwesomeB b, C_C c, C_D d, C_E e, C_F f);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/renaming-overrides-prefixing.compat.c
+++ b/tests/expectations/both/renaming-overrides-prefixing.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct StyleA StyleA;
+
+typedef struct B {
+  int32_t x;
+  float y;
+} B;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const StyleA *a, B b);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/renaming-overrides-prefixing.compat.c
+++ b/tests/expectations/both/renaming-overrides-prefixing.compat.c
@@ -11,15 +11,11 @@ typedef struct B {
 } B;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const StyleA *a, B b);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/reserved.compat.c
+++ b/tests/expectations/both/reserved.compat.c
@@ -1,0 +1,53 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct A {
+  int32_t namespace_;
+  float float_;
+} A;
+
+typedef struct B {
+  int32_t namespace_;
+  float float_;
+} B;
+
+enum C_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  D,
+};
+#ifndef __cplusplus
+
+typedef uint8_t C_Tag;
+#endif // __cplusplus
+
+
+typedef struct D_Body {
+  int32_t namespace_;
+  float float_;
+} D_Body;
+
+typedef struct C {
+  C_Tag tag;
+  union {
+    D_Body d;
+  };
+} C;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(A a, B b, C c, int32_t namespace_, float float_);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/reserved.compat.c
+++ b/tests/expectations/both/reserved.compat.c
@@ -21,10 +21,8 @@ enum C_Tag
   D,
 };
 #ifndef __cplusplus
-
 typedef uint8_t C_Tag;
 #endif // __cplusplus
-
 
 typedef struct D_Body {
   int32_t namespace_;
@@ -39,15 +37,11 @@ typedef struct C {
 } C;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(A a, B b, C c, int32_t namespace_, float float_);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/simplify-option-ptr.compat.c
+++ b/tests/expectations/both/simplify-option-ptr.compat.c
@@ -18,15 +18,11 @@ typedef union Bar {
 } Bar;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const Opaque *a, Opaque *b, Foo c, Bar d);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/simplify-option-ptr.compat.c
+++ b/tests/expectations/both/simplify-option-ptr.compat.c
@@ -1,0 +1,32 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct Foo {
+  const Opaque *x;
+  Opaque *y;
+  void (*z)();
+} Foo;
+
+typedef union Bar {
+  const Opaque *x;
+  Opaque *y;
+  void (*z)();
+} Bar;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const Opaque *a, Opaque *b, Foo c, Bar d);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/static.compat.c
+++ b/tests/expectations/both/static.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Bar Bar;
+
+typedef struct Foo {
+
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+extern const Bar BAR;
+
+extern Foo FOO;
+
+extern const int32_t NUMBER;
+
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/static.compat.c
+++ b/tests/expectations/both/static.compat.c
@@ -10,9 +10,7 @@ typedef struct Foo {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 extern const Bar BAR;
@@ -24,7 +22,5 @@ extern const int32_t NUMBER;
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/std_lib.compat.c
+++ b/tests/expectations/both/std_lib.compat.c
@@ -10,15 +10,11 @@ typedef struct Result_i32__String Result_i32__String;
 typedef struct Vec_String Vec_String;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const Vec_String *a, const Option_i32 *b, const Result_i32__String *c);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/std_lib.compat.c
+++ b/tests/expectations/both/std_lib.compat.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Option_i32 Option_i32;
+
+typedef struct Result_i32__String Result_i32__String;
+
+typedef struct Vec_String Vec_String;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const Vec_String *a, const Option_i32 *b, const Result_i32__String *c);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/struct.compat.c
+++ b/tests/expectations/both/struct.compat.c
@@ -26,15 +26,11 @@ typedef struct TupleNamed {
 } TupleNamed;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Opaque *a, Normal b, NormalWithZST c, TupleRenamed d, TupleNamed e);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/struct.compat.c
+++ b/tests/expectations/both/struct.compat.c
@@ -1,0 +1,40 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct Normal {
+  int32_t x;
+  float y;
+} Normal;
+
+typedef struct NormalWithZST {
+  int32_t x;
+  float y;
+} NormalWithZST;
+
+typedef struct TupleRenamed {
+  int32_t m0;
+  float m1;
+} TupleRenamed;
+
+typedef struct TupleNamed {
+  int32_t x;
+  float y;
+} TupleNamed;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Opaque *a, Normal b, NormalWithZST c, TupleRenamed d, TupleNamed e);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/struct_literal.compat.c
+++ b/tests/expectations/both/struct_literal.compat.c
@@ -1,0 +1,33 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Bar Bar;
+
+typedef struct Foo {
+  int32_t a;
+  uint32_t b;
+} Foo;
+#define Foo_FOO (Foo){ .a = 42, .b = 47 }
+#define Foo_FOO2 (Foo){ .a = 42, .b = 47 }
+#define Foo_FOO3 (Foo){ .a = 42, .b = 47 }
+
+
+#define BAR (Foo){ .a = 42, .b = 1337 }
+
+
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo x, Bar bar);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/struct_literal.compat.c
+++ b/tests/expectations/both/struct_literal.compat.c
@@ -19,15 +19,11 @@ typedef struct Foo {
 
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo x, Bar bar);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/style-crash.compat.c
+++ b/tests/expectations/both/style-crash.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/both/transform-op.compat.c
+++ b/tests/expectations/both/transform-op.compat.c
@@ -24,10 +24,8 @@ enum StyleFoo_i32_Tag
   Bazz_i32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleFoo_i32_Tag;
 #endif // __cplusplus
-
 
 typedef struct StyleFoo_Body_i32 {
   StyleFoo_i32_Tag tag;
@@ -59,10 +57,6 @@ typedef enum StyleBar_i32_Tag {
   Bar3_i32,
   Bar4_i32,
 } StyleBar_i32_Tag;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct StyleBar1_Body_i32 {
   int32_t x;
@@ -99,10 +93,6 @@ typedef enum StyleBar_u32_Tag {
   Bar3_u32,
   Bar4_u32,
 } StyleBar_u32_Tag;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct StyleBar1_Body_u32 {
   int32_t x;
@@ -138,10 +128,8 @@ enum StyleBaz_Tag
   Baz3,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleBaz_Tag;
 #endif // __cplusplus
-
 
 typedef struct StyleBaz1_Body {
   StyleBaz_Tag tag;
@@ -169,10 +157,8 @@ enum StyleTaz_Tag
   Taz3,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleTaz_Tag;
 #endif // __cplusplus
-
 
 typedef struct StyleTaz1_Body {
   StyleBar_u32 _0;
@@ -191,9 +177,7 @@ typedef struct StyleTaz {
 } StyleTaz;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void foo(const StyleFoo_i32 *foo,
@@ -202,7 +186,5 @@ void foo(const StyleFoo_i32 *foo,
          const StyleTaz *taz);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/transform-op.compat.c
+++ b/tests/expectations/both/transform-op.compat.c
@@ -1,0 +1,208 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct StylePoint_i32 {
+  int32_t x;
+  int32_t y;
+} StylePoint_i32;
+
+typedef struct StylePoint_f32 {
+  float x;
+  float y;
+} StylePoint_f32;
+
+enum StyleFoo_i32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo_i32,
+  Bar_i32,
+  Baz_i32,
+  Bazz_i32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleFoo_i32_Tag;
+#endif // __cplusplus
+
+
+typedef struct StyleFoo_Body_i32 {
+  StyleFoo_i32_Tag tag;
+  int32_t x;
+  StylePoint_i32 y;
+  StylePoint_f32 z;
+} StyleFoo_Body_i32;
+
+typedef struct StyleBar_Body_i32 {
+  StyleFoo_i32_Tag tag;
+  int32_t _0;
+} StyleBar_Body_i32;
+
+typedef struct StyleBaz_Body_i32 {
+  StyleFoo_i32_Tag tag;
+  StylePoint_i32 _0;
+} StyleBaz_Body_i32;
+
+typedef union StyleFoo_i32 {
+  StyleFoo_i32_Tag tag;
+  StyleFoo_Body_i32 foo;
+  StyleBar_Body_i32 bar;
+  StyleBaz_Body_i32 baz;
+} StyleFoo_i32;
+
+typedef enum StyleBar_i32_Tag {
+  Bar1_i32,
+  Bar2_i32,
+  Bar3_i32,
+  Bar4_i32,
+} StyleBar_i32_Tag;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct StyleBar1_Body_i32 {
+  int32_t x;
+  StylePoint_i32 y;
+  StylePoint_f32 z;
+  int32_t (*u)(int32_t);
+} StyleBar1_Body_i32;
+
+typedef struct StyleBar2_Body_i32 {
+  int32_t _0;
+} StyleBar2_Body_i32;
+
+typedef struct StyleBar3_Body_i32 {
+  StylePoint_i32 _0;
+} StyleBar3_Body_i32;
+
+typedef struct StyleBar_i32 {
+  StyleBar_i32_Tag tag;
+  union {
+    StyleBar1_Body_i32 bar1;
+    StyleBar2_Body_i32 bar2;
+    StyleBar3_Body_i32 bar3;
+  };
+} StyleBar_i32;
+
+typedef struct StylePoint_u32 {
+  uint32_t x;
+  uint32_t y;
+} StylePoint_u32;
+
+typedef enum StyleBar_u32_Tag {
+  Bar1_u32,
+  Bar2_u32,
+  Bar3_u32,
+  Bar4_u32,
+} StyleBar_u32_Tag;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct StyleBar1_Body_u32 {
+  int32_t x;
+  StylePoint_u32 y;
+  StylePoint_f32 z;
+  int32_t (*u)(int32_t);
+} StyleBar1_Body_u32;
+
+typedef struct StyleBar2_Body_u32 {
+  uint32_t _0;
+} StyleBar2_Body_u32;
+
+typedef struct StyleBar3_Body_u32 {
+  StylePoint_u32 _0;
+} StyleBar3_Body_u32;
+
+typedef struct StyleBar_u32 {
+  StyleBar_u32_Tag tag;
+  union {
+    StyleBar1_Body_u32 bar1;
+    StyleBar2_Body_u32 bar2;
+    StyleBar3_Body_u32 bar3;
+  };
+} StyleBar_u32;
+
+enum StyleBaz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Baz1,
+  Baz2,
+  Baz3,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleBaz_Tag;
+#endif // __cplusplus
+
+
+typedef struct StyleBaz1_Body {
+  StyleBaz_Tag tag;
+  StyleBar_u32 _0;
+} StyleBaz1_Body;
+
+typedef struct StyleBaz2_Body {
+  StyleBaz_Tag tag;
+  StylePoint_i32 _0;
+} StyleBaz2_Body;
+
+typedef union StyleBaz {
+  StyleBaz_Tag tag;
+  StyleBaz1_Body baz1;
+  StyleBaz2_Body baz2;
+} StyleBaz;
+
+enum StyleTaz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Taz1,
+  Taz2,
+  Taz3,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleTaz_Tag;
+#endif // __cplusplus
+
+
+typedef struct StyleTaz1_Body {
+  StyleBar_u32 _0;
+} StyleTaz1_Body;
+
+typedef struct StyleTaz2_Body {
+  StyleBaz _0;
+} StyleTaz2_Body;
+
+typedef struct StyleTaz {
+  StyleTaz_Tag tag;
+  union {
+    StyleTaz1_Body taz1;
+    StyleTaz2_Body taz2;
+  };
+} StyleTaz;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void foo(const StyleFoo_i32 *foo,
+         const StyleBar_i32 *bar,
+         const StyleBaz *baz,
+         const StyleTaz *taz);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/transparent.compat.c
+++ b/tests/expectations/both/transparent.compat.c
@@ -26,9 +26,7 @@ typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 #define EnumWithAssociatedConstantInImpl_TEN 10
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(TransparentComplexWrappingStructTuple a,
@@ -41,7 +39,5 @@ void root(TransparentComplexWrappingStructTuple a,
           EnumWithAssociatedConstantInImpl h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/transparent.compat.c
+++ b/tests/expectations/both/transparent.compat.c
@@ -1,0 +1,47 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct DummyStruct DummyStruct;
+
+typedef struct EnumWithAssociatedConstantInImpl EnumWithAssociatedConstantInImpl;
+
+typedef DummyStruct TransparentComplexWrappingStructTuple;
+
+typedef uint32_t TransparentPrimitiveWrappingStructTuple;
+
+typedef DummyStruct TransparentComplexWrappingStructure;
+
+typedef uint32_t TransparentPrimitiveWrappingStructure;
+
+typedef DummyStruct TransparentComplexWrapper_i32;
+
+typedef uint32_t TransparentPrimitiveWrapper_i32;
+
+typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
+#define TransparentPrimitiveWithAssociatedConstants_ZERO 0
+#define TransparentPrimitiveWithAssociatedConstants_ONE 1
+
+#define EnumWithAssociatedConstantInImpl_TEN 10
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(TransparentComplexWrappingStructTuple a,
+          TransparentPrimitiveWrappingStructTuple b,
+          TransparentComplexWrappingStructure c,
+          TransparentPrimitiveWrappingStructure d,
+          TransparentComplexWrapper_i32 e,
+          TransparentPrimitiveWrapper_i32 f,
+          TransparentPrimitiveWithAssociatedConstants g,
+          EnumWithAssociatedConstantInImpl h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/typedef.compat.c
+++ b/tests/expectations/both/typedef.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo_i32__i32 {
+  int32_t x;
+  int32_t y;
+} Foo_i32__i32;
+
+typedef Foo_i32__i32 IntFoo_i32;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(IntFoo_i32 a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/typedef.compat.c
+++ b/tests/expectations/both/typedef.compat.c
@@ -11,15 +11,11 @@ typedef struct Foo_i32__i32 {
 typedef Foo_i32__i32 IntFoo_i32;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(IntFoo_i32 a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/union.compat.c
+++ b/tests/expectations/both/union.compat.c
@@ -16,15 +16,11 @@ typedef union NormalWithZST {
 } NormalWithZST;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Opaque *a, Normal b, NormalWithZST c);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/union.compat.c
+++ b/tests/expectations/both/union.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef union Normal {
+  int32_t x;
+  float y;
+} Normal;
+
+typedef union NormalWithZST {
+  int32_t x;
+  float y;
+} NormalWithZST;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Opaque *a, Normal b, NormalWithZST c);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/va_list.compat.c
+++ b/tests/expectations/both/va_list.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+int32_t va_list_test(va_list ap);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/va_list.compat.c
+++ b/tests/expectations/both/va_list.compat.c
@@ -4,15 +4,11 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 int32_t va_list_test(va_list ap);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/both/workspace.compat.c
+++ b/tests/expectations/both/workspace.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct ExtType {
+  uint32_t data;
+} ExtType;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void consume_ext(ExtType _ext);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/both/workspace.compat.c
+++ b/tests/expectations/both/workspace.compat.c
@@ -8,15 +8,11 @@ typedef struct ExtType {
 } ExtType;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void consume_ext(ExtType _ext);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/cdecl.compat.c
+++ b/tests/expectations/cdecl.compat.c
@@ -34,9 +34,7 @@ typedef void (*N[16])(int32_t, int32_t);
 typedef void (*P)(int32_t named1st, bool, bool named3rd, int32_t _);
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void (*O(void))(void);
@@ -44,7 +42,5 @@ void (*O(void))(void);
 void root(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m, N n, P p);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/cdecl.compat.c
+++ b/tests/expectations/cdecl.compat.c
@@ -1,0 +1,50 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef void (*A)();
+
+typedef void (*B)();
+
+typedef bool (*C)(int32_t, int32_t);
+
+typedef bool (*(*D)(int32_t))(float);
+
+typedef const int32_t (*(*E)())[16];
+
+typedef const int32_t *F;
+
+typedef const int32_t *const *G;
+
+typedef int32_t *const *H;
+
+typedef const int32_t (*I)[16];
+
+typedef double (**J)(float);
+
+typedef int32_t K[16];
+
+typedef const int32_t *L[16];
+
+typedef bool (*M[16])(int32_t, int32_t);
+
+typedef void (*N[16])(int32_t, int32_t);
+
+typedef void (*P)(int32_t named1st, bool, bool named3rd, int32_t _);
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void (*O(void))(void);
+
+void root(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m, N n, P p);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/cfg-2.compat.c
+++ b/tests/expectations/cfg-2.compat.c
@@ -1,0 +1,48 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if defined(NOT_DEFINED)
+#define DEFAULT_X 8
+#endif
+
+#if defined(DEFINED)
+#define DEFAULT_X 42
+#endif
+
+#if (defined(NOT_DEFINED) || defined(DEFINED))
+typedef struct {
+  int32_t x;
+} Foo;
+#endif
+
+#if defined(NOT_DEFINED)
+typedef struct {
+  Foo y;
+} Bar;
+#endif
+
+#if defined(DEFINED)
+typedef struct {
+  Foo z;
+} Bar;
+#endif
+
+typedef struct {
+  Bar w;
+} Root;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Root a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/cfg-2.compat.c
+++ b/tests/expectations/cfg-2.compat.c
@@ -34,15 +34,11 @@ typedef struct {
 } Root;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Root a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/cfg-field.compat.c
+++ b/tests/expectations/cfg-field.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/cfg.compat.c
+++ b/tests/expectations/cfg.compat.c
@@ -14,10 +14,8 @@ enum BarType
   C,
 };
 #ifndef __cplusplus
-
 typedef uint32_t BarType;
 #endif // __cplusplus
-
 #endif
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
@@ -31,10 +29,8 @@ enum FooType
   C,
 };
 #ifndef __cplusplus
-
 typedef uint32_t FooType;
 #endif // __cplusplus
-
 #endif
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
@@ -54,9 +50,7 @@ typedef struct {
 #endif
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
@@ -68,7 +62,5 @@ void root(BarHandle a);
 #endif
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/cfg.compat.c
+++ b/tests/expectations/cfg.compat.c
@@ -1,0 +1,74 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+enum BarType
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  A,
+  B,
+  C,
+};
+#ifndef __cplusplus
+
+typedef uint32_t BarType;
+#endif // __cplusplus
+
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+enum FooType
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  A,
+  B,
+  C,
+};
+#ifndef __cplusplus
+
+typedef uint32_t FooType;
+#endif // __cplusplus
+
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+typedef struct {
+  FooType ty;
+  int32_t x;
+  float y;
+} FooHandle;
+#endif
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+typedef struct {
+  BarType ty;
+  int32_t x;
+  float y;
+} BarHandle;
+#endif
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+void root(FooHandle a);
+#endif
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+void root(BarHandle a);
+#endif
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/const_conflict.compat.c
+++ b/tests/expectations/const_conflict.compat.c
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define Foo_FOO 42

--- a/tests/expectations/const_transparent.compat.c
+++ b/tests/expectations/const_transparent.compat.c
@@ -1,0 +1,8 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef uint8_t Transparent;
+
+#define FOO 0

--- a/tests/expectations/constant.compat.c
+++ b/tests/expectations/constant.compat.c
@@ -28,15 +28,11 @@ typedef struct {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/constant.compat.c
+++ b/tests/expectations/constant.compat.c
@@ -1,0 +1,42 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define DELIMITER ':'
+
+#define FOO 10
+
+#define HEART L'\u2764'
+
+#define LEFTCURLY '{'
+
+#define NEG_ONE -1
+
+#define NEWLINE '\n'
+
+#define POS_ONE 1
+
+#define QUOTE '\''
+
+#define TAB '\t'
+
+#define ZOM 3.14
+
+typedef struct {
+  int32_t x[FOO];
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/derive-eq.compat.c
+++ b/tests/expectations/derive-eq.compat.c
@@ -19,10 +19,8 @@ enum Bar_Tag
   FooParen,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Bar_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   Bar_Tag tag;
@@ -49,15 +47,11 @@ typedef union {
 } Bar;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 Foo root(Bar aBar);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/derive-eq.compat.c
+++ b/tests/expectations/derive-eq.compat.c
@@ -1,0 +1,63 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  bool a;
+  int32_t b;
+} Foo;
+
+enum Bar_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Baz,
+  Bazz,
+  FooNamed,
+  FooParen,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Bar_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  Bar_Tag tag;
+  Foo named;
+} Bazz_Body;
+
+typedef struct {
+  Bar_Tag tag;
+  int32_t different;
+  uint32_t fields;
+} FooNamed_Body;
+
+typedef struct {
+  Bar_Tag tag;
+  int32_t _0;
+  Foo _1;
+} FooParen_Body;
+
+typedef union {
+  Bar_Tag tag;
+  Bazz_Body bazz;
+  FooNamed_Body foo_named;
+  FooParen_Body foo_paren;
+} Bar;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+Foo root(Bar aBar);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/destructor-and-copy-ctor.compat.c
@@ -1,0 +1,213 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum FillRule
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  A,
+  B,
+};
+#ifndef __cplusplus
+
+typedef uint8_t FillRule;
+#endif // __cplusplus
+
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+typedef struct {
+  uintptr_t len;
+  uint32_t *ptr;
+} OwnedSlice_u32;
+
+typedef struct {
+  FillRule fill;
+  OwnedSlice_u32 coordinates;
+} Polygon_u32;
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+typedef struct {
+  uintptr_t len;
+  int32_t *ptr;
+} OwnedSlice_i32;
+
+enum Foo_u32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar_u32,
+  Polygon1_u32,
+  Slice1_u32,
+  Slice2_u32,
+  Slice3_u32,
+  Slice4_u32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Foo_u32_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  Polygon_u32 _0;
+} Polygon1_Body_u32;
+
+typedef struct {
+  OwnedSlice_u32 _0;
+} Slice1_Body_u32;
+
+typedef struct {
+  OwnedSlice_i32 _0;
+} Slice2_Body_u32;
+
+typedef struct {
+  FillRule fill;
+  OwnedSlice_u32 coords;
+} Slice3_Body_u32;
+
+typedef struct {
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice4_Body_u32;
+
+typedef struct {
+  Foo_u32_Tag tag;
+  union {
+    Polygon1_Body_u32 polygon1;
+    Slice1_Body_u32 slice1;
+    Slice2_Body_u32 slice2;
+    Slice3_Body_u32 slice3;
+    Slice4_Body_u32 slice4;
+  };
+} Foo_u32;
+
+typedef struct {
+  FillRule fill;
+  OwnedSlice_i32 coordinates;
+} Polygon_i32;
+
+enum Baz_i32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar2_i32,
+  Polygon21_i32,
+  Slice21_i32,
+  Slice22_i32,
+  Slice23_i32,
+  Slice24_i32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Baz_i32_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  Baz_i32_Tag tag;
+  Polygon_i32 _0;
+} Polygon21_Body_i32;
+
+typedef struct {
+  Baz_i32_Tag tag;
+  OwnedSlice_i32 _0;
+} Slice21_Body_i32;
+
+typedef struct {
+  Baz_i32_Tag tag;
+  OwnedSlice_i32 _0;
+} Slice22_Body_i32;
+
+typedef struct {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice23_Body_i32;
+
+typedef struct {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  OwnedSlice_i32 coords;
+} Slice24_Body_i32;
+
+typedef union {
+  Baz_i32_Tag tag;
+  Polygon21_Body_i32 polygon21;
+  Slice21_Body_i32 slice21;
+  Slice22_Body_i32 slice22;
+  Slice23_Body_i32 slice23;
+  Slice24_Body_i32 slice24;
+} Baz_i32;
+
+enum Taz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar3,
+  Taz1,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Taz_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  Taz_Tag tag;
+  int32_t _0;
+} Taz1_Body;
+
+typedef union {
+  Taz_Tag tag;
+  Taz1_Body taz1;
+} Taz;
+
+enum Tazz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar4,
+  Taz2,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Tazz_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  Tazz_Tag tag;
+  int32_t _0;
+} Taz2_Body;
+
+typedef union {
+  Tazz_Tag tag;
+  Taz2_Body taz2;
+} Tazz;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const Foo_u32 *a, const Baz_i32 *b, const Taz *c, Tazz d);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/destructor-and-copy-ctor.compat.c
@@ -12,10 +12,8 @@ enum FillRule
   B,
 };
 #ifndef __cplusplus
-
 typedef uint8_t FillRule;
 #endif // __cplusplus
-
 
 /**
  * This will have a destructor manually implemented via variant_body, and
@@ -53,10 +51,8 @@ enum Foo_u32_Tag
   Slice4_u32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Foo_u32_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   Polygon_u32 _0;
@@ -109,10 +105,8 @@ enum Baz_i32_Tag
   Slice24_i32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Baz_i32_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   Baz_i32_Tag tag;
@@ -159,10 +153,8 @@ enum Taz_Tag
   Taz1,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Taz_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   Taz_Tag tag;
@@ -183,10 +175,8 @@ enum Tazz_Tag
   Taz2,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Tazz_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   Tazz_Tag tag;
@@ -199,15 +189,11 @@ typedef union {
 } Tazz;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const Foo_u32 *a, const Baz_i32 *b, const Taz *c, Tazz d);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/display_list.compat.c
+++ b/tests/expectations/display_list.compat.c
@@ -1,0 +1,65 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  float x;
+  float y;
+  float w;
+  float h;
+} Rect;
+
+typedef struct {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+  uint8_t a;
+} Color;
+
+enum DisplayItem_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Fill,
+  Image,
+  ClearScreen,
+};
+#ifndef __cplusplus
+
+typedef uint8_t DisplayItem_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  DisplayItem_Tag tag;
+  Rect _0;
+  Color _1;
+} Fill_Body;
+
+typedef struct {
+  DisplayItem_Tag tag;
+  uint32_t id;
+  Rect bounds;
+} Image_Body;
+
+typedef union {
+  DisplayItem_Tag tag;
+  Fill_Body fill;
+  Image_Body image;
+} DisplayItem;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+bool push_item(DisplayItem item);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/display_list.compat.c
+++ b/tests/expectations/display_list.compat.c
@@ -27,10 +27,8 @@ enum DisplayItem_Tag
   ClearScreen,
 };
 #ifndef __cplusplus
-
 typedef uint8_t DisplayItem_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   DisplayItem_Tag tag;
@@ -51,15 +49,11 @@ typedef union {
 } DisplayItem;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 bool push_item(DisplayItem item);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/docstyle_auto.compat.c
+++ b/tests/expectations/docstyle_auto.compat.c
@@ -1,0 +1,21 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+/**
+ * The root of all evil.
+ */
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/docstyle_auto.compat.c
+++ b/tests/expectations/docstyle_auto.compat.c
@@ -4,9 +4,7 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 /**
@@ -15,7 +13,5 @@ extern "C" {
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/docstyle_c99.compat.c
+++ b/tests/expectations/docstyle_c99.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+// The root of all evil.
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/docstyle_c99.compat.c
+++ b/tests/expectations/docstyle_c99.compat.c
@@ -4,16 +4,12 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 // The root of all evil.
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/docstyle_doxy.compat.c
+++ b/tests/expectations/docstyle_doxy.compat.c
@@ -1,0 +1,21 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+/**
+ * The root of all evil.
+ */
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/docstyle_doxy.compat.c
+++ b/tests/expectations/docstyle_doxy.compat.c
@@ -4,9 +4,7 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 /**
@@ -15,7 +13,5 @@ extern "C" {
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/enum.compat.c
+++ b/tests/expectations/enum.compat.c
@@ -1,0 +1,221 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum A
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  a1 = 0,
+  a2 = 2,
+  a3,
+  a4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uint32_t A;
+#endif // __cplusplus
+
+
+enum B
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  b1 = 0,
+  b2 = 2,
+  b3,
+  b4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uint16_t B;
+#endif // __cplusplus
+
+
+enum C
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  c1 = 0,
+  c2 = 2,
+  c3,
+  c4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uint8_t C;
+#endif // __cplusplus
+
+
+enum D
+#ifdef __cplusplus
+  : uintptr_t
+#endif // __cplusplus
+ {
+  d1 = 0,
+  d2 = 2,
+  d3,
+  d4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uintptr_t D;
+#endif // __cplusplus
+
+
+enum E
+#ifdef __cplusplus
+  : intptr_t
+#endif // __cplusplus
+ {
+  e1 = 0,
+  e2 = 2,
+  e3,
+  e4 = 5,
+};
+#ifndef __cplusplus
+
+typedef intptr_t E;
+#endif // __cplusplus
+
+
+typedef enum {
+  k1,
+  k2,
+  k3,
+  k4,
+} K;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+enum L
+#ifdef __cplusplus
+  : int8_t
+#endif // __cplusplus
+ {
+  l1 = -1,
+  l2 = 0,
+  l3 = 1,
+};
+#ifndef __cplusplus
+
+typedef int8_t L;
+#endif // __cplusplus
+
+
+typedef struct I I;
+
+typedef struct J J;
+
+typedef struct Opaque Opaque;
+
+enum F_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+  Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t F_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  F_Tag tag;
+  int16_t _0;
+} Foo_Body;
+
+typedef struct {
+  F_Tag tag;
+  uint8_t x;
+  int16_t y;
+} Bar_Body;
+
+typedef union {
+  F_Tag tag;
+  Foo_Body foo;
+  Bar_Body bar;
+} F;
+
+typedef enum {
+  G_Foo,
+  G_Bar,
+  G_Baz,
+} G_Tag;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct {
+  int16_t _0;
+} G_Foo_Body;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} G_Bar_Body;
+
+typedef struct {
+  G_Tag tag;
+  union {
+    G_Foo_Body foo;
+    G_Bar_Body bar;
+  };
+} G;
+
+enum H_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t H_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  int16_t _0;
+} H_Foo_Body;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} H_Bar_Body;
+
+typedef struct {
+  H_Tag tag;
+  union {
+    H_Foo_Body foo;
+    H_Bar_Body bar;
+  };
+} H;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/enum.compat.c
+++ b/tests/expectations/enum.compat.c
@@ -14,10 +14,8 @@ enum A
   a4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uint32_t A;
 #endif // __cplusplus
-
 
 enum B
 #ifdef __cplusplus
@@ -30,10 +28,8 @@ enum B
   b4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uint16_t B;
 #endif // __cplusplus
-
 
 enum C
 #ifdef __cplusplus
@@ -46,10 +42,8 @@ enum C
   c4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uint8_t C;
 #endif // __cplusplus
-
 
 enum D
 #ifdef __cplusplus
@@ -62,10 +56,8 @@ enum D
   d4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uintptr_t D;
 #endif // __cplusplus
-
 
 enum E
 #ifdef __cplusplus
@@ -78,10 +70,8 @@ enum E
   e4 = 5,
 };
 #ifndef __cplusplus
-
 typedef intptr_t E;
 #endif // __cplusplus
-
 
 typedef enum {
   k1,
@@ -89,10 +79,6 @@ typedef enum {
   k3,
   k4,
 } K;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 enum L
 #ifdef __cplusplus
@@ -104,10 +90,8 @@ enum L
   l3 = 1,
 };
 #ifndef __cplusplus
-
 typedef int8_t L;
 #endif // __cplusplus
-
 
 typedef struct I I;
 
@@ -125,10 +109,8 @@ enum F_Tag
   Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t F_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   F_Tag tag;
@@ -152,10 +134,6 @@ typedef enum {
   G_Bar,
   G_Baz,
 } G_Tag;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct {
   int16_t _0;
@@ -184,10 +162,8 @@ enum H_Tag
   H_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t H_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   int16_t _0;
@@ -207,15 +183,11 @@ typedef struct {
 } H;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/euclid.compat.c
+++ b/tests/expectations/euclid.compat.c
@@ -1,0 +1,129 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  float _0;
+} TypedLength_f32__UnknownUnit;
+
+typedef struct {
+  float _0;
+} TypedLength_f32__LayoutUnit;
+
+typedef TypedLength_f32__UnknownUnit Length_f32;
+
+typedef TypedLength_f32__LayoutUnit LayoutLength;
+
+typedef struct {
+  float top;
+  float right;
+  float bottom;
+  float left;
+} TypedSideOffsets2D_f32__UnknownUnit;
+
+typedef struct {
+  float top;
+  float right;
+  float bottom;
+  float left;
+} TypedSideOffsets2D_f32__LayoutUnit;
+
+typedef TypedSideOffsets2D_f32__UnknownUnit SideOffsets2D_f32;
+
+typedef TypedSideOffsets2D_f32__LayoutUnit LayoutSideOffsets2D;
+
+typedef struct {
+  float width;
+  float height;
+} TypedSize2D_f32__UnknownUnit;
+
+typedef struct {
+  float width;
+  float height;
+} TypedSize2D_f32__LayoutUnit;
+
+typedef TypedSize2D_f32__UnknownUnit Size2D_f32;
+
+typedef TypedSize2D_f32__LayoutUnit LayoutSize2D;
+
+typedef struct {
+  float x;
+  float y;
+} TypedPoint2D_f32__UnknownUnit;
+
+typedef struct {
+  float x;
+  float y;
+} TypedPoint2D_f32__LayoutUnit;
+
+typedef TypedPoint2D_f32__UnknownUnit Point2D_f32;
+
+typedef TypedPoint2D_f32__LayoutUnit LayoutPoint2D;
+
+typedef struct {
+  TypedPoint2D_f32__UnknownUnit origin;
+  TypedSize2D_f32__UnknownUnit size;
+} TypedRect_f32__UnknownUnit;
+
+typedef struct {
+  TypedPoint2D_f32__LayoutUnit origin;
+  TypedSize2D_f32__LayoutUnit size;
+} TypedRect_f32__LayoutUnit;
+
+typedef TypedRect_f32__UnknownUnit Rect_f32;
+
+typedef TypedRect_f32__LayoutUnit LayoutRect;
+
+typedef struct {
+  float m11;
+  float m12;
+  float m21;
+  float m22;
+  float m31;
+  float m32;
+} TypedTransform2D_f32__UnknownUnit__LayoutUnit;
+
+typedef struct {
+  float m11;
+  float m12;
+  float m21;
+  float m22;
+  float m31;
+  float m32;
+} TypedTransform2D_f32__LayoutUnit__UnknownUnit;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(TypedLength_f32__UnknownUnit length_a,
+          TypedLength_f32__LayoutUnit length_b,
+          Length_f32 length_c,
+          LayoutLength length_d,
+          TypedSideOffsets2D_f32__UnknownUnit side_offsets_a,
+          TypedSideOffsets2D_f32__LayoutUnit side_offsets_b,
+          SideOffsets2D_f32 side_offsets_c,
+          LayoutSideOffsets2D side_offsets_d,
+          TypedSize2D_f32__UnknownUnit size_a,
+          TypedSize2D_f32__LayoutUnit size_b,
+          Size2D_f32 size_c,
+          LayoutSize2D size_d,
+          TypedPoint2D_f32__UnknownUnit point_a,
+          TypedPoint2D_f32__LayoutUnit point_b,
+          Point2D_f32 point_c,
+          LayoutPoint2D point_d,
+          TypedRect_f32__UnknownUnit rect_a,
+          TypedRect_f32__LayoutUnit rect_b,
+          Rect_f32 rect_c,
+          LayoutRect rect_d,
+          TypedTransform2D_f32__UnknownUnit__LayoutUnit transform_a,
+          TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/euclid.compat.c
+++ b/tests/expectations/euclid.compat.c
@@ -94,9 +94,7 @@ typedef struct {
 } TypedTransform2D_f32__LayoutUnit__UnknownUnit;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(TypedLength_f32__UnknownUnit length_a,
@@ -123,7 +121,5 @@ void root(TypedLength_f32__UnknownUnit length_a,
           TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/expand.compat.c
+++ b/tests/expectations/expand.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/expand.compat.c
+++ b/tests/expectations/expand.compat.c
@@ -8,15 +8,11 @@ typedef struct {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/expand_default_features.compat.c
+++ b/tests/expectations/expand_default_features.compat.c
@@ -8,9 +8,7 @@ typedef struct {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void extra_debug_fn(void);
@@ -18,7 +16,5 @@ void extra_debug_fn(void);
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/expand_default_features.compat.c
+++ b/tests/expectations/expand_default_features.compat.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void extra_debug_fn(void);
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/expand_features.compat.c
+++ b/tests/expectations/expand_features.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void cbindgen(void);
+
+void extra_debug_fn(void);
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/expand_features.compat.c
+++ b/tests/expectations/expand_features.compat.c
@@ -8,9 +8,7 @@ typedef struct {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void cbindgen(void);
@@ -20,7 +18,5 @@ void extra_debug_fn(void);
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/expand_no_default_features.compat.c
+++ b/tests/expectations/expand_no_default_features.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/expand_no_default_features.compat.c
+++ b/tests/expectations/expand_no_default_features.compat.c
@@ -8,15 +8,11 @@ typedef struct {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/extern-2.compat.c
+++ b/tests/expectations/extern-2.compat.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void first(void);
+
+void second(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/extern-2.compat.c
+++ b/tests/expectations/extern-2.compat.c
@@ -4,9 +4,7 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void first(void);
@@ -14,7 +12,5 @@ void first(void);
 void second(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/extern.compat.c
+++ b/tests/expectations/extern.compat.c
@@ -9,9 +9,7 @@ typedef struct {
 } Normal;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 extern void bar(Normal a);
@@ -19,7 +17,5 @@ extern void bar(Normal a);
 extern int32_t foo(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/extern.compat.c
+++ b/tests/expectations/extern.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  float y;
+} Normal;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+extern void bar(Normal a);
+
+extern int32_t foo(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/external_workspace_child.compat.c
+++ b/tests/expectations/external_workspace_child.compat.c
@@ -8,15 +8,11 @@ typedef struct {
 } ExtType;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void consume_ext(ExtType _ext);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/external_workspace_child.compat.c
+++ b/tests/expectations/external_workspace_child.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  uint32_t data;
+} ExtType;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void consume_ext(ExtType _ext);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/fns.compat.c
+++ b/tests/expectations/fns.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  void (*noArgs)();
+  void (*anonymousArg)(int32_t);
+  int32_t (*returnsNumber)();
+  int8_t (*namedArgs)(int32_t first, int16_t snd);
+  int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
+} Fns;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Fns _fns);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/fns.compat.c
+++ b/tests/expectations/fns.compat.c
@@ -12,15 +12,11 @@ typedef struct {
 } Fns;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Fns _fns);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/global_attr.compat.c
+++ b/tests/expectations/global_attr.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/include.compat.c
+++ b/tests/expectations/include.compat.c
@@ -1,0 +1,5 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>

--- a/tests/expectations/include_item.compat.c
+++ b/tests/expectations/include_item.compat.c
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  float y;
+} A;
+
+typedef struct {
+  A data;
+} B;

--- a/tests/expectations/include_specific.compat.c
+++ b/tests/expectations/include_specific.compat.c
@@ -1,0 +1,1 @@
+#include <math.h>

--- a/tests/expectations/inner_mod.compat.c
+++ b/tests/expectations/inner_mod.compat.c
@@ -8,15 +8,11 @@ typedef struct {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/inner_mod.compat.c
+++ b/tests/expectations/inner_mod.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  float x;
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/item_types.compat.c
+++ b/tests/expectations/item_types.compat.c
@@ -12,7 +12,5 @@ enum OnlyThisShouldBeGenerated
   Bar,
 };
 #ifndef __cplusplus
-
 typedef uint8_t OnlyThisShouldBeGenerated;
 #endif // __cplusplus
-

--- a/tests/expectations/item_types.compat.c
+++ b/tests/expectations/item_types.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum OnlyThisShouldBeGenerated
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+};
+#ifndef __cplusplus
+
+typedef uint8_t OnlyThisShouldBeGenerated;
+#endif // __cplusplus
+

--- a/tests/expectations/item_types_renamed.compat.c
+++ b/tests/expectations/item_types_renamed.compat.c
@@ -12,7 +12,5 @@ enum StyleOnlyThisShouldBeGenerated
   Bar,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleOnlyThisShouldBeGenerated;
 #endif // __cplusplus
-

--- a/tests/expectations/item_types_renamed.compat.c
+++ b/tests/expectations/item_types_renamed.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum StyleOnlyThisShouldBeGenerated
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleOnlyThisShouldBeGenerated;
+#endif // __cplusplus
+

--- a/tests/expectations/lifetime_arg.compat.c
+++ b/tests/expectations/lifetime_arg.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  const int32_t *data;
+} A;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(A _a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/lifetime_arg.compat.c
+++ b/tests/expectations/lifetime_arg.compat.c
@@ -8,15 +8,11 @@ typedef struct {
 } A;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(A _a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/mod_attr.compat.c
+++ b/tests/expectations/mod_attr.compat.c
@@ -1,0 +1,44 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if defined(BAR)
+#define BAR 2
+#endif
+
+#if defined(FOO)
+#define FOO 1
+#endif
+
+#if defined(BAR)
+typedef struct {
+
+} Bar;
+#endif
+
+#if defined(FOO)
+typedef struct {
+
+} Foo;
+#endif
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+#if defined(BAR)
+void bar(const Bar *bar);
+#endif
+
+#if defined(FOO)
+void foo(const Foo *foo);
+#endif
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/mod_attr.compat.c
+++ b/tests/expectations/mod_attr.compat.c
@@ -24,9 +24,7 @@ typedef struct {
 #endif
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 #if defined(BAR)
@@ -38,7 +36,5 @@ void foo(const Foo *foo);
 #endif
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/mod_path.compat.c
+++ b/tests/expectations/mod_path.compat.c
@@ -10,15 +10,11 @@ typedef struct {
 } ExportMe;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void export_me(ExportMe *val);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/mod_path.compat.c
+++ b/tests/expectations/mod_path.compat.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define EXPORT_ME_TOO 42
+
+typedef struct {
+  uint64_t val;
+} ExportMe;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void export_me(ExportMe *val);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/monomorph-1.compat.c
+++ b/tests/expectations/monomorph-1.compat.c
@@ -34,9 +34,7 @@ typedef struct {
 typedef Tuple_f32__f32 Indirection_f32;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo_i32 a,
@@ -49,7 +47,5 @@ void root(Foo_i32 a,
           Indirection_f32 h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/monomorph-1.compat.c
+++ b/tests/expectations/monomorph-1.compat.c
@@ -1,0 +1,55 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Bar_Bar_f32 Bar_Bar_f32;
+
+typedef struct Bar_Foo_f32 Bar_Foo_f32;
+
+typedef struct Bar_f32 Bar_f32;
+
+typedef struct {
+  const int32_t *data;
+} Foo_i32;
+
+typedef struct {
+  const float *data;
+} Foo_f32;
+
+typedef struct {
+  const Bar_f32 *data;
+} Foo_Bar_f32;
+
+typedef struct {
+  const Foo_f32 *a;
+  const float *b;
+} Tuple_Foo_f32_____f32;
+
+typedef struct {
+  const float *a;
+  const float *b;
+} Tuple_f32__f32;
+
+typedef Tuple_f32__f32 Indirection_f32;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo_i32 a,
+          Foo_f32 b,
+          Bar_f32 c,
+          Foo_Bar_f32 d,
+          Bar_Foo_f32 e,
+          Bar_Bar_f32 f,
+          Tuple_Foo_f32_____f32 g,
+          Indirection_f32 h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/monomorph-2.compat.c
+++ b/tests/expectations/monomorph-2.compat.c
@@ -1,0 +1,34 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct A A;
+
+typedef struct B B;
+
+typedef struct {
+  B *members;
+  uintptr_t count;
+} List_B;
+
+typedef struct {
+  A *members;
+  uintptr_t count;
+} List_A;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void bar(List_B b);
+
+void foo(List_A a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/monomorph-2.compat.c
+++ b/tests/expectations/monomorph-2.compat.c
@@ -18,9 +18,7 @@ typedef struct {
 } List_A;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void bar(List_B b);
@@ -28,7 +26,5 @@ void bar(List_B b);
 void foo(List_A a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/monomorph-3.compat.c
+++ b/tests/expectations/monomorph-3.compat.c
@@ -34,9 +34,7 @@ typedef union {
 typedef Tuple_f32__f32 Indirection_f32;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo_i32 a,
@@ -49,7 +47,5 @@ void root(Foo_i32 a,
           Indirection_f32 h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/monomorph-3.compat.c
+++ b/tests/expectations/monomorph-3.compat.c
@@ -1,0 +1,55 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Bar_Bar_f32 Bar_Bar_f32;
+
+typedef struct Bar_Foo_f32 Bar_Foo_f32;
+
+typedef struct Bar_f32 Bar_f32;
+
+typedef union {
+  const int32_t *data;
+} Foo_i32;
+
+typedef union {
+  const float *data;
+} Foo_f32;
+
+typedef union {
+  const Bar_f32 *data;
+} Foo_Bar_f32;
+
+typedef union {
+  const Foo_f32 *a;
+  const float *b;
+} Tuple_Foo_f32_____f32;
+
+typedef union {
+  const float *a;
+  const float *b;
+} Tuple_f32__f32;
+
+typedef Tuple_f32__f32 Indirection_f32;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo_i32 a,
+          Foo_f32 b,
+          Bar_f32 c,
+          Foo_Bar_f32 d,
+          Bar_Foo_f32 e,
+          Bar_Bar_f32 f,
+          Tuple_Foo_f32_____f32 g,
+          Indirection_f32 h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/must-use.compat.c
+++ b/tests/expectations/must-use.compat.c
@@ -1,0 +1,52 @@
+#define MUST_USE_FUNC __attribute__((warn_unused_result))
+#define MUST_USE_STRUCT __attribute__((warn_unused))
+#define MUST_USE_ENUM /* nothing */
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum MaybeOwnedPtr_i32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Owned_i32,
+  None_i32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t MaybeOwnedPtr_i32_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  int32_t *_0;
+} Owned_Body_i32;
+
+typedef struct {
+  MaybeOwnedPtr_i32_Tag tag;
+  union {
+    Owned_Body_i32 owned;
+  };
+} MaybeOwnedPtr_i32;
+
+typedef struct MUST_USE_STRUCT {
+  int32_t *ptr;
+} OwnedPtr_i32;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+MUST_USE_FUNC MaybeOwnedPtr_i32 maybe_consume(OwnedPtr_i32 input);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/must-use.compat.c
+++ b/tests/expectations/must-use.compat.c
@@ -17,10 +17,8 @@ enum MaybeOwnedPtr_i32_Tag
   None_i32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   int32_t *_0;
@@ -38,15 +36,11 @@ typedef struct MUST_USE_STRUCT {
 } OwnedPtr_i32;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 MUST_USE_FUNC MaybeOwnedPtr_i32 maybe_consume(OwnedPtr_i32 input);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/namespace_constant.compat.c
+++ b/tests/expectations/namespace_constant.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define FOO 10
+
+#define ZOM 3.14
+
+typedef struct {
+  int32_t x[FOO];
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/namespace_constant.compat.c
+++ b/tests/expectations/namespace_constant.compat.c
@@ -12,15 +12,11 @@ typedef struct {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/namespaces_constant.compat.c
+++ b/tests/expectations/namespaces_constant.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define FOO 10
+
+#define ZOM 3.14
+
+typedef struct {
+  int32_t x[FOO];
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/namespaces_constant.compat.c
+++ b/tests/expectations/namespaces_constant.compat.c
@@ -12,15 +12,11 @@ typedef struct {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/nested_import.compat.c
+++ b/tests/expectations/nested_import.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/no_includes.compat.c
+++ b/tests/expectations/no_includes.compat.c
@@ -1,13 +1,9 @@
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/no_includes.compat.c
+++ b/tests/expectations/no_includes.compat.c
@@ -1,0 +1,13 @@
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/no_includes.cpp
+++ b/tests/expectations/no_includes.cpp
@@ -1,3 +1,4 @@
+
 extern "C" {
 
 void root();

--- a/tests/expectations/nonnull.compat.c
+++ b/tests/expectations/nonnull.compat.c
@@ -1,0 +1,32 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct {
+  float *a;
+  uint64_t *b;
+  Opaque *c;
+  uint64_t **d;
+  float **e;
+  Opaque **f;
+  uint64_t *g;
+  int32_t *h;
+  int32_t **i;
+} Foo_u64;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(int32_t *arg, Foo_u64 *foo, Opaque **d);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/nonnull.compat.c
+++ b/tests/expectations/nonnull.compat.c
@@ -18,15 +18,11 @@ typedef struct {
 } Foo_u64;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(int32_t *arg, Foo_u64 *foo, Opaque **d);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/prefix.compat.c
+++ b/tests/expectations/prefix.compat.c
@@ -19,10 +19,8 @@ enum PREFIX_AbsoluteFontWeight_Tag
   Bold,
 };
 #ifndef __cplusplus
-
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   PREFIX_AbsoluteFontWeight_Tag tag;
@@ -35,15 +33,11 @@ typedef union {
 } PREFIX_AbsoluteFontWeight;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/prefix.compat.c
+++ b/tests/expectations/prefix.compat.c
@@ -1,0 +1,49 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define PREFIX_LEN 42
+
+typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
+
+typedef int32_t PREFIX_ValuedLenArray[42];
+
+enum PREFIX_AbsoluteFontWeight_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Weight,
+  Normal,
+  Bold,
+};
+#ifndef __cplusplus
+
+typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  PREFIX_AbsoluteFontWeight_Tag tag;
+  float _0;
+} PREFIX_Weight_Body;
+
+typedef union {
+  PREFIX_AbsoluteFontWeight_Tag tag;
+  PREFIX_Weight_Body weight;
+} PREFIX_AbsoluteFontWeight;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/prefixed_struct_literal.compat.c
+++ b/tests/expectations/prefixed_struct_literal.compat.c
@@ -12,15 +12,11 @@ typedef struct {
 #define PREFIXBAR (PREFIXFoo){ .a = 42, .b = 1337 }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(PREFIXFoo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/prefixed_struct_literal.compat.c
+++ b/tests/expectations/prefixed_struct_literal.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t a;
+  uint32_t b;
+} PREFIXFoo;
+#define PREFIXFoo_FOO (PREFIXFoo){ .a = 42, .b = 47 }
+
+#define PREFIXBAR (PREFIXFoo){ .a = 42, .b = 1337 }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(PREFIXFoo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/prefixed_struct_literal_deep.compat.c
+++ b/tests/expectations/prefixed_struct_literal_deep.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t a;
+} PREFIXBar;
+
+typedef struct {
+  int32_t a;
+  uint32_t b;
+  PREFIXBar bar;
+} PREFIXFoo;
+
+#define PREFIXVAL (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(PREFIXFoo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/prefixed_struct_literal_deep.compat.c
+++ b/tests/expectations/prefixed_struct_literal_deep.compat.c
@@ -16,15 +16,11 @@ typedef struct {
 #define PREFIXVAL (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(PREFIXFoo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/rename-crate.compat.c
+++ b/tests/expectations/rename-crate.compat.c
@@ -30,9 +30,7 @@ typedef struct {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void no_extern_func(ContainsNoExternTy a);
@@ -42,7 +40,5 @@ void renamed_func(RenamedTy a);
 void root(Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/rename-crate.compat.c
+++ b/tests/expectations/rename-crate.compat.c
@@ -1,0 +1,48 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if !defined(DEFINE_FREEBSD)
+typedef struct {
+  uint8_t field;
+} NoExternTy;
+#endif
+
+#if !defined(DEFINE_FREEBSD)
+typedef struct {
+  NoExternTy field;
+} ContainsNoExternTy;
+#endif
+
+#if defined(DEFINE_FREEBSD)
+typedef struct {
+  uint64_t field;
+} ContainsNoExternTy;
+#endif
+
+typedef struct {
+  uint64_t y;
+} RenamedTy;
+
+typedef struct {
+  int32_t x;
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void no_extern_func(ContainsNoExternTy a);
+
+void renamed_func(RenamedTy a);
+
+void root(Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/rename.compat.c
+++ b/tests/expectations/rename.compat.c
@@ -14,10 +14,8 @@ enum C_E
   y = 1,
 };
 #ifndef __cplusplus
-
 typedef uint8_t C_E;
 #endif // __cplusplus
-
 
 typedef struct C_A C_A;
 
@@ -36,9 +34,7 @@ typedef union {
 typedef C_A C_F;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 extern const int32_t G;
@@ -46,7 +42,5 @@ extern const int32_t G;
 void root(const C_A *a, C_AwesomeB b, C_C c, C_D d, C_E e, C_F f);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/rename.compat.c
+++ b/tests/expectations/rename.compat.c
@@ -1,0 +1,52 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define C_H 10
+
+enum C_E
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  x = 0,
+  y = 1,
+};
+#ifndef __cplusplus
+
+typedef uint8_t C_E;
+#endif // __cplusplus
+
+
+typedef struct C_A C_A;
+
+typedef struct C_C C_C;
+
+typedef struct {
+  int32_t x;
+  float y;
+} C_AwesomeB;
+
+typedef union {
+  int32_t x;
+  float y;
+} C_D;
+
+typedef C_A C_F;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+extern const int32_t G;
+
+void root(const C_A *a, C_AwesomeB b, C_C c, C_D d, C_E e, C_F f);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/renaming-overrides-prefixing.compat.c
+++ b/tests/expectations/renaming-overrides-prefixing.compat.c
@@ -11,15 +11,11 @@ typedef struct {
 } B;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const StyleA *a, B b);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/renaming-overrides-prefixing.compat.c
+++ b/tests/expectations/renaming-overrides-prefixing.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct StyleA StyleA;
+
+typedef struct {
+  int32_t x;
+  float y;
+} B;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const StyleA *a, B b);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/reserved.compat.c
+++ b/tests/expectations/reserved.compat.c
@@ -1,0 +1,53 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t namespace_;
+  float float_;
+} A;
+
+typedef struct {
+  int32_t namespace_;
+  float float_;
+} B;
+
+enum C_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  D,
+};
+#ifndef __cplusplus
+
+typedef uint8_t C_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  int32_t namespace_;
+  float float_;
+} D_Body;
+
+typedef struct {
+  C_Tag tag;
+  union {
+    D_Body d;
+  };
+} C;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(A a, B b, C c, int32_t namespace_, float float_);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/reserved.compat.c
+++ b/tests/expectations/reserved.compat.c
@@ -21,10 +21,8 @@ enum C_Tag
   D,
 };
 #ifndef __cplusplus
-
 typedef uint8_t C_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   int32_t namespace_;
@@ -39,15 +37,11 @@ typedef struct {
 } C;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(A a, B b, C c, int32_t namespace_, float float_);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/simplify-option-ptr.compat.c
+++ b/tests/expectations/simplify-option-ptr.compat.c
@@ -18,15 +18,11 @@ typedef union {
 } Bar;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const Opaque *a, Opaque *b, Foo c, Bar d);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/simplify-option-ptr.compat.c
+++ b/tests/expectations/simplify-option-ptr.compat.c
@@ -1,0 +1,32 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct {
+  const Opaque *x;
+  Opaque *y;
+  void (*z)();
+} Foo;
+
+typedef union {
+  const Opaque *x;
+  Opaque *y;
+  void (*z)();
+} Bar;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const Opaque *a, Opaque *b, Foo c, Bar d);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/static.compat.c
+++ b/tests/expectations/static.compat.c
@@ -10,9 +10,7 @@ typedef struct {
 } Foo;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 extern const Bar BAR;
@@ -24,7 +22,5 @@ extern const int32_t NUMBER;
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/static.compat.c
+++ b/tests/expectations/static.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Bar Bar;
+
+typedef struct {
+
+} Foo;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+extern const Bar BAR;
+
+extern Foo FOO;
+
+extern const int32_t NUMBER;
+
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/std_lib.compat.c
+++ b/tests/expectations/std_lib.compat.c
@@ -10,15 +10,11 @@ typedef struct Result_i32__String Result_i32__String;
 typedef struct Vec_String Vec_String;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const Vec_String *a, const Option_i32 *b, const Result_i32__String *c);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/std_lib.compat.c
+++ b/tests/expectations/std_lib.compat.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Option_i32 Option_i32;
+
+typedef struct Result_i32__String Result_i32__String;
+
+typedef struct Vec_String Vec_String;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const Vec_String *a, const Option_i32 *b, const Result_i32__String *c);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/struct.compat.c
+++ b/tests/expectations/struct.compat.c
@@ -26,15 +26,11 @@ typedef struct {
 } TupleNamed;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Opaque *a, Normal b, NormalWithZST c, TupleRenamed d, TupleNamed e);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/struct.compat.c
+++ b/tests/expectations/struct.compat.c
@@ -1,0 +1,40 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct {
+  int32_t x;
+  float y;
+} Normal;
+
+typedef struct {
+  int32_t x;
+  float y;
+} NormalWithZST;
+
+typedef struct {
+  int32_t m0;
+  float m1;
+} TupleRenamed;
+
+typedef struct {
+  int32_t x;
+  float y;
+} TupleNamed;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Opaque *a, Normal b, NormalWithZST c, TupleRenamed d, TupleNamed e);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/struct_literal.compat.c
+++ b/tests/expectations/struct_literal.compat.c
@@ -19,15 +19,11 @@ typedef struct {
 
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Foo x, Bar bar);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/struct_literal.compat.c
+++ b/tests/expectations/struct_literal.compat.c
@@ -1,0 +1,33 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Bar Bar;
+
+typedef struct {
+  int32_t a;
+  uint32_t b;
+} Foo;
+#define Foo_FOO (Foo){ .a = 42, .b = 47 }
+#define Foo_FOO2 (Foo){ .a = 42, .b = 47 }
+#define Foo_FOO3 (Foo){ .a = 42, .b = 47 }
+
+
+#define BAR (Foo){ .a = 42, .b = 1337 }
+
+
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Foo x, Bar bar);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/style-crash.compat.c
+++ b/tests/expectations/style-crash.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/tag/alias.compat.c
+++ b/tests/expectations/tag/alias.compat.c
@@ -12,10 +12,8 @@ enum Status
   Err,
 };
 #ifndef __cplusplus
-
 typedef uint32_t Status;
 #endif // __cplusplus
-
 
 struct Dep {
   int32_t a;
@@ -43,15 +41,11 @@ typedef int32_t Unit;
 typedef Status SpecialStatus;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(IntFoo x, DoubleFoo y, Unit z, SpecialStatus w);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/alias.compat.c
+++ b/tests/expectations/tag/alias.compat.c
@@ -1,0 +1,57 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum Status
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  Ok,
+  Err,
+};
+#ifndef __cplusplus
+
+typedef uint32_t Status;
+#endif // __cplusplus
+
+
+struct Dep {
+  int32_t a;
+  float b;
+};
+
+struct Foo_i32 {
+  int32_t a;
+  int32_t b;
+  struct Dep c;
+};
+
+typedef struct Foo_i32 IntFoo;
+
+struct Foo_f64 {
+  double a;
+  double b;
+  struct Dep c;
+};
+
+typedef struct Foo_f64 DoubleFoo;
+
+typedef int32_t Unit;
+
+typedef Status SpecialStatus;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(IntFoo x, DoubleFoo y, Unit z, SpecialStatus w);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/annotation.compat.c
+++ b/tests/expectations/tag/annotation.compat.c
@@ -12,10 +12,8 @@ enum C
   Y,
 };
 #ifndef __cplusplus
-
 typedef uint32_t C;
 #endif // __cplusplus
-
 
 struct A {
   int32_t m0;
@@ -36,10 +34,8 @@ enum F_Tag
   Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t F_Tag;
 #endif // __cplusplus
-
 
 struct Foo_Body {
   F_Tag tag;
@@ -68,10 +64,8 @@ enum H_Tag
   Everyone,
 };
 #ifndef __cplusplus
-
 typedef uint8_t H_Tag;
 #endif // __cplusplus
-
 
 struct Hello_Body {
   int16_t _0;
@@ -91,15 +85,11 @@ struct H {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct A x, struct B y, C z, union F f, struct H h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/annotation.compat.c
+++ b/tests/expectations/tag/annotation.compat.c
@@ -1,0 +1,105 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum C
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  X = 2,
+  Y,
+};
+#ifndef __cplusplus
+
+typedef uint32_t C;
+#endif // __cplusplus
+
+
+struct A {
+  int32_t m0;
+};
+
+struct B {
+  int32_t x;
+  float y;
+};
+
+enum F_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+  Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t F_Tag;
+#endif // __cplusplus
+
+
+struct Foo_Body {
+  F_Tag tag;
+  int16_t _0;
+};
+
+struct Bar_Body {
+  F_Tag tag;
+  uint8_t x;
+  int16_t y;
+};
+
+union F {
+  enum F_Tag tag;
+  struct Foo_Body foo;
+  struct Bar_Body bar;
+};
+
+enum H_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Hello,
+  There,
+  Everyone,
+};
+#ifndef __cplusplus
+
+typedef uint8_t H_Tag;
+#endif // __cplusplus
+
+
+struct Hello_Body {
+  int16_t _0;
+};
+
+struct There_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct H {
+  enum H_Tag tag;
+  union {
+    struct Hello_Body hello;
+    struct There_Body there;
+  };
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct A x, struct B y, C z, union F f, struct H h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/array.compat.c
+++ b/tests/expectations/tag/array.compat.c
@@ -1,0 +1,37 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum Foo_Tag {
+  A,
+};
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+struct A_Body {
+  float _0[20];
+};
+
+struct Foo {
+  enum Foo_Tag tag;
+  union {
+    struct A_Body a;
+  };
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/array.compat.c
+++ b/tests/expectations/tag/array.compat.c
@@ -6,10 +6,6 @@
 enum Foo_Tag {
   A,
 };
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 struct A_Body {
   float _0[20];
@@ -23,15 +19,11 @@ struct Foo {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/asserted-cast.compat.c
+++ b/tests/expectations/tag/asserted-cast.compat.c
@@ -1,0 +1,119 @@
+#define MY_ASSERT(...) do { } while (0)
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct I;
+
+enum H_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t H_Tag;
+#endif // __cplusplus
+
+
+struct H_Foo_Body {
+  int16_t _0;
+};
+
+struct H_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct H {
+  enum H_Tag tag;
+  union {
+    struct H_Foo_Body foo;
+    struct H_Bar_Body bar;
+  };
+};
+
+enum J_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  J_Foo,
+  J_Bar,
+  J_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t J_Tag;
+#endif // __cplusplus
+
+
+struct J_Foo_Body {
+  int16_t _0;
+};
+
+struct J_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct J {
+  enum J_Tag tag;
+  union {
+    struct J_Foo_Body foo;
+    struct J_Bar_Body bar;
+  };
+};
+
+enum K_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  K_Foo,
+  K_Bar,
+  K_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t K_Tag;
+#endif // __cplusplus
+
+
+struct K_Foo_Body {
+  K_Tag tag;
+  int16_t _0;
+};
+
+struct K_Bar_Body {
+  K_Tag tag;
+  uint8_t x;
+  int16_t y;
+};
+
+union K {
+  enum K_Tag tag;
+  struct K_Foo_Body foo;
+  struct K_Bar_Body bar;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void foo(struct H h, struct I i, struct J j, union K k);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/asserted-cast.compat.c
+++ b/tests/expectations/tag/asserted-cast.compat.c
@@ -18,10 +18,8 @@ enum H_Tag
   H_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t H_Tag;
 #endif // __cplusplus
-
 
 struct H_Foo_Body {
   int16_t _0;
@@ -50,10 +48,8 @@ enum J_Tag
   J_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t J_Tag;
 #endif // __cplusplus
-
 
 struct J_Foo_Body {
   int16_t _0;
@@ -82,10 +78,8 @@ enum K_Tag
   K_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t K_Tag;
 #endif // __cplusplus
-
 
 struct K_Foo_Body {
   K_Tag tag;
@@ -105,15 +99,11 @@ union K {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void foo(struct H h, struct I i, struct J j, union K k);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/assoc_const_conflict.compat.c
+++ b/tests/expectations/tag/assoc_const_conflict.compat.c
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define Foo_FOO 42

--- a/tests/expectations/tag/assoc_constant.compat.c
+++ b/tests/expectations/tag/assoc_constant.compat.c
@@ -10,15 +10,11 @@ struct Foo {
 #define Foo_ZO 3.14
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/assoc_constant.compat.c
+++ b/tests/expectations/tag/assoc_constant.compat.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo {
+
+};
+#define Foo_GA 10
+#define Foo_ZO 3.14
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/associated_in_body.compat.c
+++ b/tests/expectations/tag/associated_in_body.compat.c
@@ -1,0 +1,31 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Constants shared by multiple CSS Box Alignment properties
+ * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
+ */
+struct StyleAlignFlags {
+  uint8_t bits;
+};
+#define StyleAlignFlags_AUTO (StyleAlignFlags){ .bits = 0 }
+#define StyleAlignFlags_NORMAL (StyleAlignFlags){ .bits = 1 }
+#define StyleAlignFlags_START (StyleAlignFlags){ .bits = 1 << 1 }
+#define StyleAlignFlags_END (StyleAlignFlags){ .bits = 1 << 2 }
+#define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = 1 << 3 }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct StyleAlignFlags flags);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/associated_in_body.compat.c
+++ b/tests/expectations/tag/associated_in_body.compat.c
@@ -17,15 +17,11 @@ struct StyleAlignFlags {
 #define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = 1 << 3 }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct StyleAlignFlags flags);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/bitflags.compat.c
+++ b/tests/expectations/tag/bitflags.compat.c
@@ -1,0 +1,31 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Constants shared by multiple CSS Box Alignment properties
+ * These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
+ */
+struct AlignFlags {
+  uint8_t bits;
+};
+#define AlignFlags_AUTO (AlignFlags){ .bits = 0 }
+#define AlignFlags_NORMAL (AlignFlags){ .bits = 1 }
+#define AlignFlags_START (AlignFlags){ .bits = 1 << 1 }
+#define AlignFlags_END (AlignFlags){ .bits = 1 << 2 }
+#define AlignFlags_FLEX_START (AlignFlags){ .bits = 1 << 3 }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct AlignFlags flags);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/bitflags.compat.c
+++ b/tests/expectations/tag/bitflags.compat.c
@@ -17,15 +17,11 @@ struct AlignFlags {
 #define AlignFlags_FLEX_START (AlignFlags){ .bits = 1 << 3 }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct AlignFlags flags);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/body.compat.c
+++ b/tests/expectations/tag/body.compat.c
@@ -8,10 +8,6 @@ enum MyCLikeEnum {
   Bar1,
   Baz1,
 };
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 struct MyFancyStruct {
   int32_t i;
@@ -25,10 +21,6 @@ enum MyFancyEnum_Tag {
   Bar,
   Baz,
 };
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 struct Bar_Body {
   int32_t _0;
@@ -56,15 +48,11 @@ union MyUnion {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct MyFancyStruct s, struct MyFancyEnum e, enum MyCLikeEnum c, union MyUnion u);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/body.compat.c
+++ b/tests/expectations/tag/body.compat.c
@@ -1,0 +1,70 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum MyCLikeEnum {
+  Foo1,
+  Bar1,
+  Baz1,
+};
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+struct MyFancyStruct {
+  int32_t i;
+#ifdef __cplusplus
+  inline void foo();
+#endif
+};
+
+enum MyFancyEnum_Tag {
+  Foo,
+  Bar,
+  Baz,
+};
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+struct Bar_Body {
+  int32_t _0;
+};
+
+struct Baz_Body {
+  int32_t _0;
+};
+
+struct MyFancyEnum {
+  enum MyFancyEnum_Tag tag;
+  union {
+    struct Bar_Body bar;
+    struct Baz_Body baz;
+  };
+#ifdef __cplusplus
+  inline void wohoo();
+#endif
+};
+
+union MyUnion {
+  float f;
+  uint32_t u;
+  int32_t extra_member; // yolo
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct MyFancyStruct s, struct MyFancyEnum e, enum MyCLikeEnum c, union MyUnion u);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/cdecl.compat.c
+++ b/tests/expectations/tag/cdecl.compat.c
@@ -34,9 +34,7 @@ typedef void (*N[16])(int32_t, int32_t);
 typedef void (*P)(int32_t named1st, bool, bool named3rd, int32_t _);
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void (*O(void))(void);
@@ -44,7 +42,5 @@ void (*O(void))(void);
 void root(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m, N n, P p);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/cdecl.compat.c
+++ b/tests/expectations/tag/cdecl.compat.c
@@ -1,0 +1,50 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef void (*A)();
+
+typedef void (*B)();
+
+typedef bool (*C)(int32_t, int32_t);
+
+typedef bool (*(*D)(int32_t))(float);
+
+typedef const int32_t (*(*E)())[16];
+
+typedef const int32_t *F;
+
+typedef const int32_t *const *G;
+
+typedef int32_t *const *H;
+
+typedef const int32_t (*I)[16];
+
+typedef double (**J)(float);
+
+typedef int32_t K[16];
+
+typedef const int32_t *L[16];
+
+typedef bool (*M[16])(int32_t, int32_t);
+
+typedef void (*N[16])(int32_t, int32_t);
+
+typedef void (*P)(int32_t named1st, bool, bool named3rd, int32_t _);
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void (*O(void))(void);
+
+void root(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m, N n, P p);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/cfg-2.compat.c
+++ b/tests/expectations/tag/cfg-2.compat.c
@@ -1,0 +1,48 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if defined(NOT_DEFINED)
+#define DEFAULT_X 8
+#endif
+
+#if defined(DEFINED)
+#define DEFAULT_X 42
+#endif
+
+#if (defined(NOT_DEFINED) || defined(DEFINED))
+struct Foo {
+  int32_t x;
+};
+#endif
+
+#if defined(NOT_DEFINED)
+struct Bar {
+  struct Foo y;
+};
+#endif
+
+#if defined(DEFINED)
+struct Bar {
+  struct Foo z;
+};
+#endif
+
+struct Root {
+  struct Bar w;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Root a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/cfg-2.compat.c
+++ b/tests/expectations/tag/cfg-2.compat.c
@@ -34,15 +34,11 @@ struct Root {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Root a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/cfg-field.compat.c
+++ b/tests/expectations/tag/cfg-field.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/tag/cfg.compat.c
+++ b/tests/expectations/tag/cfg.compat.c
@@ -1,0 +1,74 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+enum BarType
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  A,
+  B,
+  C,
+};
+#ifndef __cplusplus
+
+typedef uint32_t BarType;
+#endif // __cplusplus
+
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+enum FooType
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  A,
+  B,
+  C,
+};
+#ifndef __cplusplus
+
+typedef uint32_t FooType;
+#endif // __cplusplus
+
+#endif
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+struct FooHandle {
+  FooType ty;
+  int32_t x;
+  float y;
+};
+#endif
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+struct BarHandle {
+  BarType ty;
+  int32_t x;
+  float y;
+};
+#endif
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+#if (defined(PLATFORM_UNIX) && defined(X11))
+void root(struct FooHandle a);
+#endif
+
+#if (defined(PLATFORM_WIN) || defined(M_32))
+void root(struct BarHandle a);
+#endif
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/cfg.compat.c
+++ b/tests/expectations/tag/cfg.compat.c
@@ -14,10 +14,8 @@ enum BarType
   C,
 };
 #ifndef __cplusplus
-
 typedef uint32_t BarType;
 #endif // __cplusplus
-
 #endif
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
@@ -31,10 +29,8 @@ enum FooType
   C,
 };
 #ifndef __cplusplus
-
 typedef uint32_t FooType;
 #endif // __cplusplus
-
 #endif
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
@@ -54,9 +50,7 @@ struct BarHandle {
 #endif
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
@@ -68,7 +62,5 @@ void root(struct BarHandle a);
 #endif
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/const_conflict.compat.c
+++ b/tests/expectations/tag/const_conflict.compat.c
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define Foo_FOO 42

--- a/tests/expectations/tag/const_transparent.compat.c
+++ b/tests/expectations/tag/const_transparent.compat.c
@@ -1,0 +1,8 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef uint8_t Transparent;
+
+#define FOO 0

--- a/tests/expectations/tag/constant.compat.c
+++ b/tests/expectations/tag/constant.compat.c
@@ -28,15 +28,11 @@ struct Foo {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/constant.compat.c
+++ b/tests/expectations/tag/constant.compat.c
@@ -1,0 +1,42 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define DELIMITER ':'
+
+#define FOO 10
+
+#define HEART L'\u2764'
+
+#define LEFTCURLY '{'
+
+#define NEG_ONE -1
+
+#define NEWLINE '\n'
+
+#define POS_ONE 1
+
+#define QUOTE '\''
+
+#define TAB '\t'
+
+#define ZOM 3.14
+
+struct Foo {
+  int32_t x[FOO];
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/derive-eq.compat.c
+++ b/tests/expectations/tag/derive-eq.compat.c
@@ -19,10 +19,8 @@ enum Bar_Tag
   FooParen,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Bar_Tag;
 #endif // __cplusplus
-
 
 struct Bazz_Body {
   Bar_Tag tag;
@@ -49,15 +47,11 @@ union Bar {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 struct Foo root(union Bar aBar);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/derive-eq.compat.c
+++ b/tests/expectations/tag/derive-eq.compat.c
@@ -1,0 +1,63 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo {
+  bool a;
+  int32_t b;
+};
+
+enum Bar_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Baz,
+  Bazz,
+  FooNamed,
+  FooParen,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Bar_Tag;
+#endif // __cplusplus
+
+
+struct Bazz_Body {
+  Bar_Tag tag;
+  struct Foo named;
+};
+
+struct FooNamed_Body {
+  Bar_Tag tag;
+  int32_t different;
+  uint32_t fields;
+};
+
+struct FooParen_Body {
+  Bar_Tag tag;
+  int32_t _0;
+  struct Foo _1;
+};
+
+union Bar {
+  enum Bar_Tag tag;
+  struct Bazz_Body bazz;
+  struct FooNamed_Body foo_named;
+  struct FooParen_Body foo_paren;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+struct Foo root(union Bar aBar);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/tag/destructor-and-copy-ctor.compat.c
@@ -1,0 +1,213 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum FillRule
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  A,
+  B,
+};
+#ifndef __cplusplus
+
+typedef uint8_t FillRule;
+#endif // __cplusplus
+
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+struct OwnedSlice_u32 {
+  uintptr_t len;
+  uint32_t *ptr;
+};
+
+struct Polygon_u32 {
+  FillRule fill;
+  struct OwnedSlice_u32 coordinates;
+};
+
+/**
+ * This will have a destructor manually implemented via variant_body, and
+ * similarly a Drop impl in Rust.
+ */
+struct OwnedSlice_i32 {
+  uintptr_t len;
+  int32_t *ptr;
+};
+
+enum Foo_u32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar_u32,
+  Polygon1_u32,
+  Slice1_u32,
+  Slice2_u32,
+  Slice3_u32,
+  Slice4_u32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Foo_u32_Tag;
+#endif // __cplusplus
+
+
+struct Polygon1_Body_u32 {
+  struct Polygon_u32 _0;
+};
+
+struct Slice1_Body_u32 {
+  struct OwnedSlice_u32 _0;
+};
+
+struct Slice2_Body_u32 {
+  struct OwnedSlice_i32 _0;
+};
+
+struct Slice3_Body_u32 {
+  FillRule fill;
+  struct OwnedSlice_u32 coords;
+};
+
+struct Slice4_Body_u32 {
+  FillRule fill;
+  struct OwnedSlice_i32 coords;
+};
+
+struct Foo_u32 {
+  enum Foo_u32_Tag tag;
+  union {
+    struct Polygon1_Body_u32 polygon1;
+    struct Slice1_Body_u32 slice1;
+    struct Slice2_Body_u32 slice2;
+    struct Slice3_Body_u32 slice3;
+    struct Slice4_Body_u32 slice4;
+  };
+};
+
+struct Polygon_i32 {
+  FillRule fill;
+  struct OwnedSlice_i32 coordinates;
+};
+
+enum Baz_i32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar2_i32,
+  Polygon21_i32,
+  Slice21_i32,
+  Slice22_i32,
+  Slice23_i32,
+  Slice24_i32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Baz_i32_Tag;
+#endif // __cplusplus
+
+
+struct Polygon21_Body_i32 {
+  Baz_i32_Tag tag;
+  struct Polygon_i32 _0;
+};
+
+struct Slice21_Body_i32 {
+  Baz_i32_Tag tag;
+  struct OwnedSlice_i32 _0;
+};
+
+struct Slice22_Body_i32 {
+  Baz_i32_Tag tag;
+  struct OwnedSlice_i32 _0;
+};
+
+struct Slice23_Body_i32 {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  struct OwnedSlice_i32 coords;
+};
+
+struct Slice24_Body_i32 {
+  Baz_i32_Tag tag;
+  FillRule fill;
+  struct OwnedSlice_i32 coords;
+};
+
+union Baz_i32 {
+  enum Baz_i32_Tag tag;
+  struct Polygon21_Body_i32 polygon21;
+  struct Slice21_Body_i32 slice21;
+  struct Slice22_Body_i32 slice22;
+  struct Slice23_Body_i32 slice23;
+  struct Slice24_Body_i32 slice24;
+};
+
+enum Taz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar3,
+  Taz1,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Taz_Tag;
+#endif // __cplusplus
+
+
+struct Taz1_Body {
+  Taz_Tag tag;
+  int32_t _0;
+};
+
+union Taz {
+  enum Taz_Tag tag;
+  struct Taz1_Body taz1;
+};
+
+enum Tazz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Bar4,
+  Taz2,
+};
+#ifndef __cplusplus
+
+typedef uint8_t Tazz_Tag;
+#endif // __cplusplus
+
+
+struct Taz2_Body {
+  Tazz_Tag tag;
+  int32_t _0;
+};
+
+union Tazz {
+  enum Tazz_Tag tag;
+  struct Taz2_Body taz2;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const struct Foo_u32 *a, const union Baz_i32 *b, const union Taz *c, union Tazz d);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/tag/destructor-and-copy-ctor.compat.c
@@ -12,10 +12,8 @@ enum FillRule
   B,
 };
 #ifndef __cplusplus
-
 typedef uint8_t FillRule;
 #endif // __cplusplus
-
 
 /**
  * This will have a destructor manually implemented via variant_body, and
@@ -53,10 +51,8 @@ enum Foo_u32_Tag
   Slice4_u32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Foo_u32_Tag;
 #endif // __cplusplus
-
 
 struct Polygon1_Body_u32 {
   struct Polygon_u32 _0;
@@ -109,10 +105,8 @@ enum Baz_i32_Tag
   Slice24_i32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Baz_i32_Tag;
 #endif // __cplusplus
-
 
 struct Polygon21_Body_i32 {
   Baz_i32_Tag tag;
@@ -159,10 +153,8 @@ enum Taz_Tag
   Taz1,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Taz_Tag;
 #endif // __cplusplus
-
 
 struct Taz1_Body {
   Taz_Tag tag;
@@ -183,10 +175,8 @@ enum Tazz_Tag
   Taz2,
 };
 #ifndef __cplusplus
-
 typedef uint8_t Tazz_Tag;
 #endif // __cplusplus
-
 
 struct Taz2_Body {
   Tazz_Tag tag;
@@ -199,15 +189,11 @@ union Tazz {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const struct Foo_u32 *a, const union Baz_i32 *b, const union Taz *c, union Tazz d);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/display_list.compat.c
+++ b/tests/expectations/tag/display_list.compat.c
@@ -27,10 +27,8 @@ enum DisplayItem_Tag
   ClearScreen,
 };
 #ifndef __cplusplus
-
 typedef uint8_t DisplayItem_Tag;
 #endif // __cplusplus
-
 
 struct Fill_Body {
   DisplayItem_Tag tag;
@@ -51,15 +49,11 @@ union DisplayItem {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 bool push_item(union DisplayItem item);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/display_list.compat.c
+++ b/tests/expectations/tag/display_list.compat.c
@@ -1,0 +1,65 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Rect {
+  float x;
+  float y;
+  float w;
+  float h;
+};
+
+struct Color {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+  uint8_t a;
+};
+
+enum DisplayItem_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Fill,
+  Image,
+  ClearScreen,
+};
+#ifndef __cplusplus
+
+typedef uint8_t DisplayItem_Tag;
+#endif // __cplusplus
+
+
+struct Fill_Body {
+  DisplayItem_Tag tag;
+  struct Rect _0;
+  struct Color _1;
+};
+
+struct Image_Body {
+  DisplayItem_Tag tag;
+  uint32_t id;
+  struct Rect bounds;
+};
+
+union DisplayItem {
+  enum DisplayItem_Tag tag;
+  struct Fill_Body fill;
+  struct Image_Body image;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+bool push_item(union DisplayItem item);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/docstyle_auto.compat.c
+++ b/tests/expectations/tag/docstyle_auto.compat.c
@@ -1,0 +1,21 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+/**
+ * The root of all evil.
+ */
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/docstyle_auto.compat.c
+++ b/tests/expectations/tag/docstyle_auto.compat.c
@@ -4,9 +4,7 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 /**
@@ -15,7 +13,5 @@ extern "C" {
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/docstyle_c99.compat.c
+++ b/tests/expectations/tag/docstyle_c99.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+// The root of all evil.
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/docstyle_c99.compat.c
+++ b/tests/expectations/tag/docstyle_c99.compat.c
@@ -4,16 +4,12 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 // The root of all evil.
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/docstyle_doxy.compat.c
+++ b/tests/expectations/tag/docstyle_doxy.compat.c
@@ -1,0 +1,21 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+/**
+ * The root of all evil.
+ */
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/docstyle_doxy.compat.c
+++ b/tests/expectations/tag/docstyle_doxy.compat.c
@@ -4,9 +4,7 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 /**
@@ -15,7 +13,5 @@ extern "C" {
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/enum.compat.c
+++ b/tests/expectations/tag/enum.compat.c
@@ -14,10 +14,8 @@ enum A
   a4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uint32_t A;
 #endif // __cplusplus
-
 
 enum B
 #ifdef __cplusplus
@@ -30,10 +28,8 @@ enum B
   b4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uint16_t B;
 #endif // __cplusplus
-
 
 enum C
 #ifdef __cplusplus
@@ -46,10 +42,8 @@ enum C
   c4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uint8_t C;
 #endif // __cplusplus
-
 
 enum D
 #ifdef __cplusplus
@@ -62,10 +56,8 @@ enum D
   d4 = 5,
 };
 #ifndef __cplusplus
-
 typedef uintptr_t D;
 #endif // __cplusplus
-
 
 enum E
 #ifdef __cplusplus
@@ -78,10 +70,8 @@ enum E
   e4 = 5,
 };
 #ifndef __cplusplus
-
 typedef intptr_t E;
 #endif // __cplusplus
-
 
 enum K {
   k1,
@@ -89,10 +79,6 @@ enum K {
   k3,
   k4,
 };
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 enum L
 #ifdef __cplusplus
@@ -104,10 +90,8 @@ enum L
   l3 = 1,
 };
 #ifndef __cplusplus
-
 typedef int8_t L;
 #endif // __cplusplus
-
 
 struct I;
 
@@ -125,10 +109,8 @@ enum F_Tag
   Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t F_Tag;
 #endif // __cplusplus
-
 
 struct Foo_Body {
   F_Tag tag;
@@ -152,10 +134,6 @@ enum G_Tag {
   G_Bar,
   G_Baz,
 };
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 struct G_Foo_Body {
   int16_t _0;
@@ -184,10 +162,8 @@ enum H_Tag
   H_Baz,
 };
 #ifndef __cplusplus
-
 typedef uint8_t H_Tag;
 #endif // __cplusplus
-
 
 struct H_Foo_Body {
   int16_t _0;
@@ -207,9 +183,7 @@ struct H {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Opaque *o,
@@ -227,7 +201,5 @@ void root(struct Opaque *o,
           L l);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/enum.compat.c
+++ b/tests/expectations/tag/enum.compat.c
@@ -1,0 +1,233 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum A
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  a1 = 0,
+  a2 = 2,
+  a3,
+  a4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uint32_t A;
+#endif // __cplusplus
+
+
+enum B
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  b1 = 0,
+  b2 = 2,
+  b3,
+  b4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uint16_t B;
+#endif // __cplusplus
+
+
+enum C
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  c1 = 0,
+  c2 = 2,
+  c3,
+  c4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uint8_t C;
+#endif // __cplusplus
+
+
+enum D
+#ifdef __cplusplus
+  : uintptr_t
+#endif // __cplusplus
+ {
+  d1 = 0,
+  d2 = 2,
+  d3,
+  d4 = 5,
+};
+#ifndef __cplusplus
+
+typedef uintptr_t D;
+#endif // __cplusplus
+
+
+enum E
+#ifdef __cplusplus
+  : intptr_t
+#endif // __cplusplus
+ {
+  e1 = 0,
+  e2 = 2,
+  e3,
+  e4 = 5,
+};
+#ifndef __cplusplus
+
+typedef intptr_t E;
+#endif // __cplusplus
+
+
+enum K {
+  k1,
+  k2,
+  k3,
+  k4,
+};
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+enum L
+#ifdef __cplusplus
+  : int8_t
+#endif // __cplusplus
+ {
+  l1 = -1,
+  l2 = 0,
+  l3 = 1,
+};
+#ifndef __cplusplus
+
+typedef int8_t L;
+#endif // __cplusplus
+
+
+struct I;
+
+struct J;
+
+struct Opaque;
+
+enum F_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+  Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t F_Tag;
+#endif // __cplusplus
+
+
+struct Foo_Body {
+  F_Tag tag;
+  int16_t _0;
+};
+
+struct Bar_Body {
+  F_Tag tag;
+  uint8_t x;
+  int16_t y;
+};
+
+union F {
+  enum F_Tag tag;
+  struct Foo_Body foo;
+  struct Bar_Body bar;
+};
+
+enum G_Tag {
+  G_Foo,
+  G_Bar,
+  G_Baz,
+};
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+struct G_Foo_Body {
+  int16_t _0;
+};
+
+struct G_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct G {
+  enum G_Tag tag;
+  union {
+    struct G_Foo_Body foo;
+    struct G_Bar_Body bar;
+  };
+};
+
+enum H_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+};
+#ifndef __cplusplus
+
+typedef uint8_t H_Tag;
+#endif // __cplusplus
+
+
+struct H_Foo_Body {
+  int16_t _0;
+};
+
+struct H_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct H {
+  enum H_Tag tag;
+  union {
+    struct H_Foo_Body foo;
+    struct H_Bar_Body bar;
+  };
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Opaque *o,
+          A a,
+          B b,
+          C c,
+          D d,
+          E e,
+          union F f,
+          struct G g,
+          struct H h,
+          struct I i,
+          struct J j,
+          enum K k,
+          L l);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/euclid.compat.c
+++ b/tests/expectations/tag/euclid.compat.c
@@ -1,0 +1,129 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct TypedLength_f32__UnknownUnit {
+  float _0;
+};
+
+struct TypedLength_f32__LayoutUnit {
+  float _0;
+};
+
+typedef struct TypedLength_f32__UnknownUnit Length_f32;
+
+typedef struct TypedLength_f32__LayoutUnit LayoutLength;
+
+struct TypedSideOffsets2D_f32__UnknownUnit {
+  float top;
+  float right;
+  float bottom;
+  float left;
+};
+
+struct TypedSideOffsets2D_f32__LayoutUnit {
+  float top;
+  float right;
+  float bottom;
+  float left;
+};
+
+typedef struct TypedSideOffsets2D_f32__UnknownUnit SideOffsets2D_f32;
+
+typedef struct TypedSideOffsets2D_f32__LayoutUnit LayoutSideOffsets2D;
+
+struct TypedSize2D_f32__UnknownUnit {
+  float width;
+  float height;
+};
+
+struct TypedSize2D_f32__LayoutUnit {
+  float width;
+  float height;
+};
+
+typedef struct TypedSize2D_f32__UnknownUnit Size2D_f32;
+
+typedef struct TypedSize2D_f32__LayoutUnit LayoutSize2D;
+
+struct TypedPoint2D_f32__UnknownUnit {
+  float x;
+  float y;
+};
+
+struct TypedPoint2D_f32__LayoutUnit {
+  float x;
+  float y;
+};
+
+typedef struct TypedPoint2D_f32__UnknownUnit Point2D_f32;
+
+typedef struct TypedPoint2D_f32__LayoutUnit LayoutPoint2D;
+
+struct TypedRect_f32__UnknownUnit {
+  struct TypedPoint2D_f32__UnknownUnit origin;
+  struct TypedSize2D_f32__UnknownUnit size;
+};
+
+struct TypedRect_f32__LayoutUnit {
+  struct TypedPoint2D_f32__LayoutUnit origin;
+  struct TypedSize2D_f32__LayoutUnit size;
+};
+
+typedef struct TypedRect_f32__UnknownUnit Rect_f32;
+
+typedef struct TypedRect_f32__LayoutUnit LayoutRect;
+
+struct TypedTransform2D_f32__UnknownUnit__LayoutUnit {
+  float m11;
+  float m12;
+  float m21;
+  float m22;
+  float m31;
+  float m32;
+};
+
+struct TypedTransform2D_f32__LayoutUnit__UnknownUnit {
+  float m11;
+  float m12;
+  float m21;
+  float m22;
+  float m31;
+  float m32;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct TypedLength_f32__UnknownUnit length_a,
+          struct TypedLength_f32__LayoutUnit length_b,
+          Length_f32 length_c,
+          LayoutLength length_d,
+          struct TypedSideOffsets2D_f32__UnknownUnit side_offsets_a,
+          struct TypedSideOffsets2D_f32__LayoutUnit side_offsets_b,
+          SideOffsets2D_f32 side_offsets_c,
+          LayoutSideOffsets2D side_offsets_d,
+          struct TypedSize2D_f32__UnknownUnit size_a,
+          struct TypedSize2D_f32__LayoutUnit size_b,
+          Size2D_f32 size_c,
+          LayoutSize2D size_d,
+          struct TypedPoint2D_f32__UnknownUnit point_a,
+          struct TypedPoint2D_f32__LayoutUnit point_b,
+          Point2D_f32 point_c,
+          LayoutPoint2D point_d,
+          struct TypedRect_f32__UnknownUnit rect_a,
+          struct TypedRect_f32__LayoutUnit rect_b,
+          Rect_f32 rect_c,
+          LayoutRect rect_d,
+          struct TypedTransform2D_f32__UnknownUnit__LayoutUnit transform_a,
+          struct TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/euclid.compat.c
+++ b/tests/expectations/tag/euclid.compat.c
@@ -94,9 +94,7 @@ struct TypedTransform2D_f32__LayoutUnit__UnknownUnit {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct TypedLength_f32__UnknownUnit length_a,
@@ -123,7 +121,5 @@ void root(struct TypedLength_f32__UnknownUnit length_a,
           struct TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/expand.compat.c
+++ b/tests/expectations/tag/expand.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo {
+
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/expand.compat.c
+++ b/tests/expectations/tag/expand.compat.c
@@ -8,15 +8,11 @@ struct Foo {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/expand_default_features.compat.c
+++ b/tests/expectations/tag/expand_default_features.compat.c
@@ -8,9 +8,7 @@ struct Foo {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void extra_debug_fn(void);
@@ -18,7 +16,5 @@ void extra_debug_fn(void);
 void root(struct Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/expand_default_features.compat.c
+++ b/tests/expectations/tag/expand_default_features.compat.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo {
+
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void extra_debug_fn(void);
+
+void root(struct Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/expand_features.compat.c
+++ b/tests/expectations/tag/expand_features.compat.c
@@ -8,9 +8,7 @@ struct Foo {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void cbindgen(void);
@@ -20,7 +18,5 @@ void extra_debug_fn(void);
 void root(struct Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/expand_features.compat.c
+++ b/tests/expectations/tag/expand_features.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo {
+
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void cbindgen(void);
+
+void extra_debug_fn(void);
+
+void root(struct Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/expand_no_default_features.compat.c
+++ b/tests/expectations/tag/expand_no_default_features.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo {
+
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/expand_no_default_features.compat.c
+++ b/tests/expectations/tag/expand_no_default_features.compat.c
@@ -8,15 +8,11 @@ struct Foo {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/extern-2.compat.c
+++ b/tests/expectations/tag/extern-2.compat.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void first(void);
+
+void second(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/extern-2.compat.c
+++ b/tests/expectations/tag/extern-2.compat.c
@@ -4,9 +4,7 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void first(void);
@@ -14,7 +12,5 @@ void first(void);
 void second(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/extern.compat.c
+++ b/tests/expectations/tag/extern.compat.c
@@ -9,9 +9,7 @@ struct Normal {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 extern void bar(struct Normal a);
@@ -19,7 +17,5 @@ extern void bar(struct Normal a);
 extern int32_t foo(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/extern.compat.c
+++ b/tests/expectations/tag/extern.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Normal {
+  int32_t x;
+  float y;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+extern void bar(struct Normal a);
+
+extern int32_t foo(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/external_workspace_child.compat.c
+++ b/tests/expectations/tag/external_workspace_child.compat.c
@@ -8,15 +8,11 @@ struct ExtType {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void consume_ext(struct ExtType _ext);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/external_workspace_child.compat.c
+++ b/tests/expectations/tag/external_workspace_child.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct ExtType {
+  uint32_t data;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void consume_ext(struct ExtType _ext);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/fns.compat.c
+++ b/tests/expectations/tag/fns.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Fns {
+  void (*noArgs)();
+  void (*anonymousArg)(int32_t);
+  int32_t (*returnsNumber)();
+  int8_t (*namedArgs)(int32_t first, int16_t snd);
+  int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Fns _fns);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/fns.compat.c
+++ b/tests/expectations/tag/fns.compat.c
@@ -12,15 +12,11 @@ struct Fns {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Fns _fns);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/global_attr.compat.c
+++ b/tests/expectations/tag/global_attr.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/tag/include.compat.c
+++ b/tests/expectations/tag/include.compat.c
@@ -1,0 +1,5 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>

--- a/tests/expectations/tag/include_item.compat.c
+++ b/tests/expectations/tag/include_item.compat.c
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct A {
+  int32_t x;
+  float y;
+};
+
+struct B {
+  struct A data;
+};

--- a/tests/expectations/tag/include_specific.compat.c
+++ b/tests/expectations/tag/include_specific.compat.c
@@ -1,0 +1,1 @@
+#include <math.h>

--- a/tests/expectations/tag/inner_mod.compat.c
+++ b/tests/expectations/tag/inner_mod.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo {
+  float x;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/inner_mod.compat.c
+++ b/tests/expectations/tag/inner_mod.compat.c
@@ -8,15 +8,11 @@ struct Foo {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/item_types.compat.c
+++ b/tests/expectations/tag/item_types.compat.c
@@ -12,7 +12,5 @@ enum OnlyThisShouldBeGenerated
   Bar,
 };
 #ifndef __cplusplus
-
 typedef uint8_t OnlyThisShouldBeGenerated;
 #endif // __cplusplus
-

--- a/tests/expectations/tag/item_types.compat.c
+++ b/tests/expectations/tag/item_types.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum OnlyThisShouldBeGenerated
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+};
+#ifndef __cplusplus
+
+typedef uint8_t OnlyThisShouldBeGenerated;
+#endif // __cplusplus
+

--- a/tests/expectations/tag/item_types_renamed.compat.c
+++ b/tests/expectations/tag/item_types_renamed.compat.c
@@ -12,7 +12,5 @@ enum StyleOnlyThisShouldBeGenerated
   Bar,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleOnlyThisShouldBeGenerated;
 #endif // __cplusplus
-

--- a/tests/expectations/tag/item_types_renamed.compat.c
+++ b/tests/expectations/tag/item_types_renamed.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum StyleOnlyThisShouldBeGenerated
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo,
+  Bar,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleOnlyThisShouldBeGenerated;
+#endif // __cplusplus
+

--- a/tests/expectations/tag/lifetime_arg.compat.c
+++ b/tests/expectations/tag/lifetime_arg.compat.c
@@ -8,15 +8,11 @@ struct A {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct A _a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/lifetime_arg.compat.c
+++ b/tests/expectations/tag/lifetime_arg.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct A {
+  const int32_t *data;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct A _a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/mod_attr.compat.c
+++ b/tests/expectations/tag/mod_attr.compat.c
@@ -1,0 +1,44 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if defined(BAR)
+#define BAR 2
+#endif
+
+#if defined(FOO)
+#define FOO 1
+#endif
+
+#if defined(BAR)
+struct Bar {
+
+};
+#endif
+
+#if defined(FOO)
+struct Foo {
+
+};
+#endif
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+#if defined(BAR)
+void bar(const struct Bar *bar);
+#endif
+
+#if defined(FOO)
+void foo(const struct Foo *foo);
+#endif
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/mod_attr.compat.c
+++ b/tests/expectations/tag/mod_attr.compat.c
@@ -24,9 +24,7 @@ struct Foo {
 #endif
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 #if defined(BAR)
@@ -38,7 +36,5 @@ void foo(const struct Foo *foo);
 #endif
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/mod_path.compat.c
+++ b/tests/expectations/tag/mod_path.compat.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define EXPORT_ME_TOO 42
+
+struct ExportMe {
+  uint64_t val;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void export_me(struct ExportMe *val);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/mod_path.compat.c
+++ b/tests/expectations/tag/mod_path.compat.c
@@ -10,15 +10,11 @@ struct ExportMe {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void export_me(struct ExportMe *val);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/monomorph-1.compat.c
+++ b/tests/expectations/tag/monomorph-1.compat.c
@@ -34,9 +34,7 @@ struct Tuple_f32__f32 {
 typedef struct Tuple_f32__f32 Indirection_f32;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Foo_i32 a,
@@ -49,7 +47,5 @@ void root(struct Foo_i32 a,
           Indirection_f32 h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/monomorph-1.compat.c
+++ b/tests/expectations/tag/monomorph-1.compat.c
@@ -1,0 +1,55 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Bar_Bar_f32;
+
+struct Bar_Foo_f32;
+
+struct Bar_f32;
+
+struct Foo_i32 {
+  const int32_t *data;
+};
+
+struct Foo_f32 {
+  const float *data;
+};
+
+struct Foo_Bar_f32 {
+  const struct Bar_f32 *data;
+};
+
+struct Tuple_Foo_f32_____f32 {
+  const struct Foo_f32 *a;
+  const float *b;
+};
+
+struct Tuple_f32__f32 {
+  const float *a;
+  const float *b;
+};
+
+typedef struct Tuple_f32__f32 Indirection_f32;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Foo_i32 a,
+          struct Foo_f32 b,
+          struct Bar_f32 c,
+          struct Foo_Bar_f32 d,
+          struct Bar_Foo_f32 e,
+          struct Bar_Bar_f32 f,
+          struct Tuple_Foo_f32_____f32 g,
+          Indirection_f32 h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/monomorph-2.compat.c
+++ b/tests/expectations/tag/monomorph-2.compat.c
@@ -1,0 +1,34 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct A;
+
+struct B;
+
+struct List_B {
+  struct B *members;
+  uintptr_t count;
+};
+
+struct List_A {
+  struct A *members;
+  uintptr_t count;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void bar(struct List_B b);
+
+void foo(struct List_A a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/monomorph-2.compat.c
+++ b/tests/expectations/tag/monomorph-2.compat.c
@@ -18,9 +18,7 @@ struct List_A {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void bar(struct List_B b);
@@ -28,7 +26,5 @@ void bar(struct List_B b);
 void foo(struct List_A a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/monomorph-3.compat.c
+++ b/tests/expectations/tag/monomorph-3.compat.c
@@ -34,9 +34,7 @@ union Tuple_f32__f32 {
 typedef union Tuple_f32__f32 Indirection_f32;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(union Foo_i32 a,
@@ -49,7 +47,5 @@ void root(union Foo_i32 a,
           Indirection_f32 h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/monomorph-3.compat.c
+++ b/tests/expectations/tag/monomorph-3.compat.c
@@ -1,0 +1,55 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Bar_Bar_f32;
+
+struct Bar_Foo_f32;
+
+struct Bar_f32;
+
+union Foo_i32 {
+  const int32_t *data;
+};
+
+union Foo_f32 {
+  const float *data;
+};
+
+union Foo_Bar_f32 {
+  const struct Bar_f32 *data;
+};
+
+union Tuple_Foo_f32_____f32 {
+  const union Foo_f32 *a;
+  const float *b;
+};
+
+union Tuple_f32__f32 {
+  const float *a;
+  const float *b;
+};
+
+typedef union Tuple_f32__f32 Indirection_f32;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(union Foo_i32 a,
+          union Foo_f32 b,
+          struct Bar_f32 c,
+          union Foo_Bar_f32 d,
+          struct Bar_Foo_f32 e,
+          struct Bar_Bar_f32 f,
+          union Tuple_Foo_f32_____f32 g,
+          Indirection_f32 h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/must-use.compat.c
+++ b/tests/expectations/tag/must-use.compat.c
@@ -1,0 +1,52 @@
+#define MUST_USE_FUNC __attribute__((warn_unused_result))
+#define MUST_USE_STRUCT __attribute__((warn_unused))
+#define MUST_USE_ENUM /* nothing */
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum MaybeOwnedPtr_i32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Owned_i32,
+  None_i32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t MaybeOwnedPtr_i32_Tag;
+#endif // __cplusplus
+
+
+struct Owned_Body_i32 {
+  int32_t *_0;
+};
+
+struct MaybeOwnedPtr_i32 {
+  enum MaybeOwnedPtr_i32_Tag tag;
+  union {
+    struct Owned_Body_i32 owned;
+  };
+};
+
+struct MUST_USE_STRUCT OwnedPtr_i32 {
+  int32_t *ptr;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+MUST_USE_FUNC struct MaybeOwnedPtr_i32 maybe_consume(struct OwnedPtr_i32 input);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/must-use.compat.c
+++ b/tests/expectations/tag/must-use.compat.c
@@ -17,10 +17,8 @@ enum MaybeOwnedPtr_i32_Tag
   None_i32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
 #endif // __cplusplus
-
 
 struct Owned_Body_i32 {
   int32_t *_0;
@@ -38,15 +36,11 @@ struct MUST_USE_STRUCT OwnedPtr_i32 {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 MUST_USE_FUNC struct MaybeOwnedPtr_i32 maybe_consume(struct OwnedPtr_i32 input);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/namespace_constant.compat.c
+++ b/tests/expectations/tag/namespace_constant.compat.c
@@ -12,15 +12,11 @@ struct Foo {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/namespace_constant.compat.c
+++ b/tests/expectations/tag/namespace_constant.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define FOO 10
+
+#define ZOM 3.14
+
+struct Foo {
+  int32_t x[FOO];
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/namespaces_constant.compat.c
+++ b/tests/expectations/tag/namespaces_constant.compat.c
@@ -12,15 +12,11 @@ struct Foo {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Foo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/namespaces_constant.compat.c
+++ b/tests/expectations/tag/namespaces_constant.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define FOO 10
+
+#define ZOM 3.14
+
+struct Foo {
+  int32_t x[FOO];
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Foo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/nested_import.compat.c
+++ b/tests/expectations/tag/nested_import.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/tag/no_includes.compat.c
+++ b/tests/expectations/tag/no_includes.compat.c
@@ -1,13 +1,9 @@
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/no_includes.compat.c
+++ b/tests/expectations/tag/no_includes.compat.c
@@ -1,0 +1,13 @@
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/nonnull.compat.c
+++ b/tests/expectations/tag/nonnull.compat.c
@@ -18,15 +18,11 @@ struct Foo_u64 {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(int32_t *arg, struct Foo_u64 *foo, struct Opaque **d);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/nonnull.compat.c
+++ b/tests/expectations/tag/nonnull.compat.c
@@ -1,0 +1,32 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Opaque;
+
+struct Foo_u64 {
+  float *a;
+  uint64_t *b;
+  struct Opaque *c;
+  uint64_t **d;
+  float **e;
+  struct Opaque **f;
+  uint64_t *g;
+  int32_t *h;
+  int32_t **i;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(int32_t *arg, struct Foo_u64 *foo, struct Opaque **d);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/prefix.compat.c
+++ b/tests/expectations/tag/prefix.compat.c
@@ -1,0 +1,49 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define PREFIX_LEN 42
+
+typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
+
+typedef int32_t PREFIX_ValuedLenArray[42];
+
+enum PREFIX_AbsoluteFontWeight_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Weight,
+  Normal,
+  Bold,
+};
+#ifndef __cplusplus
+
+typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+#endif // __cplusplus
+
+
+struct PREFIX_Weight_Body {
+  PREFIX_AbsoluteFontWeight_Tag tag;
+  float _0;
+};
+
+union PREFIX_AbsoluteFontWeight {
+  enum PREFIX_AbsoluteFontWeight_Tag tag;
+  struct PREFIX_Weight_Body weight;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, union PREFIX_AbsoluteFontWeight z);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/prefix.compat.c
+++ b/tests/expectations/tag/prefix.compat.c
@@ -19,10 +19,8 @@ enum PREFIX_AbsoluteFontWeight_Tag
   Bold,
 };
 #ifndef __cplusplus
-
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 #endif // __cplusplus
-
 
 struct PREFIX_Weight_Body {
   PREFIX_AbsoluteFontWeight_Tag tag;
@@ -35,15 +33,11 @@ union PREFIX_AbsoluteFontWeight {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, union PREFIX_AbsoluteFontWeight z);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/prefixed_struct_literal.compat.c
+++ b/tests/expectations/tag/prefixed_struct_literal.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct PREFIXFoo {
+  int32_t a;
+  uint32_t b;
+};
+#define PREFIXFoo_FOO (PREFIXFoo){ .a = 42, .b = 47 }
+
+#define PREFIXBAR (PREFIXFoo){ .a = 42, .b = 1337 }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct PREFIXFoo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/prefixed_struct_literal.compat.c
+++ b/tests/expectations/tag/prefixed_struct_literal.compat.c
@@ -12,15 +12,11 @@ struct PREFIXFoo {
 #define PREFIXBAR (PREFIXFoo){ .a = 42, .b = 1337 }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct PREFIXFoo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/prefixed_struct_literal_deep.compat.c
+++ b/tests/expectations/tag/prefixed_struct_literal_deep.compat.c
@@ -16,15 +16,11 @@ struct PREFIXFoo {
 #define PREFIXVAL (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } }
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct PREFIXFoo x);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/prefixed_struct_literal_deep.compat.c
+++ b/tests/expectations/tag/prefixed_struct_literal_deep.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct PREFIXBar {
+  int32_t a;
+};
+
+struct PREFIXFoo {
+  int32_t a;
+  uint32_t b;
+  struct PREFIXBar bar;
+};
+
+#define PREFIXVAL (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } }
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct PREFIXFoo x);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/rename-crate.compat.c
+++ b/tests/expectations/tag/rename-crate.compat.c
@@ -1,0 +1,48 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if !defined(DEFINE_FREEBSD)
+struct NoExternTy {
+  uint8_t field;
+};
+#endif
+
+#if !defined(DEFINE_FREEBSD)
+struct ContainsNoExternTy {
+  struct NoExternTy field;
+};
+#endif
+
+#if defined(DEFINE_FREEBSD)
+struct ContainsNoExternTy {
+  uint64_t field;
+};
+#endif
+
+struct RenamedTy {
+  uint64_t y;
+};
+
+struct Foo {
+  int32_t x;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void no_extern_func(struct ContainsNoExternTy a);
+
+void renamed_func(struct RenamedTy a);
+
+void root(struct Foo a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/rename-crate.compat.c
+++ b/tests/expectations/tag/rename-crate.compat.c
@@ -30,9 +30,7 @@ struct Foo {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void no_extern_func(struct ContainsNoExternTy a);
@@ -42,7 +40,5 @@ void renamed_func(struct RenamedTy a);
 void root(struct Foo a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/rename.compat.c
+++ b/tests/expectations/tag/rename.compat.c
@@ -14,10 +14,8 @@ enum C_E
   y = 1,
 };
 #ifndef __cplusplus
-
 typedef uint8_t C_E;
 #endif // __cplusplus
-
 
 struct C_A;
 
@@ -36,9 +34,7 @@ union C_D {
 typedef struct C_A C_F;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 extern const int32_t G;
@@ -46,7 +42,5 @@ extern const int32_t G;
 void root(const struct C_A *a, struct C_AwesomeB b, struct C_C c, union C_D d, C_E e, C_F f);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/rename.compat.c
+++ b/tests/expectations/tag/rename.compat.c
@@ -1,0 +1,52 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define C_H 10
+
+enum C_E
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  x = 0,
+  y = 1,
+};
+#ifndef __cplusplus
+
+typedef uint8_t C_E;
+#endif // __cplusplus
+
+
+struct C_A;
+
+struct C_C;
+
+struct C_AwesomeB {
+  int32_t x;
+  float y;
+};
+
+union C_D {
+  int32_t x;
+  float y;
+};
+
+typedef struct C_A C_F;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+extern const int32_t G;
+
+void root(const struct C_A *a, struct C_AwesomeB b, struct C_C c, union C_D d, C_E e, C_F f);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/renaming-overrides-prefixing.compat.c
+++ b/tests/expectations/tag/renaming-overrides-prefixing.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct StyleA;
+
+struct B {
+  int32_t x;
+  float y;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const struct StyleA *a, struct B b);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/renaming-overrides-prefixing.compat.c
+++ b/tests/expectations/tag/renaming-overrides-prefixing.compat.c
@@ -11,15 +11,11 @@ struct B {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const struct StyleA *a, struct B b);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/reserved.compat.c
+++ b/tests/expectations/tag/reserved.compat.c
@@ -1,0 +1,53 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct A {
+  int32_t namespace_;
+  float float_;
+};
+
+struct B {
+  int32_t namespace_;
+  float float_;
+};
+
+enum C_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  D,
+};
+#ifndef __cplusplus
+
+typedef uint8_t C_Tag;
+#endif // __cplusplus
+
+
+struct D_Body {
+  int32_t namespace_;
+  float float_;
+};
+
+struct C {
+  enum C_Tag tag;
+  union {
+    struct D_Body d;
+  };
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct A a, struct B b, struct C c, int32_t namespace_, float float_);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/reserved.compat.c
+++ b/tests/expectations/tag/reserved.compat.c
@@ -21,10 +21,8 @@ enum C_Tag
   D,
 };
 #ifndef __cplusplus
-
 typedef uint8_t C_Tag;
 #endif // __cplusplus
-
 
 struct D_Body {
   int32_t namespace_;
@@ -39,15 +37,11 @@ struct C {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct A a, struct B b, struct C c, int32_t namespace_, float float_);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/simplify-option-ptr.compat.c
+++ b/tests/expectations/tag/simplify-option-ptr.compat.c
@@ -18,15 +18,11 @@ union Bar {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const struct Opaque *a, struct Opaque *b, struct Foo c, union Bar d);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/simplify-option-ptr.compat.c
+++ b/tests/expectations/tag/simplify-option-ptr.compat.c
@@ -1,0 +1,32 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Opaque;
+
+struct Foo {
+  const struct Opaque *x;
+  struct Opaque *y;
+  void (*z)();
+};
+
+union Bar {
+  const struct Opaque *x;
+  struct Opaque *y;
+  void (*z)();
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const struct Opaque *a, struct Opaque *b, struct Foo c, union Bar d);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/static.compat.c
+++ b/tests/expectations/tag/static.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Bar;
+
+struct Foo {
+
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+extern const struct Bar BAR;
+
+extern struct Foo FOO;
+
+extern const int32_t NUMBER;
+
+void root(void);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/static.compat.c
+++ b/tests/expectations/tag/static.compat.c
@@ -10,9 +10,7 @@ struct Foo {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 extern const struct Bar BAR;
@@ -24,7 +22,5 @@ extern const int32_t NUMBER;
 void root(void);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/std_lib.compat.c
+++ b/tests/expectations/tag/std_lib.compat.c
@@ -10,9 +10,7 @@ struct Result_i32__String;
 struct Vec_String;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(const struct Vec_String *a,
@@ -20,7 +18,5 @@ void root(const struct Vec_String *a,
           const struct Result_i32__String *c);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/std_lib.compat.c
+++ b/tests/expectations/tag/std_lib.compat.c
@@ -1,0 +1,26 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Option_i32;
+
+struct Result_i32__String;
+
+struct Vec_String;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(const struct Vec_String *a,
+          const struct Option_i32 *b,
+          const struct Result_i32__String *c);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/struct.compat.c
+++ b/tests/expectations/tag/struct.compat.c
@@ -26,9 +26,7 @@ struct TupleNamed {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Opaque *a,
@@ -38,7 +36,5 @@ void root(struct Opaque *a,
           struct TupleNamed e);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/struct.compat.c
+++ b/tests/expectations/tag/struct.compat.c
@@ -1,0 +1,44 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Opaque;
+
+struct Normal {
+  int32_t x;
+  float y;
+};
+
+struct NormalWithZST {
+  int32_t x;
+  float y;
+};
+
+struct TupleRenamed {
+  int32_t m0;
+  float m1;
+};
+
+struct TupleNamed {
+  int32_t x;
+  float y;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Opaque *a,
+          struct Normal b,
+          struct NormalWithZST c,
+          struct TupleRenamed d,
+          struct TupleNamed e);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/struct_literal.compat.c
+++ b/tests/expectations/tag/struct_literal.compat.c
@@ -19,15 +19,11 @@ struct Foo {
 
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Foo x, struct Bar bar);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/struct_literal.compat.c
+++ b/tests/expectations/tag/struct_literal.compat.c
@@ -1,0 +1,33 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Bar;
+
+struct Foo {
+  int32_t a;
+  uint32_t b;
+};
+#define Foo_FOO (Foo){ .a = 42, .b = 47 }
+#define Foo_FOO2 (Foo){ .a = 42, .b = 47 }
+#define Foo_FOO3 (Foo){ .a = 42, .b = 47 }
+
+
+#define BAR (Foo){ .a = 42, .b = 1337 }
+
+
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Foo x, struct Bar bar);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/style-crash.compat.c
+++ b/tests/expectations/tag/style-crash.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/tag/transform-op.compat.c
+++ b/tests/expectations/tag/transform-op.compat.c
@@ -1,0 +1,208 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct StylePoint_i32 {
+  int32_t x;
+  int32_t y;
+};
+
+struct StylePoint_f32 {
+  float x;
+  float y;
+};
+
+enum StyleFoo_i32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo_i32,
+  Bar_i32,
+  Baz_i32,
+  Bazz_i32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleFoo_i32_Tag;
+#endif // __cplusplus
+
+
+struct StyleFoo_Body_i32 {
+  StyleFoo_i32_Tag tag;
+  int32_t x;
+  struct StylePoint_i32 y;
+  struct StylePoint_f32 z;
+};
+
+struct StyleBar_Body_i32 {
+  StyleFoo_i32_Tag tag;
+  int32_t _0;
+};
+
+struct StyleBaz_Body_i32 {
+  StyleFoo_i32_Tag tag;
+  struct StylePoint_i32 _0;
+};
+
+union StyleFoo_i32 {
+  enum StyleFoo_i32_Tag tag;
+  struct StyleFoo_Body_i32 foo;
+  struct StyleBar_Body_i32 bar;
+  struct StyleBaz_Body_i32 baz;
+};
+
+enum StyleBar_i32_Tag {
+  Bar1_i32,
+  Bar2_i32,
+  Bar3_i32,
+  Bar4_i32,
+};
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+struct StyleBar1_Body_i32 {
+  int32_t x;
+  struct StylePoint_i32 y;
+  struct StylePoint_f32 z;
+  int32_t (*u)(int32_t);
+};
+
+struct StyleBar2_Body_i32 {
+  int32_t _0;
+};
+
+struct StyleBar3_Body_i32 {
+  struct StylePoint_i32 _0;
+};
+
+struct StyleBar_i32 {
+  enum StyleBar_i32_Tag tag;
+  union {
+    struct StyleBar1_Body_i32 bar1;
+    struct StyleBar2_Body_i32 bar2;
+    struct StyleBar3_Body_i32 bar3;
+  };
+};
+
+struct StylePoint_u32 {
+  uint32_t x;
+  uint32_t y;
+};
+
+enum StyleBar_u32_Tag {
+  Bar1_u32,
+  Bar2_u32,
+  Bar3_u32,
+  Bar4_u32,
+};
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+struct StyleBar1_Body_u32 {
+  int32_t x;
+  struct StylePoint_u32 y;
+  struct StylePoint_f32 z;
+  int32_t (*u)(int32_t);
+};
+
+struct StyleBar2_Body_u32 {
+  uint32_t _0;
+};
+
+struct StyleBar3_Body_u32 {
+  struct StylePoint_u32 _0;
+};
+
+struct StyleBar_u32 {
+  enum StyleBar_u32_Tag tag;
+  union {
+    struct StyleBar1_Body_u32 bar1;
+    struct StyleBar2_Body_u32 bar2;
+    struct StyleBar3_Body_u32 bar3;
+  };
+};
+
+enum StyleBaz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Baz1,
+  Baz2,
+  Baz3,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleBaz_Tag;
+#endif // __cplusplus
+
+
+struct StyleBaz1_Body {
+  StyleBaz_Tag tag;
+  struct StyleBar_u32 _0;
+};
+
+struct StyleBaz2_Body {
+  StyleBaz_Tag tag;
+  struct StylePoint_i32 _0;
+};
+
+union StyleBaz {
+  enum StyleBaz_Tag tag;
+  struct StyleBaz1_Body baz1;
+  struct StyleBaz2_Body baz2;
+};
+
+enum StyleTaz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Taz1,
+  Taz2,
+  Taz3,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleTaz_Tag;
+#endif // __cplusplus
+
+
+struct StyleTaz1_Body {
+  struct StyleBar_u32 _0;
+};
+
+struct StyleTaz2_Body {
+  union StyleBaz _0;
+};
+
+struct StyleTaz {
+  enum StyleTaz_Tag tag;
+  union {
+    struct StyleTaz1_Body taz1;
+    struct StyleTaz2_Body taz2;
+  };
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void foo(const union StyleFoo_i32 *foo,
+         const struct StyleBar_i32 *bar,
+         const union StyleBaz *baz,
+         const struct StyleTaz *taz);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/transform-op.compat.c
+++ b/tests/expectations/tag/transform-op.compat.c
@@ -24,10 +24,8 @@ enum StyleFoo_i32_Tag
   Bazz_i32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleFoo_i32_Tag;
 #endif // __cplusplus
-
 
 struct StyleFoo_Body_i32 {
   StyleFoo_i32_Tag tag;
@@ -59,10 +57,6 @@ enum StyleBar_i32_Tag {
   Bar3_i32,
   Bar4_i32,
 };
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 struct StyleBar1_Body_i32 {
   int32_t x;
@@ -99,10 +93,6 @@ enum StyleBar_u32_Tag {
   Bar3_u32,
   Bar4_u32,
 };
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 struct StyleBar1_Body_u32 {
   int32_t x;
@@ -138,10 +128,8 @@ enum StyleBaz_Tag
   Baz3,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleBaz_Tag;
 #endif // __cplusplus
-
 
 struct StyleBaz1_Body {
   StyleBaz_Tag tag;
@@ -169,10 +157,8 @@ enum StyleTaz_Tag
   Taz3,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleTaz_Tag;
 #endif // __cplusplus
-
 
 struct StyleTaz1_Body {
   struct StyleBar_u32 _0;
@@ -191,9 +177,7 @@ struct StyleTaz {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void foo(const union StyleFoo_i32 *foo,
@@ -202,7 +186,5 @@ void foo(const union StyleFoo_i32 *foo,
          const struct StyleTaz *taz);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/transparent.compat.c
+++ b/tests/expectations/tag/transparent.compat.c
@@ -26,9 +26,7 @@ typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 #define EnumWithAssociatedConstantInImpl_TEN 10
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(TransparentComplexWrappingStructTuple a,
@@ -41,7 +39,5 @@ void root(TransparentComplexWrappingStructTuple a,
           struct EnumWithAssociatedConstantInImpl h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/transparent.compat.c
+++ b/tests/expectations/tag/transparent.compat.c
@@ -1,0 +1,47 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct DummyStruct;
+
+struct EnumWithAssociatedConstantInImpl;
+
+typedef struct DummyStruct TransparentComplexWrappingStructTuple;
+
+typedef uint32_t TransparentPrimitiveWrappingStructTuple;
+
+typedef struct DummyStruct TransparentComplexWrappingStructure;
+
+typedef uint32_t TransparentPrimitiveWrappingStructure;
+
+typedef struct DummyStruct TransparentComplexWrapper_i32;
+
+typedef uint32_t TransparentPrimitiveWrapper_i32;
+
+typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
+#define TransparentPrimitiveWithAssociatedConstants_ZERO 0
+#define TransparentPrimitiveWithAssociatedConstants_ONE 1
+
+#define EnumWithAssociatedConstantInImpl_TEN 10
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(TransparentComplexWrappingStructTuple a,
+          TransparentPrimitiveWrappingStructTuple b,
+          TransparentComplexWrappingStructure c,
+          TransparentPrimitiveWrappingStructure d,
+          TransparentComplexWrapper_i32 e,
+          TransparentPrimitiveWrapper_i32 f,
+          TransparentPrimitiveWithAssociatedConstants g,
+          struct EnumWithAssociatedConstantInImpl h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/typedef.compat.c
+++ b/tests/expectations/tag/typedef.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo_i32__i32 {
+  int32_t x;
+  int32_t y;
+};
+
+typedef struct Foo_i32__i32 IntFoo_i32;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(IntFoo_i32 a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/typedef.compat.c
+++ b/tests/expectations/tag/typedef.compat.c
@@ -11,15 +11,11 @@ struct Foo_i32__i32 {
 typedef struct Foo_i32__i32 IntFoo_i32;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(IntFoo_i32 a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/union.compat.c
+++ b/tests/expectations/tag/union.compat.c
@@ -16,15 +16,11 @@ union NormalWithZST {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(struct Opaque *a, union Normal b, union NormalWithZST c);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/union.compat.c
+++ b/tests/expectations/tag/union.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Opaque;
+
+union Normal {
+  int32_t x;
+  float y;
+};
+
+union NormalWithZST {
+  int32_t x;
+  float y;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(struct Opaque *a, union Normal b, union NormalWithZST c);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/va_list.compat.c
+++ b/tests/expectations/tag/va_list.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+int32_t va_list_test(va_list ap);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/tag/va_list.compat.c
+++ b/tests/expectations/tag/va_list.compat.c
@@ -4,15 +4,11 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 int32_t va_list_test(va_list ap);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/workspace.compat.c
+++ b/tests/expectations/tag/workspace.compat.c
@@ -8,15 +8,11 @@ struct ExtType {
 };
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void consume_ext(struct ExtType _ext);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/tag/workspace.compat.c
+++ b/tests/expectations/tag/workspace.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct ExtType {
+  uint32_t data;
+};
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void consume_ext(struct ExtType _ext);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/transform-op.compat.c
+++ b/tests/expectations/transform-op.compat.c
@@ -24,10 +24,8 @@ enum StyleFoo_i32_Tag
   Bazz_i32,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleFoo_i32_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   StyleFoo_i32_Tag tag;
@@ -59,10 +57,6 @@ typedef enum {
   Bar3_i32,
   Bar4_i32,
 } StyleBar_i32_Tag;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct {
   int32_t x;
@@ -99,10 +93,6 @@ typedef enum {
   Bar3_u32,
   Bar4_u32,
 } StyleBar_u32_Tag;
-#ifndef __cplusplus
-
-#endif // __cplusplus
-
 
 typedef struct {
   int32_t x;
@@ -138,10 +128,8 @@ enum StyleBaz_Tag
   Baz3,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleBaz_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   StyleBaz_Tag tag;
@@ -169,10 +157,8 @@ enum StyleTaz_Tag
   Taz3,
 };
 #ifndef __cplusplus
-
 typedef uint8_t StyleTaz_Tag;
 #endif // __cplusplus
-
 
 typedef struct {
   StyleBar_u32 _0;
@@ -191,9 +177,7 @@ typedef struct {
 } StyleTaz;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void foo(const StyleFoo_i32 *foo,
@@ -202,7 +186,5 @@ void foo(const StyleFoo_i32 *foo,
          const StyleTaz *taz);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/transform-op.compat.c
+++ b/tests/expectations/transform-op.compat.c
@@ -1,0 +1,208 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  int32_t y;
+} StylePoint_i32;
+
+typedef struct {
+  float x;
+  float y;
+} StylePoint_f32;
+
+enum StyleFoo_i32_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Foo_i32,
+  Bar_i32,
+  Baz_i32,
+  Bazz_i32,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleFoo_i32_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  StyleFoo_i32_Tag tag;
+  int32_t x;
+  StylePoint_i32 y;
+  StylePoint_f32 z;
+} StyleFoo_Body_i32;
+
+typedef struct {
+  StyleFoo_i32_Tag tag;
+  int32_t _0;
+} StyleBar_Body_i32;
+
+typedef struct {
+  StyleFoo_i32_Tag tag;
+  StylePoint_i32 _0;
+} StyleBaz_Body_i32;
+
+typedef union {
+  StyleFoo_i32_Tag tag;
+  StyleFoo_Body_i32 foo;
+  StyleBar_Body_i32 bar;
+  StyleBaz_Body_i32 baz;
+} StyleFoo_i32;
+
+typedef enum {
+  Bar1_i32,
+  Bar2_i32,
+  Bar3_i32,
+  Bar4_i32,
+} StyleBar_i32_Tag;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct {
+  int32_t x;
+  StylePoint_i32 y;
+  StylePoint_f32 z;
+  int32_t (*u)(int32_t);
+} StyleBar1_Body_i32;
+
+typedef struct {
+  int32_t _0;
+} StyleBar2_Body_i32;
+
+typedef struct {
+  StylePoint_i32 _0;
+} StyleBar3_Body_i32;
+
+typedef struct {
+  StyleBar_i32_Tag tag;
+  union {
+    StyleBar1_Body_i32 bar1;
+    StyleBar2_Body_i32 bar2;
+    StyleBar3_Body_i32 bar3;
+  };
+} StyleBar_i32;
+
+typedef struct {
+  uint32_t x;
+  uint32_t y;
+} StylePoint_u32;
+
+typedef enum {
+  Bar1_u32,
+  Bar2_u32,
+  Bar3_u32,
+  Bar4_u32,
+} StyleBar_u32_Tag;
+#ifndef __cplusplus
+
+#endif // __cplusplus
+
+
+typedef struct {
+  int32_t x;
+  StylePoint_u32 y;
+  StylePoint_f32 z;
+  int32_t (*u)(int32_t);
+} StyleBar1_Body_u32;
+
+typedef struct {
+  uint32_t _0;
+} StyleBar2_Body_u32;
+
+typedef struct {
+  StylePoint_u32 _0;
+} StyleBar3_Body_u32;
+
+typedef struct {
+  StyleBar_u32_Tag tag;
+  union {
+    StyleBar1_Body_u32 bar1;
+    StyleBar2_Body_u32 bar2;
+    StyleBar3_Body_u32 bar3;
+  };
+} StyleBar_u32;
+
+enum StyleBaz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Baz1,
+  Baz2,
+  Baz3,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleBaz_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  StyleBaz_Tag tag;
+  StyleBar_u32 _0;
+} StyleBaz1_Body;
+
+typedef struct {
+  StyleBaz_Tag tag;
+  StylePoint_i32 _0;
+} StyleBaz2_Body;
+
+typedef union {
+  StyleBaz_Tag tag;
+  StyleBaz1_Body baz1;
+  StyleBaz2_Body baz2;
+} StyleBaz;
+
+enum StyleTaz_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Taz1,
+  Taz2,
+  Taz3,
+};
+#ifndef __cplusplus
+
+typedef uint8_t StyleTaz_Tag;
+#endif // __cplusplus
+
+
+typedef struct {
+  StyleBar_u32 _0;
+} StyleTaz1_Body;
+
+typedef struct {
+  StyleBaz _0;
+} StyleTaz2_Body;
+
+typedef struct {
+  StyleTaz_Tag tag;
+  union {
+    StyleTaz1_Body taz1;
+    StyleTaz2_Body taz2;
+  };
+} StyleTaz;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void foo(const StyleFoo_i32 *foo,
+         const StyleBar_i32 *bar,
+         const StyleBaz *baz,
+         const StyleTaz *taz);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/transparent.compat.c
+++ b/tests/expectations/transparent.compat.c
@@ -26,9 +26,7 @@ typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 #define EnumWithAssociatedConstantInImpl_TEN 10
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(TransparentComplexWrappingStructTuple a,
@@ -41,7 +39,5 @@ void root(TransparentComplexWrappingStructTuple a,
           EnumWithAssociatedConstantInImpl h);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/transparent.compat.c
+++ b/tests/expectations/transparent.compat.c
@@ -1,0 +1,47 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct DummyStruct DummyStruct;
+
+typedef struct EnumWithAssociatedConstantInImpl EnumWithAssociatedConstantInImpl;
+
+typedef DummyStruct TransparentComplexWrappingStructTuple;
+
+typedef uint32_t TransparentPrimitiveWrappingStructTuple;
+
+typedef DummyStruct TransparentComplexWrappingStructure;
+
+typedef uint32_t TransparentPrimitiveWrappingStructure;
+
+typedef DummyStruct TransparentComplexWrapper_i32;
+
+typedef uint32_t TransparentPrimitiveWrapper_i32;
+
+typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
+#define TransparentPrimitiveWithAssociatedConstants_ZERO 0
+#define TransparentPrimitiveWithAssociatedConstants_ONE 1
+
+#define EnumWithAssociatedConstantInImpl_TEN 10
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(TransparentComplexWrappingStructTuple a,
+          TransparentPrimitiveWrappingStructTuple b,
+          TransparentComplexWrappingStructure c,
+          TransparentPrimitiveWrappingStructure d,
+          TransparentComplexWrapper_i32 e,
+          TransparentPrimitiveWrapper_i32 f,
+          TransparentPrimitiveWithAssociatedConstants g,
+          EnumWithAssociatedConstantInImpl h);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/typedef.compat.c
+++ b/tests/expectations/typedef.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  int32_t y;
+} Foo_i32__i32;
+
+typedef Foo_i32__i32 IntFoo_i32;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(IntFoo_i32 a);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/typedef.compat.c
+++ b/tests/expectations/typedef.compat.c
@@ -11,15 +11,11 @@ typedef struct {
 typedef Foo_i32__i32 IntFoo_i32;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(IntFoo_i32 a);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/union.compat.c
+++ b/tests/expectations/union.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef union {
+  int32_t x;
+  float y;
+} Normal;
+
+typedef union {
+  int32_t x;
+  float y;
+} NormalWithZST;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void root(Opaque *a, Normal b, NormalWithZST c);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/union.compat.c
+++ b/tests/expectations/union.compat.c
@@ -16,15 +16,11 @@ typedef union {
 } NormalWithZST;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void root(Opaque *a, Normal b, NormalWithZST c);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/va_list.compat.c
+++ b/tests/expectations/va_list.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+int32_t va_list_test(va_list ap);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/expectations/va_list.compat.c
+++ b/tests/expectations/va_list.compat.c
@@ -4,15 +4,11 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 int32_t va_list_test(va_list ap);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/workspace.compat.c
+++ b/tests/expectations/workspace.compat.c
@@ -8,15 +8,11 @@ typedef struct {
 } ExtType;
 
 #ifdef __cplusplus
-
 extern "C" {
-
 #endif // __cplusplus
 
 void consume_ext(ExtType _ext);
 
 #ifdef __cplusplus
-
 } // extern "C"
-
 #endif // __cplusplus

--- a/tests/expectations/workspace.compat.c
+++ b/tests/expectations/workspace.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  uint32_t data;
+} ExtType;
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif // __cplusplus
+
+void consume_ext(ExtType _ext);
+
+#ifdef __cplusplus
+
+} // extern "C"
+
+#endif // __cplusplus

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -132,10 +132,25 @@ fn run_compile_test(
 fn test_file(cbindgen_path: &'static str, name: &'static str, filename: &'static str) {
     let test = Path::new(filename);
     for style in &[Style::Type, Style::Tag, Style::Both] {
-        run_compile_test(cbindgen_path, name, &test, Language::C, true, Some(*style));
-        run_compile_test(cbindgen_path, name, &test, Language::C, false, Some(*style));
+        for cpp_compat in &[true, false] {
+            run_compile_test(
+                cbindgen_path,
+                name,
+                &test,
+                Language::C,
+                *cpp_compat,
+                Some(*style),
+            );
+        }
     }
-    run_compile_test(cbindgen_path, name, &test, Language::Cxx, false, None);
+    run_compile_test(
+        cbindgen_path,
+        name,
+        &test,
+        Language::Cxx,
+        /* cpp_compat = */ false,
+        None,
+    );
 }
 
 macro_rules! test_file {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -55,10 +55,10 @@ fn run_cbindgen(
 }
 
 fn compile(cbindgen_output: &Path, language: Language) {
-    let cc = env::var("CC").unwrap_or_else(|_| match language {
-        Language::Cxx => "g++".to_owned(),
-        Language::C => "gcc".to_owned(),
-    });
+    let cc = match language {
+        Language::Cxx => env::var("CXX").unwrap_or_else(|_| "g++".to_owned()),
+        Language::C => env::var("CC").unwrap_or_else(|_| "gcc".to_owned()),
+    };
 
     let mut object = cbindgen_output.to_path_buf();
     object.set_extension("o");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,7 +3,7 @@ extern crate cbindgen;
 use cbindgen::*;
 use std::path::Path;
 use std::process::Command;
-use std::{env, fs};
+use std::{env, fs, str};
 
 fn run_cbindgen(
     cbindgen_path: &'static str,
@@ -48,8 +48,9 @@ fn run_cbindgen(
     let cbindgen_output = command.output().expect("failed to execute process");
     assert!(
         cbindgen_output.status.success(),
-        "cbindgen failed: {:?}",
-        output
+        "cbindgen failed: {:?} with error: {}",
+        output,
+        str::from_utf8(&cbindgen_output.stderr).unwrap_or_default()
     );
 }
 


### PR DESCRIPTION
I added the option to generate header files that will successfully compile in both C and C++ compilers. You can opt in to this feature by setting the following setting in the `cbindgen.toml`:

```language = "Both"```

To create this feature, I had to make enums have both a tag and a typedef. As such, my code does not check whether users have opted into these styles.