### PR TITLE
ir: Add an option to generate an empty, default constructor for tagged enums.

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -270,6 +270,7 @@ The rest are just local overrides for the same options found in the cbindgen.tom
 * derive-tagged-enum-destructor
 * derive-tagged-enum-copy-constructor
 * prefix-with-name
+* private-default-tagged-enum-constructor
 
 
 
@@ -702,6 +703,14 @@ derive_tagged_enum_destructor = false
 #
 # default: false
 derive_tagged_enum_copy_constructor = false
+
+# Whether enums with fields should generate an empty, private destructor.
+# This allows the auto-generated constructor functions to compile, if there are
+# non-trivially constructible members. This falls in the same family of
+# dangerousness as `derive_tagged_enum_copy_constructor` and co.
+#
+# default: false
+private_default_tagged_enum_constructor = false
 
 
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -400,6 +400,9 @@ pub struct EnumConfig {
     pub derive_tagged_enum_destructor: bool,
     /// Whether to generate copy-constructors of tagged enums.
     pub derive_tagged_enum_copy_constructor: bool,
+    /// Whether to generate empty, private default-constructors for tagged
+    /// enums.
+    pub private_default_tagged_enum_constructor: bool,
 }
 
 impl EnumConfig {
@@ -438,6 +441,15 @@ impl EnumConfig {
             return x;
         }
         self.derive_tagged_enum_copy_constructor
+    }
+    pub(crate) fn private_default_tagged_enum_constructor(
+        &self,
+        annotations: &AnnotationSet,
+    ) -> bool {
+        if let Some(x) = annotations.bool("private-default-tagged-enum-constructor") {
+            return x;
+        }
+        self.private_default_tagged_enum_constructor
     }
 }
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -895,6 +895,22 @@ impl Source for Enum {
             if config.language == Language::Cxx
                 && config
                     .enumeration
+                    .private_default_tagged_enum_constructor(&self.annotations)
+            {
+                out.new_line();
+                out.new_line();
+                write!(out, "private:");
+                out.new_line();
+                write!(out, "{}()", self.export_name);
+                out.open_brace();
+                out.close_brace(false);
+                write!(out, "public:");
+                out.new_line();
+            }
+
+            if config.language == Language::Cxx
+                && config
+                    .enumeration
                     .derive_tagged_enum_destructor(&self.annotations)
             {
                 out.new_line();

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -904,6 +904,7 @@ impl Source for Enum {
                 write!(out, "{}()", self.export_name);
                 out.open_brace();
                 out.close_brace(false);
+                out.new_line();
                 write!(out, "public:");
                 out.new_line();
             }

--- a/template.toml
+++ b/template.toml
@@ -102,6 +102,7 @@ derive_mut_casts = false
 # cast_assert_name = "ASSERT"
 derive_tagged_enum_destructor = false
 derive_tagged_enum_copy_constructor = false
+private_default_tagged_enum_constructor = false
 
 
 

--- a/tests/expectations/both/destructor-and-copy-ctor.c
+++ b/tests/expectations/both/destructor-and-copy-ctor.c
@@ -129,6 +129,7 @@ typedef union Baz_i32 {
 enum Taz_Tag {
   Bar3,
   Taz1,
+  Taz3,
 };
 typedef uint8_t Taz_Tag;
 
@@ -137,9 +138,15 @@ typedef struct Taz1_Body {
   int32_t _0;
 } Taz1_Body;
 
+typedef struct Taz3_Body {
+  Taz_Tag tag;
+  OwnedSlice_i32 _0;
+} Taz3_Body;
+
 typedef union Taz {
   Taz_Tag tag;
   Taz1_Body taz1;
+  Taz3_Body taz3;
 } Taz;
 
 enum Tazz_Tag {

--- a/tests/expectations/both/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/both/destructor-and-copy-ctor.compat.c
@@ -151,6 +151,7 @@ enum Taz_Tag
  {
   Bar3,
   Taz1,
+  Taz3,
 };
 #ifndef __cplusplus
 typedef uint8_t Taz_Tag;
@@ -161,9 +162,15 @@ typedef struct Taz1_Body {
   int32_t _0;
 } Taz1_Body;
 
+typedef struct Taz3_Body {
+  Taz_Tag tag;
+  OwnedSlice_i32 _0;
+} Taz3_Body;
+
 typedef union Taz {
   Taz_Tag tag;
   Taz1_Body taz1;
+  Taz3_Body taz3;
 } Taz;
 
 enum Tazz_Tag

--- a/tests/expectations/destructor-and-copy-ctor.c
+++ b/tests/expectations/destructor-and-copy-ctor.c
@@ -129,6 +129,7 @@ typedef union {
 enum Taz_Tag {
   Bar3,
   Taz1,
+  Taz3,
 };
 typedef uint8_t Taz_Tag;
 
@@ -137,9 +138,15 @@ typedef struct {
   int32_t _0;
 } Taz1_Body;
 
+typedef struct {
+  Taz_Tag tag;
+  OwnedSlice_i32 _0;
+} Taz3_Body;
+
 typedef union {
   Taz_Tag tag;
   Taz1_Body taz1;
+  Taz3_Body taz3;
 } Taz;
 
 enum Tazz_Tag {

--- a/tests/expectations/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/destructor-and-copy-ctor.compat.c
@@ -151,6 +151,7 @@ enum Taz_Tag
  {
   Bar3,
   Taz1,
+  Taz3,
 };
 #ifndef __cplusplus
 typedef uint8_t Taz_Tag;
@@ -161,9 +162,15 @@ typedef struct {
   int32_t _0;
 } Taz1_Body;
 
+typedef struct {
+  Taz_Tag tag;
+  OwnedSlice_i32 _0;
+} Taz3_Body;
+
 typedef union {
   Taz_Tag tag;
   Taz1_Body taz1;
+  Taz3_Body taz3;
 } Taz;
 
 enum Tazz_Tag

--- a/tests/expectations/destructor-and-copy-ctor.cpp
+++ b/tests/expectations/destructor-and-copy-ctor.cpp
@@ -137,7 +137,8 @@ struct Foo {
   private:
   Foo() {
 
-  }public:
+  }
+  public:
 
 
   ~Foo() {
@@ -283,7 +284,8 @@ union Baz {
   private:
   Baz() {
 
-  }public:
+  }
+  public:
 
 
   ~Baz() {
@@ -368,7 +370,8 @@ union Taz {
   private:
   Taz() {
 
-  }public:
+  }
+  public:
 
 
   ~Taz() {
@@ -429,7 +432,8 @@ union Tazz {
   private:
   Tazz() {
 
-  }public:
+  }
+  public:
 
 };
 

--- a/tests/expectations/destructor-and-copy-ctor.cpp
+++ b/tests/expectations/destructor-and-copy-ctor.cpp
@@ -14,6 +14,7 @@ template<typename T>
 struct OwnedSlice {
   uintptr_t len;
   T *ptr;
+  ~OwnedSlice() {}
 };
 
 template<typename LengthPercentage>
@@ -63,6 +64,81 @@ struct Foo {
     Slice3_Body slice3;
     Slice4_Body slice4;
   };
+
+  static Foo Bar() {
+    Foo result;
+    result.tag = Tag::Bar;
+    return result;
+  }
+
+  static Foo Polygon1(const Polygon<T> &a0) {
+    Foo result;
+    ::new (&result.polygon1._0) (Polygon<T>)(a0);
+    result.tag = Tag::Polygon1;
+    return result;
+  }
+
+  static Foo Slice1(const OwnedSlice<T> &a0) {
+    Foo result;
+    ::new (&result.slice1._0) (OwnedSlice<T>)(a0);
+    result.tag = Tag::Slice1;
+    return result;
+  }
+
+  static Foo Slice2(const OwnedSlice<int32_t> &a0) {
+    Foo result;
+    ::new (&result.slice2._0) (OwnedSlice<int32_t>)(a0);
+    result.tag = Tag::Slice2;
+    return result;
+  }
+
+  static Foo Slice3(const FillRule &aFill,
+                    const OwnedSlice<T> &aCoords) {
+    Foo result;
+    ::new (&result.slice3.fill) (FillRule)(aFill);
+    ::new (&result.slice3.coords) (OwnedSlice<T>)(aCoords);
+    result.tag = Tag::Slice3;
+    return result;
+  }
+
+  static Foo Slice4(const FillRule &aFill,
+                    const OwnedSlice<int32_t> &aCoords) {
+    Foo result;
+    ::new (&result.slice4.fill) (FillRule)(aFill);
+    ::new (&result.slice4.coords) (OwnedSlice<int32_t>)(aCoords);
+    result.tag = Tag::Slice4;
+    return result;
+  }
+
+  bool IsBar() const {
+    return tag == Tag::Bar;
+  }
+
+  bool IsPolygon1() const {
+    return tag == Tag::Polygon1;
+  }
+
+  bool IsSlice1() const {
+    return tag == Tag::Slice1;
+  }
+
+  bool IsSlice2() const {
+    return tag == Tag::Slice2;
+  }
+
+  bool IsSlice3() const {
+    return tag == Tag::Slice3;
+  }
+
+  bool IsSlice4() const {
+    return tag == Tag::Slice4;
+  }
+
+  private:
+  Foo() {
+
+  }public:
+
 
   ~Foo() {
     switch (tag) {
@@ -135,6 +211,81 @@ union Baz {
   Slice23_Body slice23;
   Slice24_Body slice24;
 
+  static Baz Bar2() {
+    Baz result;
+    result.tag = Tag::Bar2;
+    return result;
+  }
+
+  static Baz Polygon21(const Polygon<T> &a0) {
+    Baz result;
+    ::new (&result.polygon21._0) (Polygon<T>)(a0);
+    result.tag = Tag::Polygon21;
+    return result;
+  }
+
+  static Baz Slice21(const OwnedSlice<T> &a0) {
+    Baz result;
+    ::new (&result.slice21._0) (OwnedSlice<T>)(a0);
+    result.tag = Tag::Slice21;
+    return result;
+  }
+
+  static Baz Slice22(const OwnedSlice<int32_t> &a0) {
+    Baz result;
+    ::new (&result.slice22._0) (OwnedSlice<int32_t>)(a0);
+    result.tag = Tag::Slice22;
+    return result;
+  }
+
+  static Baz Slice23(const FillRule &aFill,
+                     const OwnedSlice<T> &aCoords) {
+    Baz result;
+    ::new (&result.slice23.fill) (FillRule)(aFill);
+    ::new (&result.slice23.coords) (OwnedSlice<T>)(aCoords);
+    result.tag = Tag::Slice23;
+    return result;
+  }
+
+  static Baz Slice24(const FillRule &aFill,
+                     const OwnedSlice<int32_t> &aCoords) {
+    Baz result;
+    ::new (&result.slice24.fill) (FillRule)(aFill);
+    ::new (&result.slice24.coords) (OwnedSlice<int32_t>)(aCoords);
+    result.tag = Tag::Slice24;
+    return result;
+  }
+
+  bool IsBar2() const {
+    return tag == Tag::Bar2;
+  }
+
+  bool IsPolygon21() const {
+    return tag == Tag::Polygon21;
+  }
+
+  bool IsSlice21() const {
+    return tag == Tag::Slice21;
+  }
+
+  bool IsSlice22() const {
+    return tag == Tag::Slice22;
+  }
+
+  bool IsSlice23() const {
+    return tag == Tag::Slice23;
+  }
+
+  bool IsSlice24() const {
+    return tag == Tag::Slice24;
+  }
+
+  private:
+  Baz() {
+
+  }public:
+
+
   ~Baz() {
     switch (tag) {
       case Tag::Polygon21: polygon21.~Polygon21_Body(); break;
@@ -163,6 +314,7 @@ union Taz {
   enum class Tag : uint8_t {
     Bar3,
     Taz1,
+    Taz3,
   };
 
   struct Taz1_Body {
@@ -170,14 +322,59 @@ union Taz {
     int32_t _0;
   };
 
+  struct Taz3_Body {
+    Tag tag;
+    OwnedSlice<int32_t> _0;
+  };
+
   struct {
     Tag tag;
   };
   Taz1_Body taz1;
+  Taz3_Body taz3;
+
+  static Taz Bar3() {
+    Taz result;
+    result.tag = Tag::Bar3;
+    return result;
+  }
+
+  static Taz Taz1(const int32_t &a0) {
+    Taz result;
+    ::new (&result.taz1._0) (int32_t)(a0);
+    result.tag = Tag::Taz1;
+    return result;
+  }
+
+  static Taz Taz3(const OwnedSlice<int32_t> &a0) {
+    Taz result;
+    ::new (&result.taz3._0) (OwnedSlice<int32_t>)(a0);
+    result.tag = Tag::Taz3;
+    return result;
+  }
+
+  bool IsBar3() const {
+    return tag == Tag::Bar3;
+  }
+
+  bool IsTaz1() const {
+    return tag == Tag::Taz1;
+  }
+
+  bool IsTaz3() const {
+    return tag == Tag::Taz3;
+  }
+
+  private:
+  Taz() {
+
+  }public:
+
 
   ~Taz() {
     switch (tag) {
       case Tag::Taz1: taz1.~Taz1_Body(); break;
+      case Tag::Taz3: taz3.~Taz3_Body(); break;
       default: break;
     }
   }
@@ -186,6 +383,7 @@ union Taz {
    : tag(other.tag) {
     switch (tag) {
       case Tag::Taz1: ::new (&taz1) (Taz1_Body)(other.taz1); break;
+      case Tag::Taz3: ::new (&taz3) (Taz3_Body)(other.taz3); break;
       default: break;
     }
   }
@@ -206,6 +404,33 @@ union Tazz {
     Tag tag;
   };
   Taz2_Body taz2;
+
+  static Tazz Bar4() {
+    Tazz result;
+    result.tag = Tag::Bar4;
+    return result;
+  }
+
+  static Tazz Taz2(const int32_t &a0) {
+    Tazz result;
+    ::new (&result.taz2._0) (int32_t)(a0);
+    result.tag = Tag::Taz2;
+    return result;
+  }
+
+  bool IsBar4() const {
+    return tag == Tag::Bar4;
+  }
+
+  bool IsTaz2() const {
+    return tag == Tag::Taz2;
+  }
+
+  private:
+  Tazz() {
+
+  }public:
+
 };
 
 extern "C" {

--- a/tests/expectations/tag/destructor-and-copy-ctor.c
+++ b/tests/expectations/tag/destructor-and-copy-ctor.c
@@ -129,6 +129,7 @@ union Baz_i32 {
 enum Taz_Tag {
   Bar3,
   Taz1,
+  Taz3,
 };
 typedef uint8_t Taz_Tag;
 
@@ -137,9 +138,15 @@ struct Taz1_Body {
   int32_t _0;
 };
 
+struct Taz3_Body {
+  Taz_Tag tag;
+  struct OwnedSlice_i32 _0;
+};
+
 union Taz {
   enum Taz_Tag tag;
   struct Taz1_Body taz1;
+  struct Taz3_Body taz3;
 };
 
 enum Tazz_Tag {

--- a/tests/expectations/tag/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/tag/destructor-and-copy-ctor.compat.c
@@ -151,6 +151,7 @@ enum Taz_Tag
  {
   Bar3,
   Taz1,
+  Taz3,
 };
 #ifndef __cplusplus
 typedef uint8_t Taz_Tag;
@@ -161,9 +162,15 @@ struct Taz1_Body {
   int32_t _0;
 };
 
+struct Taz3_Body {
+  Taz_Tag tag;
+  struct OwnedSlice_i32 _0;
+};
+
 union Taz {
   enum Taz_Tag tag;
   struct Taz1_Body taz1;
+  struct Taz3_Body taz3;
 };
 
 enum Tazz_Tag

--- a/tests/rust/destructor-and-copy-ctor.rs
+++ b/tests/rust/destructor-and-copy-ctor.rs
@@ -53,6 +53,7 @@ pub enum Baz<T> {
 pub enum Taz {
     Bar3,
     Taz1(i32),
+    Taz3(OwnedSlice<i32>),
 }
 
 /// cbindgen:derive-tagged-enum-destructor=false

--- a/tests/rust/destructor-and-copy-ctor.toml
+++ b/tests/rust/destructor-and-copy-ctor.toml
@@ -1,3 +1,10 @@
 [enum]
 derive_tagged_enum_destructor = true
 derive_tagged_enum_copy_constructor = true
+derive_helper_methods = true
+private_default_tagged_enum_constructor = true
+
+[export.body]
+"OwnedSlice" = """
+  ~OwnedSlice() {}
+"""


### PR DESCRIPTION
This allows to clean up a pattern that has been showing up lately, see
occurrences of:

  https://searchfox.org/mozilla-central/rev/9775cca0a10a9b5c5f4e15c8f7b3eff5bf91bbd0/servo/ports/geckolib/cbindgen.toml#329