### PR TITLE
Add an option to generate consts / globals / fn from parsed dependencies.

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -751,6 +751,12 @@ exclude = ["libc"]
 # default: false
 clean = false
 
+# Whether to generate top-level constants / globals and functions defined in
+# dependent crates.
+#
+# default: false
+top_level_items_outside_of_binding_crate = true
+
 [parse.expand]
 # A list of crate names that should be run through `cargo expand` before
 # parsing to expand any macros. Note that if a crate is named here, it

--- a/docs.md
+++ b/docs.md
@@ -752,10 +752,10 @@ exclude = ["libc"]
 clean = false
 
 # Which crates other than the top-level binding crate we should generate
-# top-level constants / globals and functions.
+# bindings for.
 #
 # default: []
-deps_with_top_level_items = ["my_awesome_dep"]
+extra_bindings = ["my_awesome_dep"]
 
 [parse.expand]
 # A list of crate names that should be run through `cargo expand` before

--- a/docs.md
+++ b/docs.md
@@ -751,11 +751,11 @@ exclude = ["libc"]
 # default: false
 clean = false
 
-# Whether to generate top-level constants / globals and functions defined in
-# dependent crates.
+# Which crates other than the top-level binding crate we should generate
+# top-level constants / globals and functions.
 #
-# default: false
-top_level_items_outside_of_binding_crate = true
+# default: []
+deps_with_top_level_items = ["my_awesome_dep"]
 
 [parse.expand]
 # A list of crate names that should be run through `cargo expand` before

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -329,6 +329,7 @@ impl Builder {
                 self.config.parse.expand.all_features,
                 self.config.parse.expand.default_features,
                 &self.config.parse.expand.features,
+                self.config.parse.top_level_items_outside_of_binding_crate,
             )?);
         } else if let Some(cargo) = self.lib_cargo.clone() {
             result.extend_with(&parser::parse_lib(
@@ -341,6 +342,7 @@ impl Builder {
                 self.config.parse.expand.all_features,
                 self.config.parse.expand.default_features,
                 &self.config.parse.expand.features,
+                self.config.parse.top_level_items_outside_of_binding_crate,
             )?);
         }
 

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -322,27 +322,13 @@ impl Builder {
             result.extend_with(&parser::parse_lib(
                 cargo,
                 &self.config.macro_expansion,
-                self.config.parse.parse_deps,
-                &self.config.parse.include,
-                &self.config.parse.exclude,
-                &self.config.parse.expand.crates,
-                self.config.parse.expand.all_features,
-                self.config.parse.expand.default_features,
-                &self.config.parse.expand.features,
-                self.config.parse.top_level_items_outside_of_binding_crate,
+                &self.config.parse,
             )?);
         } else if let Some(cargo) = self.lib_cargo.clone() {
             result.extend_with(&parser::parse_lib(
                 cargo,
                 &self.config.macro_expansion,
-                self.config.parse.parse_deps,
-                &self.config.parse.include,
-                &self.config.parse.exclude,
-                &self.config.parse.expand.crates,
-                self.config.parse.expand.all_features,
-                self.config.parse.expand.default_features,
-                &self.config.parse.expand.features,
-                self.config.parse.top_level_items_outside_of_binding_crate,
+                &self.config.parse,
             )?);
         }
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -562,11 +562,26 @@ pub struct ParseConfig {
     /// Whether to use a new temporary target directory when running `rustc --pretty=expanded`.
     /// This may be required for some build processes.
     pub clean: bool,
-    /// Whether consts, statics, and fns are generated even if outside of the
-    /// binding crate.
-    ///
-    /// It's probably a good idea to combine this with `exports.include`.
-    pub top_level_items_outside_of_binding_crate: bool,
+    /// List of crate names which generate consts, statics, and fns. By default
+    /// no dependent crates generate them.
+    pub deps_with_top_level_items: Vec<String>,
+}
+
+impl ParseConfig {
+    pub(crate) fn should_generate_top_level_item(
+        &self,
+        crate_name: &str,
+        binding_crate_name: &str,
+    ) -> bool {
+        if crate_name == binding_crate_name {
+            // Always generate items for the binding crate.
+            return true;
+        }
+
+        self.deps_with_top_level_items
+            .iter()
+            .any(|dep| dep == crate_name)
+    }
 }
 
 /// A collection of settings to customize the generated bindings.

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -538,7 +538,7 @@ fn retrocomp_parse_expand_config_deserialize<'de, D: Deserializer<'de>>(
 }
 
 /// Settings to apply when parsing.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 #[serde(default)]
@@ -562,18 +562,11 @@ pub struct ParseConfig {
     /// Whether to use a new temporary target directory when running `rustc --pretty=expanded`.
     /// This may be required for some build processes.
     pub clean: bool,
-}
-
-impl Default for ParseConfig {
-    fn default() -> ParseConfig {
-        ParseConfig {
-            parse_deps: false,
-            include: None,
-            exclude: Vec::new(),
-            expand: ParseExpandConfig::default(),
-            clean: false,
-        }
-    }
+    /// Whether consts, statics, and fns are generated even if outside of the
+    /// binding crate.
+    ///
+    /// It's probably a good idea to combine this with `exports.include`.
+    pub top_level_items_outside_of_binding_crate: bool,
 }
 
 /// A collection of settings to customize the generated bindings.

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -564,7 +564,7 @@ pub struct ParseConfig {
     pub clean: bool,
     /// List of crate names which generate consts, statics, and fns. By default
     /// no dependent crates generate them.
-    pub deps_with_top_level_items: Vec<String>,
+    pub extra_bindings: Vec<String>,
 }
 
 impl ParseConfig {
@@ -578,9 +578,7 @@ impl ParseConfig {
             return true;
         }
 
-        self.deps_with_top_level_items
-            .iter()
-            .any(|dep| dep == crate_name)
+        self.extra_bindings.iter().any(|dep| dep == crate_name)
     }
 }
 

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -539,8 +539,7 @@ impl Parse {
         for foreign_item in &item.items {
             match *foreign_item {
                 syn::ForeignItem::Fn(ref function) => {
-                    if !parse_config.top_level_items_outside_of_binding_crate
-                        && crate_name != binding_crate_name
+                    if !parse_config.should_generate_top_level_item(crate_name, binding_crate_name)
                     {
                         info!(
                             "Skip {}::{} - (fn's outside of the binding crate are not used).",
@@ -577,9 +576,7 @@ impl Parse {
         mod_cfg: Option<&Cfg>,
         item: &syn::ItemFn,
     ) {
-        if !parse_config.top_level_items_outside_of_binding_crate
-            && crate_name != binding_crate_name
-        {
+        if !parse_config.should_generate_top_level_item(crate_name, binding_crate_name) {
             info!(
                 "Skip {}::{} - (fn's outside of the binding crate are not used).",
                 crate_name, &item.ident
@@ -694,9 +691,7 @@ impl Parse {
         mod_cfg: Option<&Cfg>,
         item: &syn::ItemConst,
     ) {
-        if !parse_config.top_level_items_outside_of_binding_crate
-            && crate_name != binding_crate_name
-        {
+        if !parse_config.should_generate_top_level_item(crate_name, binding_crate_name) {
             info!(
                 "Skip {}::{} - (const's outside of the binding crate are not used).",
                 crate_name, &item.ident
@@ -735,9 +730,7 @@ impl Parse {
         mod_cfg: Option<&Cfg>,
         item: &syn::ItemStatic,
     ) {
-        if !parse_config.top_level_items_outside_of_binding_crate
-            && crate_name != binding_crate_name
-        {
+        if !parse_config.should_generate_top_level_item(crate_name, binding_crate_name) {
             info!(
                 "Skip {}::{} - (static's outside of the binding crate are not used).",
                 crate_name, &item.ident

--- a/template.toml
+++ b/template.toml
@@ -127,7 +127,7 @@ parse_deps = false
 # include = []
 exclude = []
 clean = false
-# deps_with_top_level_items = []
+extra_bindings = []
 
 
 

--- a/template.toml
+++ b/template.toml
@@ -127,6 +127,7 @@ parse_deps = false
 # include = []
 exclude = []
 clean = false
+# top_level_items_outside_of_binding_crate = true
 
 
 

--- a/template.toml
+++ b/template.toml
@@ -127,7 +127,7 @@ parse_deps = false
 # include = []
 exclude = []
 clean = false
-# top_level_items_outside_of_binding_crate = true
+# deps_with_top_level_items = []
 
 
 

--- a/tests/expectations/both/workspace.c
+++ b/tests/expectations/both/workspace.c
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define EXT_CONST 0
+
 typedef struct ExtType {
   uint32_t data;
 } ExtType;

--- a/tests/expectations/both/workspace.compat.c
+++ b/tests/expectations/both/workspace.compat.c
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define EXT_CONST 0
+
 typedef struct ExtType {
   uint32_t data;
 } ExtType;

--- a/tests/expectations/tag/workspace.c
+++ b/tests/expectations/tag/workspace.c
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define EXT_CONST 0
+
 struct ExtType {
   uint32_t data;
 };

--- a/tests/expectations/tag/workspace.compat.c
+++ b/tests/expectations/tag/workspace.compat.c
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define EXT_CONST 0
+
 struct ExtType {
   uint32_t data;
 };

--- a/tests/expectations/workspace.c
+++ b/tests/expectations/workspace.c
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define EXT_CONST 0
+
 typedef struct {
   uint32_t data;
 } ExtType;

--- a/tests/expectations/workspace.compat.c
+++ b/tests/expectations/workspace.compat.c
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define EXT_CONST 0
+
 typedef struct {
   uint32_t data;
 } ExtType;

--- a/tests/expectations/workspace.cpp
+++ b/tests/expectations/workspace.cpp
@@ -3,6 +3,8 @@
 #include <cstdlib>
 #include <new>
 
+static const int32_t EXT_CONST = 0;
+
 struct ExtType {
   uint32_t data;
 };

--- a/tests/rust/workspace/cbindgen.toml
+++ b/tests/rust/workspace/cbindgen.toml
@@ -1,3 +1,3 @@
 [parse]
 parse_deps = true
-top_level_items_outside_of_binding_crate = true
+deps_with_top_level_items = ["dep"]

--- a/tests/rust/workspace/cbindgen.toml
+++ b/tests/rust/workspace/cbindgen.toml
@@ -1,3 +1,3 @@
 [parse]
 parse_deps = true
-deps_with_top_level_items = ["dep"]
+extra_bindings = ["dep"]

--- a/tests/rust/workspace/cbindgen.toml
+++ b/tests/rust/workspace/cbindgen.toml
@@ -1,2 +1,3 @@
 [parse]
 parse_deps = true
+top_level_items_outside_of_binding_crate = true

--- a/tests/rust/workspace/dep/src/lib.rs
+++ b/tests/rust/workspace/dep/src/lib.rs
@@ -2,3 +2,5 @@
 pub struct ExtType {
     pub data: u32,
 }
+
+pub const EXT_CONST: i32 = 0;


### PR DESCRIPTION
This is a limitation that may not be useful if you're using it to parse known
dependencies.