### PR TITLE
Enable verbose logging as well as echo the command line on expansion.

### DIFF
--- a/src/bindgen/cargo/cargo_expand.rs
+++ b/src/bindgen/cargo/cargo_expand.rs
@@ -110,10 +110,12 @@ pub fn expand(
     }
     cmd.arg("-p");
     cmd.arg(&format!("{}:{}", crate_name, version));
+    cmd.arg("--verbose");
     cmd.arg("--");
     cmd.arg("-Z");
     cmd.arg("unstable-options");
     cmd.arg("--pretty=expanded");
+    info!("Command: {:?}", cmd);
     let output = cmd.output()?;
 
     let src = from_utf8(&output.stdout)?.to_owned();


### PR DESCRIPTION
This helps investigating the mysterious errors that sometimes appear, like https://github.com/servo/media/issues/280#issuecomment-509338508