### PR TITLE
Surround namespace with __cplusplus ifdef in cpp_compat mode

### DIFF
--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -286,8 +286,6 @@ impl Bindings {
         }
     }
 
-    //pub(crate) fn open_cpp_compat
-
     pub(crate) fn open_namespaces<F: Write>(&self, out: &mut SourceWriter<F>) {
         let mut wrote_namespace: bool = false;
         if let Some(ref namespace) = self.config.namespace {

--- a/tests/expectations/both/namespace_constant.compat.c
+++ b/tests/expectations/both/namespace_constant.compat.c
@@ -3,6 +3,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+namespace constants {
+#endif // __cplusplus
+
 #define FOO 10
 
 #define ZOM 3.14
@@ -19,4 +23,8 @@ void root(Foo x);
 
 #ifdef __cplusplus
 } // extern "C"
+#endif // __cplusplus
+
+#ifdef __cplusplus
+} // namespace constants
 #endif // __cplusplus

--- a/tests/expectations/both/namespaces_constant.compat.c
+++ b/tests/expectations/both/namespaces_constant.compat.c
@@ -3,6 +3,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+namespace constants {
+namespace test {
+#endif // __cplusplus
+
 #define FOO 10
 
 #define ZOM 3.14
@@ -19,4 +24,9 @@ void root(Foo x);
 
 #ifdef __cplusplus
 } // extern "C"
+#endif // __cplusplus
+
+#ifdef __cplusplus
+} // namespace test
+} // namespace constants
 #endif // __cplusplus

--- a/tests/expectations/both/using_namespaces.compat.c
+++ b/tests/expectations/both/using_namespaces.compat.c
@@ -4,6 +4,10 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
+namespace root {
+#endif // __cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
@@ -11,4 +15,8 @@ void root(void);
 
 #ifdef __cplusplus
 } // extern "C"
+#endif // __cplusplus
+
+#ifdef __cplusplus
+} // namespace root
 #endif // __cplusplus

--- a/tests/expectations/namespace_constant.compat.c
+++ b/tests/expectations/namespace_constant.compat.c
@@ -3,6 +3,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+namespace constants {
+#endif // __cplusplus
+
 #define FOO 10
 
 #define ZOM 3.14
@@ -19,4 +23,8 @@ void root(Foo x);
 
 #ifdef __cplusplus
 } // extern "C"
+#endif // __cplusplus
+
+#ifdef __cplusplus
+} // namespace constants
 #endif // __cplusplus

--- a/tests/expectations/namespaces_constant.compat.c
+++ b/tests/expectations/namespaces_constant.compat.c
@@ -3,6 +3,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+namespace constants {
+namespace test {
+#endif // __cplusplus
+
 #define FOO 10
 
 #define ZOM 3.14
@@ -19,4 +24,9 @@ void root(Foo x);
 
 #ifdef __cplusplus
 } // extern "C"
+#endif // __cplusplus
+
+#ifdef __cplusplus
+} // namespace test
+} // namespace constants
 #endif // __cplusplus

--- a/tests/expectations/tag/namespace_constant.compat.c
+++ b/tests/expectations/tag/namespace_constant.compat.c
@@ -3,6 +3,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+namespace constants {
+#endif // __cplusplus
+
 #define FOO 10
 
 #define ZOM 3.14
@@ -19,4 +23,8 @@ void root(struct Foo x);
 
 #ifdef __cplusplus
 } // extern "C"
+#endif // __cplusplus
+
+#ifdef __cplusplus
+} // namespace constants
 #endif // __cplusplus

--- a/tests/expectations/tag/namespaces_constant.compat.c
+++ b/tests/expectations/tag/namespaces_constant.compat.c
@@ -3,6 +3,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+namespace constants {
+namespace test {
+#endif // __cplusplus
+
 #define FOO 10
 
 #define ZOM 3.14
@@ -19,4 +24,9 @@ void root(struct Foo x);
 
 #ifdef __cplusplus
 } // extern "C"
+#endif // __cplusplus
+
+#ifdef __cplusplus
+} // namespace test
+} // namespace constants
 #endif // __cplusplus

--- a/tests/expectations/tag/using_namespaces.compat.c
+++ b/tests/expectations/tag/using_namespaces.compat.c
@@ -4,6 +4,10 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
+namespace root {
+#endif // __cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
@@ -11,4 +15,8 @@ void root(void);
 
 #ifdef __cplusplus
 } // extern "C"
+#endif // __cplusplus
+
+#ifdef __cplusplus
+} // namespace root
 #endif // __cplusplus

--- a/tests/expectations/using_namespaces.compat.c
+++ b/tests/expectations/using_namespaces.compat.c
@@ -4,6 +4,10 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
+namespace root {
+#endif // __cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
@@ -11,4 +15,8 @@ void root(void);
 
 #ifdef __cplusplus
 } // extern "C"
+#endif // __cplusplus
+
+#ifdef __cplusplus
+} // namespace root
 #endif // __cplusplus


### PR DESCRIPTION
This implements #391 

Ideally I think some of the outputs should be refactored into seperate functions e.g. `open_cpp_compat` and `close_cpp_compat` to keep things DRY. 

