### PR TITLE
Avoid most trimming and preserve comment structure.

### DIFF
--- a/src/bindgen/ir/annotation.rs
+++ b/src/bindgen/ir/annotation.rs
@@ -50,10 +50,17 @@ impl AnnotationSet {
     }
 
     pub fn load(attrs: &[syn::Attribute]) -> Result<AnnotationSet, String> {
-        let lines: Vec<String> = attrs
-            .get_comment_lines()
-            .into_iter()
-            .filter(|x| !x.is_empty() && x.starts_with("cbindgen:"))
+        let lines = attrs.get_comment_lines();
+        let lines: Vec<&str> = lines
+            .iter()
+            .filter_map(|line| {
+                let line = line.trim_start();
+                if !line.starts_with("cbindgen:") {
+                    return None;
+                }
+
+                Some(line)
+            })
             .collect();
 
         let must_use = attrs.has_attr_word("must_use");
@@ -62,12 +69,9 @@ impl AnnotationSet {
 
         // Look at each line for an annotation
         for line in lines {
-            // Skip lines that don't start with cbindgen
-            if !line.starts_with("cbindgen:") {
-                continue;
-            }
+            debug_assert!(line.starts_with("cbindgen:"));
 
-            // Remove the "cbingen:" prefix
+            // Remove the "cbindgen:" prefix
             let annotation = &line[9..];
 
             // Split the annotation in two

--- a/src/bindgen/ir/documentation.rs
+++ b/src/bindgen/ir/documentation.rs
@@ -20,7 +20,7 @@ impl Documentation {
         let doc = attrs
             .get_comment_lines()
             .into_iter()
-            .filter(|x| !x.starts_with("cbindgen:"))
+            .filter(|x| !x.trim_start().starts_with("cbindgen:"))
             .collect();
 
         Documentation { doc_comment: doc }
@@ -72,9 +72,6 @@ impl Source for Documentation {
                 DocumentationStyle::Auto => unreachable!(), // Auto case should always be covered
             }
 
-            if line.len() != 0 {
-                out.write(" ");
-            }
             write!(out, "{}", line);
             out.new_line();
         }

--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -252,41 +252,25 @@ impl SynAttributeHelpers for [syn::Attribute] {
     }
 
     fn get_comment_lines(&self) -> Vec<String> {
-        let mut raw_comment = String::new();
+        let mut comment = Vec::new();
 
         for attr in self {
             if attr.style == syn::AttrStyle::Outer {
                 if let Some(syn::Meta::NameValue(syn::MetaNameValue {
                     ident,
-                    lit: syn::Lit::Str(comment),
+                    lit: syn::Lit::Str(content),
                     ..
                 })) = attr.interpret_meta()
                 {
                     let name = ident.to_string();
                     if &*name == "doc" {
-                        let text = comment.value();
-                        raw_comment += &text;
-                        raw_comment += "\n";
+                        let text = content.value().trim().to_owned();
+                        comment.push(text);
                     }
                 }
             }
         }
 
-        let mut comment_lines = Vec::new();
-        for raw in raw_comment.lines() {
-            let line = raw
-                .trim_start_matches(" ")
-                .trim_start_matches("//")
-                .trim_start_matches("///")
-                .trim_start_matches("/**")
-                .trim_start_matches("/*")
-                .trim_start_matches("*/")
-                .trim_start_matches("*")
-                .trim_end();
-
-            comment_lines.push(line.to_owned());
-        }
-
-        comment_lines
+        comment
     }
 }

--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -264,7 +264,7 @@ impl SynAttributeHelpers for [syn::Attribute] {
                 {
                     let name = ident.to_string();
                     if &*name == "doc" {
-                        let text = content.value().trim().to_owned();
+                        let text = content.value().trim_end().to_owned();
                         comment.push(text);
                     }
                 }

--- a/tests/expectations/both/documentation.c
+++ b/tests/expectations/both/documentation.c
@@ -12,6 +12,14 @@
  * # Hint
  *
  * Always ensure that everything is properly documented, even if you feel lazy.
- * Sometimes** it is also helpful to include some markdown formatting.
+ * **Sometimes** it is also helpful to include some markdown formatting.
+ *
+ * ////////////////////////////////////////////////////////////////////////////
+ *
+ * # Attention
+ *
+ * Rust is going to trim all leading `/` symbols. If you want to use them as a
+ * marker you need to add at least a single whitespace inbetween the tripple
+ * slash doc-comment marker and the rest.
  */
 void root(void);

--- a/tests/expectations/both/documentation.c
+++ b/tests/expectations/both/documentation.c
@@ -16,10 +16,11 @@
  *
  * ////////////////////////////////////////////////////////////////////////////
  *
- * # Attention
+ * Attention:
  *
- * Rust is going to trim all leading `/` symbols. If you want to use them as a
- * marker you need to add at least a single whitespace inbetween the tripple
- * slash doc-comment marker and the rest.
+ *    Rust is going to trim all leading `/` symbols. If you want to use them as a
+ *    marker you need to add at least a single whitespace inbetween the tripple
+ *    slash doc-comment marker and the rest.
+ *
  */
 void root(void);

--- a/tests/expectations/both/documentation.compat.c
+++ b/tests/expectations/both/documentation.compat.c
@@ -20,11 +20,12 @@ extern "C" {
  *
  * ////////////////////////////////////////////////////////////////////////////
  *
- * # Attention
+ * Attention:
  *
- * Rust is going to trim all leading `/` symbols. If you want to use them as a
- * marker you need to add at least a single whitespace inbetween the tripple
- * slash doc-comment marker and the rest.
+ *    Rust is going to trim all leading `/` symbols. If you want to use them as a
+ *    marker you need to add at least a single whitespace inbetween the tripple
+ *    slash doc-comment marker and the rest.
+ *
  */
 void root(void);
 

--- a/tests/expectations/both/documentation.compat.c
+++ b/tests/expectations/both/documentation.compat.c
@@ -16,7 +16,15 @@ extern "C" {
  * # Hint
  *
  * Always ensure that everything is properly documented, even if you feel lazy.
- * Sometimes** it is also helpful to include some markdown formatting.
+ * **Sometimes** it is also helpful to include some markdown formatting.
+ *
+ * ////////////////////////////////////////////////////////////////////////////
+ *
+ * # Attention
+ *
+ * Rust is going to trim all leading `/` symbols. If you want to use them as a
+ * marker you need to add at least a single whitespace inbetween the tripple
+ * slash doc-comment marker and the rest.
  */
 void root(void);
 

--- a/tests/expectations/documentation.c
+++ b/tests/expectations/documentation.c
@@ -12,6 +12,14 @@
  * # Hint
  *
  * Always ensure that everything is properly documented, even if you feel lazy.
- * Sometimes** it is also helpful to include some markdown formatting.
+ * **Sometimes** it is also helpful to include some markdown formatting.
+ *
+ * ////////////////////////////////////////////////////////////////////////////
+ *
+ * # Attention
+ *
+ * Rust is going to trim all leading `/` symbols. If you want to use them as a
+ * marker you need to add at least a single whitespace inbetween the tripple
+ * slash doc-comment marker and the rest.
  */
 void root(void);

--- a/tests/expectations/documentation.c
+++ b/tests/expectations/documentation.c
@@ -16,10 +16,11 @@
  *
  * ////////////////////////////////////////////////////////////////////////////
  *
- * # Attention
+ * Attention:
  *
- * Rust is going to trim all leading `/` symbols. If you want to use them as a
- * marker you need to add at least a single whitespace inbetween the tripple
- * slash doc-comment marker and the rest.
+ *    Rust is going to trim all leading `/` symbols. If you want to use them as a
+ *    marker you need to add at least a single whitespace inbetween the tripple
+ *    slash doc-comment marker and the rest.
+ *
  */
 void root(void);

--- a/tests/expectations/documentation.compat.c
+++ b/tests/expectations/documentation.compat.c
@@ -20,11 +20,12 @@ extern "C" {
  *
  * ////////////////////////////////////////////////////////////////////////////
  *
- * # Attention
+ * Attention:
  *
- * Rust is going to trim all leading `/` symbols. If you want to use them as a
- * marker you need to add at least a single whitespace inbetween the tripple
- * slash doc-comment marker and the rest.
+ *    Rust is going to trim all leading `/` symbols. If you want to use them as a
+ *    marker you need to add at least a single whitespace inbetween the tripple
+ *    slash doc-comment marker and the rest.
+ *
  */
 void root(void);
 

--- a/tests/expectations/documentation.compat.c
+++ b/tests/expectations/documentation.compat.c
@@ -16,7 +16,15 @@ extern "C" {
  * # Hint
  *
  * Always ensure that everything is properly documented, even if you feel lazy.
- * Sometimes** it is also helpful to include some markdown formatting.
+ * **Sometimes** it is also helpful to include some markdown formatting.
+ *
+ * ////////////////////////////////////////////////////////////////////////////
+ *
+ * # Attention
+ *
+ * Rust is going to trim all leading `/` symbols. If you want to use them as a
+ * marker you need to add at least a single whitespace inbetween the tripple
+ * slash doc-comment marker and the rest.
  */
 void root(void);
 

--- a/tests/expectations/documentation.cpp
+++ b/tests/expectations/documentation.cpp
@@ -17,11 +17,12 @@ extern "C" {
 ///
 /// ////////////////////////////////////////////////////////////////////////////
 ///
-/// # Attention
+/// Attention:
 ///
-/// Rust is going to trim all leading `/` symbols. If you want to use them as a
-/// marker you need to add at least a single whitespace inbetween the tripple
-/// slash doc-comment marker and the rest.
+///    Rust is going to trim all leading `/` symbols. If you want to use them as a
+///    marker you need to add at least a single whitespace inbetween the tripple
+///    slash doc-comment marker and the rest.
+///
 void root();
 
 } // extern "C"

--- a/tests/expectations/documentation.cpp
+++ b/tests/expectations/documentation.cpp
@@ -13,7 +13,15 @@ extern "C" {
 /// # Hint
 ///
 /// Always ensure that everything is properly documented, even if you feel lazy.
-/// Sometimes** it is also helpful to include some markdown formatting.
+/// **Sometimes** it is also helpful to include some markdown formatting.
+///
+/// ////////////////////////////////////////////////////////////////////////////
+///
+/// # Attention
+///
+/// Rust is going to trim all leading `/` symbols. If you want to use them as a
+/// marker you need to add at least a single whitespace inbetween the tripple
+/// slash doc-comment marker and the rest.
 void root();
 
 } // extern "C"

--- a/tests/expectations/tag/documentation.c
+++ b/tests/expectations/tag/documentation.c
@@ -12,6 +12,14 @@
  * # Hint
  *
  * Always ensure that everything is properly documented, even if you feel lazy.
- * Sometimes** it is also helpful to include some markdown formatting.
+ * **Sometimes** it is also helpful to include some markdown formatting.
+ *
+ * ////////////////////////////////////////////////////////////////////////////
+ *
+ * # Attention
+ *
+ * Rust is going to trim all leading `/` symbols. If you want to use them as a
+ * marker you need to add at least a single whitespace inbetween the tripple
+ * slash doc-comment marker and the rest.
  */
 void root(void);

--- a/tests/expectations/tag/documentation.c
+++ b/tests/expectations/tag/documentation.c
@@ -16,10 +16,11 @@
  *
  * ////////////////////////////////////////////////////////////////////////////
  *
- * # Attention
+ * Attention:
  *
- * Rust is going to trim all leading `/` symbols. If you want to use them as a
- * marker you need to add at least a single whitespace inbetween the tripple
- * slash doc-comment marker and the rest.
+ *    Rust is going to trim all leading `/` symbols. If you want to use them as a
+ *    marker you need to add at least a single whitespace inbetween the tripple
+ *    slash doc-comment marker and the rest.
+ *
  */
 void root(void);

--- a/tests/expectations/tag/documentation.compat.c
+++ b/tests/expectations/tag/documentation.compat.c
@@ -20,11 +20,12 @@ extern "C" {
  *
  * ////////////////////////////////////////////////////////////////////////////
  *
- * # Attention
+ * Attention:
  *
- * Rust is going to trim all leading `/` symbols. If you want to use them as a
- * marker you need to add at least a single whitespace inbetween the tripple
- * slash doc-comment marker and the rest.
+ *    Rust is going to trim all leading `/` symbols. If you want to use them as a
+ *    marker you need to add at least a single whitespace inbetween the tripple
+ *    slash doc-comment marker and the rest.
+ *
  */
 void root(void);
 

--- a/tests/expectations/tag/documentation.compat.c
+++ b/tests/expectations/tag/documentation.compat.c
@@ -16,7 +16,15 @@ extern "C" {
  * # Hint
  *
  * Always ensure that everything is properly documented, even if you feel lazy.
- * Sometimes** it is also helpful to include some markdown formatting.
+ * **Sometimes** it is also helpful to include some markdown formatting.
+ *
+ * ////////////////////////////////////////////////////////////////////////////
+ *
+ * # Attention
+ *
+ * Rust is going to trim all leading `/` symbols. If you want to use them as a
+ * marker you need to add at least a single whitespace inbetween the tripple
+ * slash doc-comment marker and the rest.
  */
 void root(void);
 

--- a/tests/rust/documentation.rs
+++ b/tests/rust/documentation.rs
@@ -10,11 +10,12 @@
 ///
 /// ////////////////////////////////////////////////////////////////////////////
 ///
-/// # Attention
+/// Attention:
 ///
-/// Rust is going to trim all leading `/` symbols. If you want to use them as a
-/// marker you need to add at least a single whitespace inbetween the tripple
-/// slash doc-comment marker and the rest.
+///    Rust is going to trim all leading `/` symbols. If you want to use them as a
+///    marker you need to add at least a single whitespace inbetween the tripple
+///    slash doc-comment marker and the rest.
+///
 #[no_mangle]
 pub extern "C" fn root() {
 }

--- a/tests/rust/documentation.rs
+++ b/tests/rust/documentation.rs
@@ -7,6 +7,14 @@
 ///
 /// Always ensure that everything is properly documented, even if you feel lazy.
 /// **Sometimes** it is also helpful to include some markdown formatting.
+///
+/// ////////////////////////////////////////////////////////////////////////////
+///
+/// # Attention
+///
+/// Rust is going to trim all leading `/` symbols. If you want to use them as a
+/// marker you need to add at least a single whitespace inbetween the tripple
+/// slash doc-comment marker and the rest.
 #[no_mangle]
 pub extern "C" fn root() {
 }


### PR DESCRIPTION
This fixes two additional documentation related issues: #184 & #374. Both effect nearly the same parts of the source code. It also updates the `documentation` test to verify the new expected behavior.

---

Feel free to nitpick. I will try to come up with all required changes to get this merged.