### PR TITLE
Make running cbindgen with own create expansion from build.rs

### DIFF
--- a/src/bindgen/cargo/cargo_expand.rs
+++ b/src/bindgen/cargo/cargo_expand.rs
@@ -83,6 +83,10 @@ pub fn expand(
         cmd.env("CARGO_TARGET_DIR", PathBuf::from(path).join("expanded"));
     }
 
+    // Set this variable so that we don't call it recursively if we expand a crate that is using
+    // cbindgen
+    cmd.env("_CBINDGEN_IS_RUNNING", "1");
+
     cmd.arg("rustc");
     cmd.arg("--lib");
     cmd.arg("--manifest-path");

--- a/src/bindgen/cargo/cargo_expand.rs
+++ b/src/bindgen/cargo/cargo_expand.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::error;
 use std::fmt;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::{from_utf8, Utf8Error};
 
@@ -75,6 +75,12 @@ pub fn expand(
         cmd.env("CARGO_TARGET_DIR", _temp_dir.unwrap().path());
     } else if let Ok(ref path) = env::var("CARGO_EXPAND_TARGET_DIR") {
         cmd.env("CARGO_TARGET_DIR", path);
+    } else if let Ok(ref path) = env::var("OUT_DIR") {
+        // When cbindgen was started programatically from a build.rs file, Cargo is running and
+        // locking the default target directory. In this case we need to use another directory,
+        // else we would end up in a deadlock. If Cargo is running `OUT_DIR` will be set, so we
+        // can use a directory relative to that.
+        cmd.env("CARGO_TARGET_DIR", PathBuf::from(path).join("expanded"));
     }
 
     cmd.arg("rustc");

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -179,6 +179,13 @@ impl<'a> Parser<'a> {
     fn parse_expand_crate(&mut self, pkg: &PackageRef) -> Result<(), Error> {
         assert!(self.lib.is_some());
 
+        // If you want to expand the crate you run cbindgen on you might end up in an endless
+        // recursion if the cbindgen generation is triggered from build.rs. Hence don't run the
+        // expansion if the build was already triggered by cbindgen.
+        if std::env::var("_CBINDGEN_IS_RUNNING").is_ok() {
+            return Ok(());
+        }
+
         let mod_parsed = {
             if !self.cache_expanded_crate.contains_key(&pkg.name) {
                 let s = self


### PR DESCRIPTION
With the current version of cbindgen it's not possible to have macros in the crate cbindgen is triggered from if you run cbindgen programmatically via build.rs. This issue was reported as #347. This PR fixes that problem.

I've create two commits as it is kind of two issues that need a fix.

### Commit 1: Run cargo expand outside the normal target directory 

When crates should get expanded, then cargo is run again from within cbindgen.
When cbindgen is started from a build.rs file, this means that cargo is starting
another cargo run.

Cargo locks the directory it is running on. If two cargos spawn by each other
run with the same target directory, then they both want to accquire a lock and
hence deadlock.

This commit fixes the problem with running the spawned cargo at a different
directory. Please note that this will always be the same directory, hence
any subsequent runs will be faster (as you would exepct it to be).

### Commit 2:  Don't call cbindgen recursively

To expand a crate, cbindgen calls cargo on that crate. cbindgen can be called from a build.rs
file. But if cargo is called again, it will also call cbindgen again and hence end up in an
endless recursion.

This commit makes sure that cbindgen isn't called again if it is already running.

You can verify this fix with this minimal example https://github.com/vmx/cbindgen-expand-bug
