### PR TITLE
Fix missing C header for char32_t

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -360,7 +360,7 @@ includes = ["my_great_lib.h"]
 # imports are included by default because our generated headers tend to require
 # them (e.g. for uint32_t). Currently, the generated imports are:
 #
-# * for C: <stdarg.h>, <stdbool.h>, <stdint.h>, <stdlib.h>
+# * for C: <stdarg.h>, <stdbool.h>, <stdint.h>, <stdlib.h>, <uchar.h>
 #
 # * for C++: <cstdarg>, <cstdint>, <cstdlib>, <new>, <cassert> (depending on config)
 #

--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -167,6 +167,8 @@ impl Bindings {
                 out.new_line();
                 out.write("#include <stdlib.h>");
                 out.new_line();
+                out.write("#include <uchar.h>");
+                out.new_line();
             } else {
                 out.write("#include <cstdarg>");
                 out.new_line();

--- a/tests/expectations/alias.c
+++ b/tests/expectations/alias.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum Status {
   Ok,

--- a/tests/expectations/alias.compat.c
+++ b/tests/expectations/alias.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum Status
 #ifdef __cplusplus

--- a/tests/expectations/annotation.c
+++ b/tests/expectations/annotation.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum C {
   X = 2,

--- a/tests/expectations/annotation.compat.c
+++ b/tests/expectations/annotation.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum C
 #ifdef __cplusplus

--- a/tests/expectations/array.c
+++ b/tests/expectations/array.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef enum {
   A,

--- a/tests/expectations/array.compat.c
+++ b/tests/expectations/array.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef enum {
   A,

--- a/tests/expectations/asserted-cast.c
+++ b/tests/expectations/asserted-cast.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct I I;
 

--- a/tests/expectations/asserted-cast.compat.c
+++ b/tests/expectations/asserted-cast.compat.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct I I;
 

--- a/tests/expectations/assoc_const_conflict.c
+++ b/tests/expectations/assoc_const_conflict.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/assoc_const_conflict.compat.c
+++ b/tests/expectations/assoc_const_conflict.compat.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/assoc_constant.c
+++ b/tests/expectations/assoc_constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
 

--- a/tests/expectations/assoc_constant.compat.c
+++ b/tests/expectations/assoc_constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
 

--- a/tests/expectations/associated_in_body.c
+++ b/tests/expectations/associated_in_body.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/associated_in_body.compat.c
+++ b/tests/expectations/associated_in_body.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/bitflags.c
+++ b/tests/expectations/bitflags.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/bitflags.compat.c
+++ b/tests/expectations/bitflags.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/body.c
+++ b/tests/expectations/body.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef enum {
   Foo1,

--- a/tests/expectations/body.compat.c
+++ b/tests/expectations/body.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef enum {
   Foo1,

--- a/tests/expectations/both/alias.c
+++ b/tests/expectations/both/alias.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum Status {
   Ok,

--- a/tests/expectations/both/alias.compat.c
+++ b/tests/expectations/both/alias.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum Status
 #ifdef __cplusplus

--- a/tests/expectations/both/annotation.c
+++ b/tests/expectations/both/annotation.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum C {
   X = 2,

--- a/tests/expectations/both/annotation.compat.c
+++ b/tests/expectations/both/annotation.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum C
 #ifdef __cplusplus

--- a/tests/expectations/both/array.c
+++ b/tests/expectations/both/array.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef enum Foo_Tag {
   A,

--- a/tests/expectations/both/array.compat.c
+++ b/tests/expectations/both/array.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef enum Foo_Tag {
   A,

--- a/tests/expectations/both/asserted-cast.c
+++ b/tests/expectations/both/asserted-cast.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct I I;
 

--- a/tests/expectations/both/asserted-cast.compat.c
+++ b/tests/expectations/both/asserted-cast.compat.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct I I;
 

--- a/tests/expectations/both/assoc_const_conflict.c
+++ b/tests/expectations/both/assoc_const_conflict.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/both/assoc_const_conflict.compat.c
+++ b/tests/expectations/both/assoc_const_conflict.compat.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/both/assoc_constant.c
+++ b/tests/expectations/both/assoc_constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
 

--- a/tests/expectations/both/assoc_constant.compat.c
+++ b/tests/expectations/both/assoc_constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
 

--- a/tests/expectations/both/associated_in_body.c
+++ b/tests/expectations/both/associated_in_body.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/both/associated_in_body.compat.c
+++ b/tests/expectations/both/associated_in_body.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/both/bitflags.c
+++ b/tests/expectations/both/bitflags.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/both/bitflags.compat.c
+++ b/tests/expectations/both/bitflags.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/both/body.c
+++ b/tests/expectations/both/body.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef enum MyCLikeEnum {
   Foo1,

--- a/tests/expectations/both/body.compat.c
+++ b/tests/expectations/both/body.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef enum MyCLikeEnum {
   Foo1,

--- a/tests/expectations/both/cdecl.c
+++ b/tests/expectations/both/cdecl.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef void (*A)();
 

--- a/tests/expectations/both/cdecl.compat.c
+++ b/tests/expectations/both/cdecl.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef void (*A)();
 

--- a/tests/expectations/both/cfg-2.c
+++ b/tests/expectations/both/cfg-2.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(NOT_DEFINED)
 #define DEFAULT_X 8

--- a/tests/expectations/both/cfg-2.compat.c
+++ b/tests/expectations/both/cfg-2.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(NOT_DEFINED)
 #define DEFAULT_X 8

--- a/tests/expectations/both/cfg-field.c
+++ b/tests/expectations/both/cfg-field.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/both/cfg-field.compat.c
+++ b/tests/expectations/both/cfg-field.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/both/cfg.c
+++ b/tests/expectations/both/cfg.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
 enum BarType {

--- a/tests/expectations/both/cfg.compat.c
+++ b/tests/expectations/both/cfg.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
 enum BarType

--- a/tests/expectations/both/char.c
+++ b/tests/expectations/both/char.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <uchar.h>
+
+typedef struct Foo {
+  char32_t a;
+} Foo;
+
+void root(Foo a);

--- a/tests/expectations/both/char.compat.c
+++ b/tests/expectations/both/char.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <uchar.h>
+
+typedef struct Foo {
+  char32_t a;
+} Foo;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(Foo a);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/both/const_conflict.c
+++ b/tests/expectations/both/const_conflict.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/both/const_conflict.compat.c
+++ b/tests/expectations/both/const_conflict.compat.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/both/const_transparent.c
+++ b/tests/expectations/both/const_transparent.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef uint8_t Transparent;
 

--- a/tests/expectations/both/const_transparent.compat.c
+++ b/tests/expectations/both/const_transparent.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef uint8_t Transparent;
 

--- a/tests/expectations/both/constant.c
+++ b/tests/expectations/both/constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define DELIMITER ':'
 

--- a/tests/expectations/both/constant.compat.c
+++ b/tests/expectations/both/constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define DELIMITER ':'
 

--- a/tests/expectations/both/derive-eq.c
+++ b/tests/expectations/both/derive-eq.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
   bool a;

--- a/tests/expectations/both/derive-eq.compat.c
+++ b/tests/expectations/both/derive-eq.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
   bool a;

--- a/tests/expectations/both/destructor-and-copy-ctor.c
+++ b/tests/expectations/both/destructor-and-copy-ctor.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum FillRule {
   A,

--- a/tests/expectations/both/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/both/destructor-and-copy-ctor.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum FillRule
 #ifdef __cplusplus

--- a/tests/expectations/both/display_list.c
+++ b/tests/expectations/both/display_list.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Rect {
   float x;

--- a/tests/expectations/both/display_list.compat.c
+++ b/tests/expectations/both/display_list.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Rect {
   float x;

--- a/tests/expectations/both/docstyle_auto.c
+++ b/tests/expectations/both/docstyle_auto.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * The root of all evil.

--- a/tests/expectations/both/docstyle_auto.compat.c
+++ b/tests/expectations/both/docstyle_auto.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/both/docstyle_c99.c
+++ b/tests/expectations/both/docstyle_c99.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 // The root of all evil.
 void root(void);

--- a/tests/expectations/both/docstyle_c99.compat.c
+++ b/tests/expectations/both/docstyle_c99.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/both/docstyle_doxy.c
+++ b/tests/expectations/both/docstyle_doxy.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * The root of all evil.

--- a/tests/expectations/both/docstyle_doxy.compat.c
+++ b/tests/expectations/both/docstyle_doxy.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/both/documentation.c
+++ b/tests/expectations/both/documentation.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * The root of all evil.

--- a/tests/expectations/both/documentation.compat.c
+++ b/tests/expectations/both/documentation.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/both/enum.c
+++ b/tests/expectations/both/enum.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum A {
   a1 = 0,

--- a/tests/expectations/both/enum.compat.c
+++ b/tests/expectations/both/enum.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum A
 #ifdef __cplusplus

--- a/tests/expectations/both/euclid.c
+++ b/tests/expectations/both/euclid.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct TypedLength_f32__UnknownUnit {
   float _0;

--- a/tests/expectations/both/euclid.compat.c
+++ b/tests/expectations/both/euclid.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct TypedLength_f32__UnknownUnit {
   float _0;

--- a/tests/expectations/both/expand.c
+++ b/tests/expectations/both/expand.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
 

--- a/tests/expectations/both/expand.compat.c
+++ b/tests/expectations/both/expand.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
 

--- a/tests/expectations/both/expand_default_features.c
+++ b/tests/expectations/both/expand_default_features.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
 

--- a/tests/expectations/both/expand_default_features.compat.c
+++ b/tests/expectations/both/expand_default_features.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
 

--- a/tests/expectations/both/expand_dep.c
+++ b/tests/expectations/both/expand_dep.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct dep_struct {
   uint32_t x;

--- a/tests/expectations/both/expand_dep.compat.c
+++ b/tests/expectations/both/expand_dep.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct dep_struct {
   uint32_t x;

--- a/tests/expectations/both/expand_features.c
+++ b/tests/expectations/both/expand_features.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
 

--- a/tests/expectations/both/expand_features.compat.c
+++ b/tests/expectations/both/expand_features.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
 

--- a/tests/expectations/both/expand_no_default_features.c
+++ b/tests/expectations/both/expand_no_default_features.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
 

--- a/tests/expectations/both/expand_no_default_features.compat.c
+++ b/tests/expectations/both/expand_no_default_features.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
 

--- a/tests/expectations/both/extern-2.c
+++ b/tests/expectations/both/extern-2.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 void first(void);
 

--- a/tests/expectations/both/extern-2.compat.c
+++ b/tests/expectations/both/extern-2.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/both/extern.c
+++ b/tests/expectations/both/extern.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Normal {
   int32_t x;

--- a/tests/expectations/both/extern.compat.c
+++ b/tests/expectations/both/extern.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Normal {
   int32_t x;

--- a/tests/expectations/both/external_workspace_child.c
+++ b/tests/expectations/both/external_workspace_child.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct ExtType {
   uint32_t data;

--- a/tests/expectations/both/external_workspace_child.compat.c
+++ b/tests/expectations/both/external_workspace_child.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct ExtType {
   uint32_t data;

--- a/tests/expectations/both/fns.c
+++ b/tests/expectations/both/fns.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Fns {
   void (*noArgs)();

--- a/tests/expectations/both/fns.compat.c
+++ b/tests/expectations/both/fns.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Fns {
   void (*noArgs)();

--- a/tests/expectations/both/global_attr.c
+++ b/tests/expectations/both/global_attr.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/both/global_attr.compat.c
+++ b/tests/expectations/both/global_attr.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/both/include.c
+++ b/tests/expectations/both/include.c
@@ -2,4 +2,5 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 #include <math.h>

--- a/tests/expectations/both/include.compat.c
+++ b/tests/expectations/both/include.compat.c
@@ -2,4 +2,5 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 #include <math.h>

--- a/tests/expectations/both/include_item.c
+++ b/tests/expectations/both/include_item.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct A {
   int32_t x;

--- a/tests/expectations/both/include_item.compat.c
+++ b/tests/expectations/both/include_item.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct A {
   int32_t x;

--- a/tests/expectations/both/inner_mod.c
+++ b/tests/expectations/both/inner_mod.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
   float x;

--- a/tests/expectations/both/inner_mod.compat.c
+++ b/tests/expectations/both/inner_mod.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo {
   float x;

--- a/tests/expectations/both/item_types.c
+++ b/tests/expectations/both/item_types.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum OnlyThisShouldBeGenerated {
   Foo,

--- a/tests/expectations/both/item_types.compat.c
+++ b/tests/expectations/both/item_types.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum OnlyThisShouldBeGenerated
 #ifdef __cplusplus

--- a/tests/expectations/both/item_types_renamed.c
+++ b/tests/expectations/both/item_types_renamed.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum StyleOnlyThisShouldBeGenerated {
   Foo,

--- a/tests/expectations/both/item_types_renamed.compat.c
+++ b/tests/expectations/both/item_types_renamed.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum StyleOnlyThisShouldBeGenerated
 #ifdef __cplusplus

--- a/tests/expectations/both/lifetime_arg.c
+++ b/tests/expectations/both/lifetime_arg.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct A {
   const int32_t *data;

--- a/tests/expectations/both/lifetime_arg.compat.c
+++ b/tests/expectations/both/lifetime_arg.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct A {
   const int32_t *data;

--- a/tests/expectations/both/mod_attr.c
+++ b/tests/expectations/both/mod_attr.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(BAR)
 #define BAR 2

--- a/tests/expectations/both/mod_attr.compat.c
+++ b/tests/expectations/both/mod_attr.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(BAR)
 #define BAR 2

--- a/tests/expectations/both/mod_path.c
+++ b/tests/expectations/both/mod_path.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXPORT_ME_TOO 42
 

--- a/tests/expectations/both/mod_path.compat.c
+++ b/tests/expectations/both/mod_path.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXPORT_ME_TOO 42
 

--- a/tests/expectations/both/monomorph-1.c
+++ b/tests/expectations/both/monomorph-1.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar_Bar_f32 Bar_Bar_f32;
 

--- a/tests/expectations/both/monomorph-1.compat.c
+++ b/tests/expectations/both/monomorph-1.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar_Bar_f32 Bar_Bar_f32;
 

--- a/tests/expectations/both/monomorph-2.c
+++ b/tests/expectations/both/monomorph-2.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct A A;
 

--- a/tests/expectations/both/monomorph-2.compat.c
+++ b/tests/expectations/both/monomorph-2.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct A A;
 

--- a/tests/expectations/both/monomorph-3.c
+++ b/tests/expectations/both/monomorph-3.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar_Bar_f32 Bar_Bar_f32;
 

--- a/tests/expectations/both/monomorph-3.compat.c
+++ b/tests/expectations/both/monomorph-3.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar_Bar_f32 Bar_Bar_f32;
 

--- a/tests/expectations/both/must-use.c
+++ b/tests/expectations/both/must-use.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum MaybeOwnedPtr_i32_Tag {
   Owned_i32,

--- a/tests/expectations/both/must-use.compat.c
+++ b/tests/expectations/both/must-use.compat.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum MaybeOwnedPtr_i32_Tag
 #ifdef __cplusplus

--- a/tests/expectations/both/namespace_constant.c
+++ b/tests/expectations/both/namespace_constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define FOO 10
 

--- a/tests/expectations/both/namespace_constant.compat.c
+++ b/tests/expectations/both/namespace_constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 namespace constants {

--- a/tests/expectations/both/namespaces_constant.c
+++ b/tests/expectations/both/namespaces_constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define FOO 10
 

--- a/tests/expectations/both/namespaces_constant.compat.c
+++ b/tests/expectations/both/namespaces_constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 namespace constants {

--- a/tests/expectations/both/nested_import.c
+++ b/tests/expectations/both/nested_import.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/both/nested_import.compat.c
+++ b/tests/expectations/both/nested_import.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/both/nonnull.c
+++ b/tests/expectations/both/nonnull.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/both/nonnull.compat.c
+++ b/tests/expectations/both/nonnull.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/both/prefix.c
+++ b/tests/expectations/both/prefix.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define PREFIX_LEN 42
 

--- a/tests/expectations/both/prefix.compat.c
+++ b/tests/expectations/both/prefix.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define PREFIX_LEN 42
 

--- a/tests/expectations/both/prefixed_struct_literal.c
+++ b/tests/expectations/both/prefixed_struct_literal.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct PREFIXFoo {
   int32_t a;

--- a/tests/expectations/both/prefixed_struct_literal.compat.c
+++ b/tests/expectations/both/prefixed_struct_literal.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct PREFIXFoo {
   int32_t a;

--- a/tests/expectations/both/prefixed_struct_literal_deep.c
+++ b/tests/expectations/both/prefixed_struct_literal_deep.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct PREFIXBar {
   int32_t a;

--- a/tests/expectations/both/prefixed_struct_literal_deep.compat.c
+++ b/tests/expectations/both/prefixed_struct_literal_deep.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct PREFIXBar {
   int32_t a;

--- a/tests/expectations/both/rename-crate.c
+++ b/tests/expectations/both/rename-crate.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if !defined(DEFINE_FREEBSD)
 typedef struct NoExternTy {

--- a/tests/expectations/both/rename-crate.compat.c
+++ b/tests/expectations/both/rename-crate.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if !defined(DEFINE_FREEBSD)
 typedef struct NoExternTy {

--- a/tests/expectations/both/rename.c
+++ b/tests/expectations/both/rename.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define C_H 10
 

--- a/tests/expectations/both/rename.compat.c
+++ b/tests/expectations/both/rename.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define C_H 10
 

--- a/tests/expectations/both/renaming-overrides-prefixing.c
+++ b/tests/expectations/both/renaming-overrides-prefixing.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct StyleA StyleA;
 

--- a/tests/expectations/both/renaming-overrides-prefixing.compat.c
+++ b/tests/expectations/both/renaming-overrides-prefixing.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct StyleA StyleA;
 

--- a/tests/expectations/both/reserved.c
+++ b/tests/expectations/both/reserved.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct A {
   int32_t namespace_;

--- a/tests/expectations/both/reserved.compat.c
+++ b/tests/expectations/both/reserved.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct A {
   int32_t namespace_;

--- a/tests/expectations/both/simplify-option-ptr.c
+++ b/tests/expectations/both/simplify-option-ptr.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/both/simplify-option-ptr.compat.c
+++ b/tests/expectations/both/simplify-option-ptr.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/both/static.c
+++ b/tests/expectations/both/static.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar Bar;
 

--- a/tests/expectations/both/static.compat.c
+++ b/tests/expectations/both/static.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar Bar;
 

--- a/tests/expectations/both/std_lib.c
+++ b/tests/expectations/both/std_lib.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Option_i32 Option_i32;
 

--- a/tests/expectations/both/std_lib.compat.c
+++ b/tests/expectations/both/std_lib.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Option_i32 Option_i32;
 

--- a/tests/expectations/both/struct.c
+++ b/tests/expectations/both/struct.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/both/struct.compat.c
+++ b/tests/expectations/both/struct.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/both/struct_literal.c
+++ b/tests/expectations/both/struct_literal.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar Bar;
 

--- a/tests/expectations/both/struct_literal.compat.c
+++ b/tests/expectations/both/struct_literal.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar Bar;
 

--- a/tests/expectations/both/struct_literal_order.c
+++ b/tests/expectations/both/struct_literal_order.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct ABC {
   float a;

--- a/tests/expectations/both/struct_literal_order.compat.c
+++ b/tests/expectations/both/struct_literal_order.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct ABC {
   float a;

--- a/tests/expectations/both/style-crash.c
+++ b/tests/expectations/both/style-crash.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/both/style-crash.compat.c
+++ b/tests/expectations/both/style-crash.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/both/transform-op.c
+++ b/tests/expectations/both/transform-op.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct StylePoint_i32 {
   int32_t x;

--- a/tests/expectations/both/transform-op.compat.c
+++ b/tests/expectations/both/transform-op.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct StylePoint_i32 {
   int32_t x;

--- a/tests/expectations/both/transparent.c
+++ b/tests/expectations/both/transparent.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct DummyStruct DummyStruct;
 

--- a/tests/expectations/both/transparent.compat.c
+++ b/tests/expectations/both/transparent.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct DummyStruct DummyStruct;
 

--- a/tests/expectations/both/typedef.c
+++ b/tests/expectations/both/typedef.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo_i32__i32 {
   int32_t x;

--- a/tests/expectations/both/typedef.compat.c
+++ b/tests/expectations/both/typedef.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Foo_i32__i32 {
   int32_t x;

--- a/tests/expectations/both/union.c
+++ b/tests/expectations/both/union.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/both/union.compat.c
+++ b/tests/expectations/both/union.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/both/using_namespaces.c
+++ b/tests/expectations/both/using_namespaces.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 void root(void);

--- a/tests/expectations/both/using_namespaces.compat.c
+++ b/tests/expectations/both/using_namespaces.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 namespace root {

--- a/tests/expectations/both/va_list.c
+++ b/tests/expectations/both/va_list.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 int32_t va_list_test(va_list ap);

--- a/tests/expectations/both/va_list.compat.c
+++ b/tests/expectations/both/va_list.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/both/workspace.c
+++ b/tests/expectations/both/workspace.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXT_CONST 0
 

--- a/tests/expectations/both/workspace.compat.c
+++ b/tests/expectations/both/workspace.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXT_CONST 0
 

--- a/tests/expectations/cdecl.c
+++ b/tests/expectations/cdecl.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef void (*A)();
 

--- a/tests/expectations/cdecl.compat.c
+++ b/tests/expectations/cdecl.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef void (*A)();
 

--- a/tests/expectations/cfg-2.c
+++ b/tests/expectations/cfg-2.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(NOT_DEFINED)
 #define DEFAULT_X 8

--- a/tests/expectations/cfg-2.compat.c
+++ b/tests/expectations/cfg-2.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(NOT_DEFINED)
 #define DEFAULT_X 8

--- a/tests/expectations/cfg-field.c
+++ b/tests/expectations/cfg-field.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/cfg-field.compat.c
+++ b/tests/expectations/cfg-field.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/cfg.c
+++ b/tests/expectations/cfg.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
 enum BarType {

--- a/tests/expectations/cfg.compat.c
+++ b/tests/expectations/cfg.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
 enum BarType

--- a/tests/expectations/char.c
+++ b/tests/expectations/char.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <uchar.h>
+
+typedef struct {
+  char32_t a;
+} Foo;
+
+void root(Foo a);

--- a/tests/expectations/char.compat.c
+++ b/tests/expectations/char.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <uchar.h>
+
+typedef struct {
+  char32_t a;
+} Foo;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(Foo a);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/char.cpp
+++ b/tests/expectations/char.cpp
@@ -1,0 +1,14 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+
+struct Foo {
+  char32_t a;
+};
+
+extern "C" {
+
+void root(Foo a);
+
+} // extern "C"

--- a/tests/expectations/const_conflict.c
+++ b/tests/expectations/const_conflict.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/const_conflict.compat.c
+++ b/tests/expectations/const_conflict.compat.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/const_transparent.c
+++ b/tests/expectations/const_transparent.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef uint8_t Transparent;
 

--- a/tests/expectations/const_transparent.compat.c
+++ b/tests/expectations/const_transparent.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef uint8_t Transparent;
 

--- a/tests/expectations/constant.c
+++ b/tests/expectations/constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define DELIMITER ':'
 

--- a/tests/expectations/constant.compat.c
+++ b/tests/expectations/constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define DELIMITER ':'
 

--- a/tests/expectations/derive-eq.c
+++ b/tests/expectations/derive-eq.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   bool a;

--- a/tests/expectations/derive-eq.compat.c
+++ b/tests/expectations/derive-eq.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   bool a;

--- a/tests/expectations/destructor-and-copy-ctor.c
+++ b/tests/expectations/destructor-and-copy-ctor.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum FillRule {
   A,

--- a/tests/expectations/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/destructor-and-copy-ctor.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum FillRule
 #ifdef __cplusplus

--- a/tests/expectations/display_list.c
+++ b/tests/expectations/display_list.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   float x;

--- a/tests/expectations/display_list.compat.c
+++ b/tests/expectations/display_list.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   float x;

--- a/tests/expectations/docstyle_auto.c
+++ b/tests/expectations/docstyle_auto.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * The root of all evil.

--- a/tests/expectations/docstyle_auto.compat.c
+++ b/tests/expectations/docstyle_auto.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/docstyle_c99.c
+++ b/tests/expectations/docstyle_c99.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 // The root of all evil.
 void root(void);

--- a/tests/expectations/docstyle_c99.compat.c
+++ b/tests/expectations/docstyle_c99.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/docstyle_doxy.c
+++ b/tests/expectations/docstyle_doxy.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * The root of all evil.

--- a/tests/expectations/docstyle_doxy.compat.c
+++ b/tests/expectations/docstyle_doxy.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/documentation.c
+++ b/tests/expectations/documentation.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * The root of all evil.

--- a/tests/expectations/documentation.compat.c
+++ b/tests/expectations/documentation.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/enum.c
+++ b/tests/expectations/enum.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum A {
   a1 = 0,

--- a/tests/expectations/enum.compat.c
+++ b/tests/expectations/enum.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum A
 #ifdef __cplusplus

--- a/tests/expectations/euclid.c
+++ b/tests/expectations/euclid.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   float _0;

--- a/tests/expectations/euclid.compat.c
+++ b/tests/expectations/euclid.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   float _0;

--- a/tests/expectations/expand.c
+++ b/tests/expectations/expand.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
 

--- a/tests/expectations/expand.compat.c
+++ b/tests/expectations/expand.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
 

--- a/tests/expectations/expand_default_features.c
+++ b/tests/expectations/expand_default_features.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
 

--- a/tests/expectations/expand_default_features.compat.c
+++ b/tests/expectations/expand_default_features.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
 

--- a/tests/expectations/expand_dep.c
+++ b/tests/expectations/expand_dep.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   uint32_t x;

--- a/tests/expectations/expand_dep.compat.c
+++ b/tests/expectations/expand_dep.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   uint32_t x;

--- a/tests/expectations/expand_features.c
+++ b/tests/expectations/expand_features.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
 

--- a/tests/expectations/expand_features.compat.c
+++ b/tests/expectations/expand_features.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
 

--- a/tests/expectations/expand_no_default_features.c
+++ b/tests/expectations/expand_no_default_features.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
 

--- a/tests/expectations/expand_no_default_features.compat.c
+++ b/tests/expectations/expand_no_default_features.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
 

--- a/tests/expectations/extern-2.c
+++ b/tests/expectations/extern-2.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 void first(void);
 

--- a/tests/expectations/extern-2.compat.c
+++ b/tests/expectations/extern-2.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/extern.c
+++ b/tests/expectations/extern.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t x;

--- a/tests/expectations/extern.compat.c
+++ b/tests/expectations/extern.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t x;

--- a/tests/expectations/external_workspace_child.c
+++ b/tests/expectations/external_workspace_child.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   uint32_t data;

--- a/tests/expectations/external_workspace_child.compat.c
+++ b/tests/expectations/external_workspace_child.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   uint32_t data;

--- a/tests/expectations/fns.c
+++ b/tests/expectations/fns.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   void (*noArgs)();

--- a/tests/expectations/fns.compat.c
+++ b/tests/expectations/fns.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   void (*noArgs)();

--- a/tests/expectations/global_attr.c
+++ b/tests/expectations/global_attr.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/global_attr.compat.c
+++ b/tests/expectations/global_attr.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/include.c
+++ b/tests/expectations/include.c
@@ -2,4 +2,5 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 #include <math.h>

--- a/tests/expectations/include.compat.c
+++ b/tests/expectations/include.compat.c
@@ -2,4 +2,5 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 #include <math.h>

--- a/tests/expectations/include_item.c
+++ b/tests/expectations/include_item.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t x;

--- a/tests/expectations/include_item.compat.c
+++ b/tests/expectations/include_item.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t x;

--- a/tests/expectations/inner_mod.c
+++ b/tests/expectations/inner_mod.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   float x;

--- a/tests/expectations/inner_mod.compat.c
+++ b/tests/expectations/inner_mod.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   float x;

--- a/tests/expectations/item_types.c
+++ b/tests/expectations/item_types.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum OnlyThisShouldBeGenerated {
   Foo,

--- a/tests/expectations/item_types.compat.c
+++ b/tests/expectations/item_types.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum OnlyThisShouldBeGenerated
 #ifdef __cplusplus

--- a/tests/expectations/item_types_renamed.c
+++ b/tests/expectations/item_types_renamed.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum StyleOnlyThisShouldBeGenerated {
   Foo,

--- a/tests/expectations/item_types_renamed.compat.c
+++ b/tests/expectations/item_types_renamed.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum StyleOnlyThisShouldBeGenerated
 #ifdef __cplusplus

--- a/tests/expectations/lifetime_arg.c
+++ b/tests/expectations/lifetime_arg.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   const int32_t *data;

--- a/tests/expectations/lifetime_arg.compat.c
+++ b/tests/expectations/lifetime_arg.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   const int32_t *data;

--- a/tests/expectations/mod_attr.c
+++ b/tests/expectations/mod_attr.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(BAR)
 #define BAR 2

--- a/tests/expectations/mod_attr.compat.c
+++ b/tests/expectations/mod_attr.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(BAR)
 #define BAR 2

--- a/tests/expectations/mod_path.c
+++ b/tests/expectations/mod_path.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXPORT_ME_TOO 42
 

--- a/tests/expectations/mod_path.compat.c
+++ b/tests/expectations/mod_path.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXPORT_ME_TOO 42
 

--- a/tests/expectations/monomorph-1.c
+++ b/tests/expectations/monomorph-1.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar_Bar_f32 Bar_Bar_f32;
 

--- a/tests/expectations/monomorph-1.compat.c
+++ b/tests/expectations/monomorph-1.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar_Bar_f32 Bar_Bar_f32;
 

--- a/tests/expectations/monomorph-2.c
+++ b/tests/expectations/monomorph-2.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct A A;
 

--- a/tests/expectations/monomorph-2.compat.c
+++ b/tests/expectations/monomorph-2.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct A A;
 

--- a/tests/expectations/monomorph-3.c
+++ b/tests/expectations/monomorph-3.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar_Bar_f32 Bar_Bar_f32;
 

--- a/tests/expectations/monomorph-3.compat.c
+++ b/tests/expectations/monomorph-3.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar_Bar_f32 Bar_Bar_f32;
 

--- a/tests/expectations/must-use.c
+++ b/tests/expectations/must-use.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum MaybeOwnedPtr_i32_Tag {
   Owned_i32,

--- a/tests/expectations/must-use.compat.c
+++ b/tests/expectations/must-use.compat.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum MaybeOwnedPtr_i32_Tag
 #ifdef __cplusplus

--- a/tests/expectations/namespace_constant.c
+++ b/tests/expectations/namespace_constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define FOO 10
 

--- a/tests/expectations/namespace_constant.compat.c
+++ b/tests/expectations/namespace_constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 namespace constants {

--- a/tests/expectations/namespaces_constant.c
+++ b/tests/expectations/namespaces_constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define FOO 10
 

--- a/tests/expectations/namespaces_constant.compat.c
+++ b/tests/expectations/namespaces_constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 namespace constants {

--- a/tests/expectations/nested_import.c
+++ b/tests/expectations/nested_import.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/nested_import.compat.c
+++ b/tests/expectations/nested_import.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/nonnull.c
+++ b/tests/expectations/nonnull.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/nonnull.compat.c
+++ b/tests/expectations/nonnull.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/prefix.c
+++ b/tests/expectations/prefix.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define PREFIX_LEN 42
 

--- a/tests/expectations/prefix.compat.c
+++ b/tests/expectations/prefix.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define PREFIX_LEN 42
 

--- a/tests/expectations/prefixed_struct_literal.c
+++ b/tests/expectations/prefixed_struct_literal.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t a;

--- a/tests/expectations/prefixed_struct_literal.compat.c
+++ b/tests/expectations/prefixed_struct_literal.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t a;

--- a/tests/expectations/prefixed_struct_literal_deep.c
+++ b/tests/expectations/prefixed_struct_literal_deep.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t a;

--- a/tests/expectations/prefixed_struct_literal_deep.compat.c
+++ b/tests/expectations/prefixed_struct_literal_deep.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t a;

--- a/tests/expectations/rename-crate.c
+++ b/tests/expectations/rename-crate.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if !defined(DEFINE_FREEBSD)
 typedef struct {

--- a/tests/expectations/rename-crate.compat.c
+++ b/tests/expectations/rename-crate.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if !defined(DEFINE_FREEBSD)
 typedef struct {

--- a/tests/expectations/rename.c
+++ b/tests/expectations/rename.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define C_H 10
 

--- a/tests/expectations/rename.compat.c
+++ b/tests/expectations/rename.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define C_H 10
 

--- a/tests/expectations/renaming-overrides-prefixing.c
+++ b/tests/expectations/renaming-overrides-prefixing.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct StyleA StyleA;
 

--- a/tests/expectations/renaming-overrides-prefixing.compat.c
+++ b/tests/expectations/renaming-overrides-prefixing.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct StyleA StyleA;
 

--- a/tests/expectations/reserved.c
+++ b/tests/expectations/reserved.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t namespace_;

--- a/tests/expectations/reserved.compat.c
+++ b/tests/expectations/reserved.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t namespace_;

--- a/tests/expectations/simplify-option-ptr.c
+++ b/tests/expectations/simplify-option-ptr.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/simplify-option-ptr.compat.c
+++ b/tests/expectations/simplify-option-ptr.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/static.c
+++ b/tests/expectations/static.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar Bar;
 

--- a/tests/expectations/static.compat.c
+++ b/tests/expectations/static.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar Bar;
 

--- a/tests/expectations/std_lib.c
+++ b/tests/expectations/std_lib.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Option_i32 Option_i32;
 

--- a/tests/expectations/std_lib.compat.c
+++ b/tests/expectations/std_lib.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Option_i32 Option_i32;
 

--- a/tests/expectations/struct.c
+++ b/tests/expectations/struct.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/struct.compat.c
+++ b/tests/expectations/struct.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/struct_literal.c
+++ b/tests/expectations/struct_literal.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar Bar;
 

--- a/tests/expectations/struct_literal.compat.c
+++ b/tests/expectations/struct_literal.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Bar Bar;
 

--- a/tests/expectations/struct_literal_order.c
+++ b/tests/expectations/struct_literal_order.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   float a;

--- a/tests/expectations/struct_literal_order.compat.c
+++ b/tests/expectations/struct_literal_order.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   float a;

--- a/tests/expectations/style-crash.c
+++ b/tests/expectations/style-crash.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/style-crash.compat.c
+++ b/tests/expectations/style-crash.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/tag/alias.c
+++ b/tests/expectations/tag/alias.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum Status {
   Ok,

--- a/tests/expectations/tag/alias.compat.c
+++ b/tests/expectations/tag/alias.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum Status
 #ifdef __cplusplus

--- a/tests/expectations/tag/annotation.c
+++ b/tests/expectations/tag/annotation.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum C {
   X = 2,

--- a/tests/expectations/tag/annotation.compat.c
+++ b/tests/expectations/tag/annotation.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum C
 #ifdef __cplusplus

--- a/tests/expectations/tag/array.c
+++ b/tests/expectations/tag/array.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum Foo_Tag {
   A,

--- a/tests/expectations/tag/array.compat.c
+++ b/tests/expectations/tag/array.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum Foo_Tag {
   A,

--- a/tests/expectations/tag/asserted-cast.c
+++ b/tests/expectations/tag/asserted-cast.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct I;
 

--- a/tests/expectations/tag/asserted-cast.compat.c
+++ b/tests/expectations/tag/asserted-cast.compat.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct I;
 

--- a/tests/expectations/tag/assoc_const_conflict.c
+++ b/tests/expectations/tag/assoc_const_conflict.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/tag/assoc_const_conflict.compat.c
+++ b/tests/expectations/tag/assoc_const_conflict.compat.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/tag/assoc_constant.c
+++ b/tests/expectations/tag/assoc_constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
 

--- a/tests/expectations/tag/assoc_constant.compat.c
+++ b/tests/expectations/tag/assoc_constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
 

--- a/tests/expectations/tag/associated_in_body.c
+++ b/tests/expectations/tag/associated_in_body.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/tag/associated_in_body.compat.c
+++ b/tests/expectations/tag/associated_in_body.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/tag/bitflags.c
+++ b/tests/expectations/tag/bitflags.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/tag/bitflags.compat.c
+++ b/tests/expectations/tag/bitflags.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * Constants shared by multiple CSS Box Alignment properties

--- a/tests/expectations/tag/body.c
+++ b/tests/expectations/tag/body.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum MyCLikeEnum {
   Foo1,

--- a/tests/expectations/tag/body.compat.c
+++ b/tests/expectations/tag/body.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum MyCLikeEnum {
   Foo1,

--- a/tests/expectations/tag/cdecl.c
+++ b/tests/expectations/tag/cdecl.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef void (*A)();
 

--- a/tests/expectations/tag/cdecl.compat.c
+++ b/tests/expectations/tag/cdecl.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef void (*A)();
 

--- a/tests/expectations/tag/cfg-2.c
+++ b/tests/expectations/tag/cfg-2.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(NOT_DEFINED)
 #define DEFAULT_X 8

--- a/tests/expectations/tag/cfg-2.compat.c
+++ b/tests/expectations/tag/cfg-2.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(NOT_DEFINED)
 #define DEFAULT_X 8

--- a/tests/expectations/tag/cfg-field.c
+++ b/tests/expectations/tag/cfg-field.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/tag/cfg-field.compat.c
+++ b/tests/expectations/tag/cfg-field.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/tag/cfg.c
+++ b/tests/expectations/tag/cfg.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
 enum BarType {

--- a/tests/expectations/tag/cfg.compat.c
+++ b/tests/expectations/tag/cfg.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
 enum BarType

--- a/tests/expectations/tag/char.c
+++ b/tests/expectations/tag/char.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <uchar.h>
+
+struct Foo {
+  char32_t a;
+};
+
+void root(struct Foo a);

--- a/tests/expectations/tag/char.compat.c
+++ b/tests/expectations/tag/char.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <uchar.h>
+
+struct Foo {
+  char32_t a;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(struct Foo a);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/tag/const_conflict.c
+++ b/tests/expectations/tag/const_conflict.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/tag/const_conflict.compat.c
+++ b/tests/expectations/tag/const_conflict.compat.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define Foo_FOO 42

--- a/tests/expectations/tag/const_transparent.c
+++ b/tests/expectations/tag/const_transparent.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef uint8_t Transparent;
 

--- a/tests/expectations/tag/const_transparent.compat.c
+++ b/tests/expectations/tag/const_transparent.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef uint8_t Transparent;
 

--- a/tests/expectations/tag/constant.c
+++ b/tests/expectations/tag/constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define DELIMITER ':'
 

--- a/tests/expectations/tag/constant.compat.c
+++ b/tests/expectations/tag/constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define DELIMITER ':'
 

--- a/tests/expectations/tag/derive-eq.c
+++ b/tests/expectations/tag/derive-eq.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
   bool a;

--- a/tests/expectations/tag/derive-eq.compat.c
+++ b/tests/expectations/tag/derive-eq.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
   bool a;

--- a/tests/expectations/tag/destructor-and-copy-ctor.c
+++ b/tests/expectations/tag/destructor-and-copy-ctor.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum FillRule {
   A,

--- a/tests/expectations/tag/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/tag/destructor-and-copy-ctor.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum FillRule
 #ifdef __cplusplus

--- a/tests/expectations/tag/display_list.c
+++ b/tests/expectations/tag/display_list.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Rect {
   float x;

--- a/tests/expectations/tag/display_list.compat.c
+++ b/tests/expectations/tag/display_list.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Rect {
   float x;

--- a/tests/expectations/tag/docstyle_auto.c
+++ b/tests/expectations/tag/docstyle_auto.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * The root of all evil.

--- a/tests/expectations/tag/docstyle_auto.compat.c
+++ b/tests/expectations/tag/docstyle_auto.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/tag/docstyle_c99.c
+++ b/tests/expectations/tag/docstyle_c99.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 // The root of all evil.
 void root(void);

--- a/tests/expectations/tag/docstyle_c99.compat.c
+++ b/tests/expectations/tag/docstyle_c99.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/tag/docstyle_doxy.c
+++ b/tests/expectations/tag/docstyle_doxy.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * The root of all evil.

--- a/tests/expectations/tag/docstyle_doxy.compat.c
+++ b/tests/expectations/tag/docstyle_doxy.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/tag/documentation.c
+++ b/tests/expectations/tag/documentation.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 /**
  * The root of all evil.

--- a/tests/expectations/tag/documentation.compat.c
+++ b/tests/expectations/tag/documentation.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/tag/enum.c
+++ b/tests/expectations/tag/enum.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum A {
   a1 = 0,

--- a/tests/expectations/tag/enum.compat.c
+++ b/tests/expectations/tag/enum.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum A
 #ifdef __cplusplus

--- a/tests/expectations/tag/euclid.c
+++ b/tests/expectations/tag/euclid.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct TypedLength_f32__UnknownUnit {
   float _0;

--- a/tests/expectations/tag/euclid.compat.c
+++ b/tests/expectations/tag/euclid.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct TypedLength_f32__UnknownUnit {
   float _0;

--- a/tests/expectations/tag/expand.c
+++ b/tests/expectations/tag/expand.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
 

--- a/tests/expectations/tag/expand.compat.c
+++ b/tests/expectations/tag/expand.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
 

--- a/tests/expectations/tag/expand_default_features.c
+++ b/tests/expectations/tag/expand_default_features.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
 

--- a/tests/expectations/tag/expand_default_features.compat.c
+++ b/tests/expectations/tag/expand_default_features.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
 

--- a/tests/expectations/tag/expand_dep.c
+++ b/tests/expectations/tag/expand_dep.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct dep_struct {
   uint32_t x;

--- a/tests/expectations/tag/expand_dep.compat.c
+++ b/tests/expectations/tag/expand_dep.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct dep_struct {
   uint32_t x;

--- a/tests/expectations/tag/expand_features.c
+++ b/tests/expectations/tag/expand_features.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
 

--- a/tests/expectations/tag/expand_features.compat.c
+++ b/tests/expectations/tag/expand_features.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
 

--- a/tests/expectations/tag/expand_no_default_features.c
+++ b/tests/expectations/tag/expand_no_default_features.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
 

--- a/tests/expectations/tag/expand_no_default_features.compat.c
+++ b/tests/expectations/tag/expand_no_default_features.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
 

--- a/tests/expectations/tag/extern-2.c
+++ b/tests/expectations/tag/extern-2.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 void first(void);
 

--- a/tests/expectations/tag/extern-2.compat.c
+++ b/tests/expectations/tag/extern-2.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/tag/extern.c
+++ b/tests/expectations/tag/extern.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Normal {
   int32_t x;

--- a/tests/expectations/tag/extern.compat.c
+++ b/tests/expectations/tag/extern.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Normal {
   int32_t x;

--- a/tests/expectations/tag/external_workspace_child.c
+++ b/tests/expectations/tag/external_workspace_child.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct ExtType {
   uint32_t data;

--- a/tests/expectations/tag/external_workspace_child.compat.c
+++ b/tests/expectations/tag/external_workspace_child.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct ExtType {
   uint32_t data;

--- a/tests/expectations/tag/fns.c
+++ b/tests/expectations/tag/fns.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Fns {
   void (*noArgs)();

--- a/tests/expectations/tag/fns.compat.c
+++ b/tests/expectations/tag/fns.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Fns {
   void (*noArgs)();

--- a/tests/expectations/tag/global_attr.c
+++ b/tests/expectations/tag/global_attr.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/tag/global_attr.compat.c
+++ b/tests/expectations/tag/global_attr.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/tag/include.c
+++ b/tests/expectations/tag/include.c
@@ -2,4 +2,5 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 #include <math.h>

--- a/tests/expectations/tag/include.compat.c
+++ b/tests/expectations/tag/include.compat.c
@@ -2,4 +2,5 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 #include <math.h>

--- a/tests/expectations/tag/include_item.c
+++ b/tests/expectations/tag/include_item.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct A {
   int32_t x;

--- a/tests/expectations/tag/include_item.compat.c
+++ b/tests/expectations/tag/include_item.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct A {
   int32_t x;

--- a/tests/expectations/tag/inner_mod.c
+++ b/tests/expectations/tag/inner_mod.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
   float x;

--- a/tests/expectations/tag/inner_mod.compat.c
+++ b/tests/expectations/tag/inner_mod.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo {
   float x;

--- a/tests/expectations/tag/item_types.c
+++ b/tests/expectations/tag/item_types.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum OnlyThisShouldBeGenerated {
   Foo,

--- a/tests/expectations/tag/item_types.compat.c
+++ b/tests/expectations/tag/item_types.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum OnlyThisShouldBeGenerated
 #ifdef __cplusplus

--- a/tests/expectations/tag/item_types_renamed.c
+++ b/tests/expectations/tag/item_types_renamed.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum StyleOnlyThisShouldBeGenerated {
   Foo,

--- a/tests/expectations/tag/item_types_renamed.compat.c
+++ b/tests/expectations/tag/item_types_renamed.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum StyleOnlyThisShouldBeGenerated
 #ifdef __cplusplus

--- a/tests/expectations/tag/lifetime_arg.c
+++ b/tests/expectations/tag/lifetime_arg.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct A {
   const int32_t *data;

--- a/tests/expectations/tag/lifetime_arg.compat.c
+++ b/tests/expectations/tag/lifetime_arg.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct A {
   const int32_t *data;

--- a/tests/expectations/tag/mod_attr.c
+++ b/tests/expectations/tag/mod_attr.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(BAR)
 #define BAR 2

--- a/tests/expectations/tag/mod_attr.compat.c
+++ b/tests/expectations/tag/mod_attr.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if defined(BAR)
 #define BAR 2

--- a/tests/expectations/tag/mod_path.c
+++ b/tests/expectations/tag/mod_path.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXPORT_ME_TOO 42
 

--- a/tests/expectations/tag/mod_path.compat.c
+++ b/tests/expectations/tag/mod_path.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXPORT_ME_TOO 42
 

--- a/tests/expectations/tag/monomorph-1.c
+++ b/tests/expectations/tag/monomorph-1.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Bar_Bar_f32;
 

--- a/tests/expectations/tag/monomorph-1.compat.c
+++ b/tests/expectations/tag/monomorph-1.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Bar_Bar_f32;
 

--- a/tests/expectations/tag/monomorph-2.c
+++ b/tests/expectations/tag/monomorph-2.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct A;
 

--- a/tests/expectations/tag/monomorph-2.compat.c
+++ b/tests/expectations/tag/monomorph-2.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct A;
 

--- a/tests/expectations/tag/monomorph-3.c
+++ b/tests/expectations/tag/monomorph-3.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Bar_Bar_f32;
 

--- a/tests/expectations/tag/monomorph-3.compat.c
+++ b/tests/expectations/tag/monomorph-3.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Bar_Bar_f32;
 

--- a/tests/expectations/tag/must-use.c
+++ b/tests/expectations/tag/must-use.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum MaybeOwnedPtr_i32_Tag {
   Owned_i32,

--- a/tests/expectations/tag/must-use.compat.c
+++ b/tests/expectations/tag/must-use.compat.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 enum MaybeOwnedPtr_i32_Tag
 #ifdef __cplusplus

--- a/tests/expectations/tag/namespace_constant.c
+++ b/tests/expectations/tag/namespace_constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define FOO 10
 

--- a/tests/expectations/tag/namespace_constant.compat.c
+++ b/tests/expectations/tag/namespace_constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 namespace constants {

--- a/tests/expectations/tag/namespaces_constant.c
+++ b/tests/expectations/tag/namespaces_constant.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define FOO 10
 

--- a/tests/expectations/tag/namespaces_constant.compat.c
+++ b/tests/expectations/tag/namespaces_constant.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 namespace constants {

--- a/tests/expectations/tag/nested_import.c
+++ b/tests/expectations/tag/nested_import.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/tag/nested_import.compat.c
+++ b/tests/expectations/tag/nested_import.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/tag/nonnull.c
+++ b/tests/expectations/tag/nonnull.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Opaque;
 

--- a/tests/expectations/tag/nonnull.compat.c
+++ b/tests/expectations/tag/nonnull.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Opaque;
 

--- a/tests/expectations/tag/prefix.c
+++ b/tests/expectations/tag/prefix.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define PREFIX_LEN 42
 

--- a/tests/expectations/tag/prefix.compat.c
+++ b/tests/expectations/tag/prefix.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define PREFIX_LEN 42
 

--- a/tests/expectations/tag/prefixed_struct_literal.c
+++ b/tests/expectations/tag/prefixed_struct_literal.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct PREFIXFoo {
   int32_t a;

--- a/tests/expectations/tag/prefixed_struct_literal.compat.c
+++ b/tests/expectations/tag/prefixed_struct_literal.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct PREFIXFoo {
   int32_t a;

--- a/tests/expectations/tag/prefixed_struct_literal_deep.c
+++ b/tests/expectations/tag/prefixed_struct_literal_deep.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct PREFIXBar {
   int32_t a;

--- a/tests/expectations/tag/prefixed_struct_literal_deep.compat.c
+++ b/tests/expectations/tag/prefixed_struct_literal_deep.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct PREFIXBar {
   int32_t a;

--- a/tests/expectations/tag/rename-crate.c
+++ b/tests/expectations/tag/rename-crate.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if !defined(DEFINE_FREEBSD)
 struct NoExternTy {

--- a/tests/expectations/tag/rename-crate.compat.c
+++ b/tests/expectations/tag/rename-crate.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #if !defined(DEFINE_FREEBSD)
 struct NoExternTy {

--- a/tests/expectations/tag/rename.c
+++ b/tests/expectations/tag/rename.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define C_H 10
 

--- a/tests/expectations/tag/rename.compat.c
+++ b/tests/expectations/tag/rename.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define C_H 10
 

--- a/tests/expectations/tag/renaming-overrides-prefixing.c
+++ b/tests/expectations/tag/renaming-overrides-prefixing.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct StyleA;
 

--- a/tests/expectations/tag/renaming-overrides-prefixing.compat.c
+++ b/tests/expectations/tag/renaming-overrides-prefixing.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct StyleA;
 

--- a/tests/expectations/tag/reserved.c
+++ b/tests/expectations/tag/reserved.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct A {
   int32_t namespace_;

--- a/tests/expectations/tag/reserved.compat.c
+++ b/tests/expectations/tag/reserved.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct A {
   int32_t namespace_;

--- a/tests/expectations/tag/simplify-option-ptr.c
+++ b/tests/expectations/tag/simplify-option-ptr.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Opaque;
 

--- a/tests/expectations/tag/simplify-option-ptr.compat.c
+++ b/tests/expectations/tag/simplify-option-ptr.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Opaque;
 

--- a/tests/expectations/tag/static.c
+++ b/tests/expectations/tag/static.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Bar;
 

--- a/tests/expectations/tag/static.compat.c
+++ b/tests/expectations/tag/static.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Bar;
 

--- a/tests/expectations/tag/std_lib.c
+++ b/tests/expectations/tag/std_lib.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Option_i32;
 

--- a/tests/expectations/tag/std_lib.compat.c
+++ b/tests/expectations/tag/std_lib.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Option_i32;
 

--- a/tests/expectations/tag/struct.c
+++ b/tests/expectations/tag/struct.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Opaque;
 

--- a/tests/expectations/tag/struct.compat.c
+++ b/tests/expectations/tag/struct.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Opaque;
 

--- a/tests/expectations/tag/struct_literal.c
+++ b/tests/expectations/tag/struct_literal.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Bar;
 

--- a/tests/expectations/tag/struct_literal.compat.c
+++ b/tests/expectations/tag/struct_literal.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Bar;
 

--- a/tests/expectations/tag/struct_literal_order.c
+++ b/tests/expectations/tag/struct_literal_order.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct ABC {
   float a;

--- a/tests/expectations/tag/struct_literal_order.compat.c
+++ b/tests/expectations/tag/struct_literal_order.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct ABC {
   float a;

--- a/tests/expectations/tag/style-crash.c
+++ b/tests/expectations/tag/style-crash.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/tag/style-crash.compat.c
+++ b/tests/expectations/tag/style-crash.compat.c
@@ -2,3 +2,4 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>

--- a/tests/expectations/tag/transform-op.c
+++ b/tests/expectations/tag/transform-op.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct StylePoint_i32 {
   int32_t x;

--- a/tests/expectations/tag/transform-op.compat.c
+++ b/tests/expectations/tag/transform-op.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct StylePoint_i32 {
   int32_t x;

--- a/tests/expectations/tag/transparent.c
+++ b/tests/expectations/tag/transparent.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct DummyStruct;
 

--- a/tests/expectations/tag/transparent.compat.c
+++ b/tests/expectations/tag/transparent.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct DummyStruct;
 

--- a/tests/expectations/tag/typedef.c
+++ b/tests/expectations/tag/typedef.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo_i32__i32 {
   int32_t x;

--- a/tests/expectations/tag/typedef.compat.c
+++ b/tests/expectations/tag/typedef.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Foo_i32__i32 {
   int32_t x;

--- a/tests/expectations/tag/union.c
+++ b/tests/expectations/tag/union.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Opaque;
 

--- a/tests/expectations/tag/union.compat.c
+++ b/tests/expectations/tag/union.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 struct Opaque;
 

--- a/tests/expectations/tag/using_namespaces.c
+++ b/tests/expectations/tag/using_namespaces.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 void root(void);

--- a/tests/expectations/tag/using_namespaces.compat.c
+++ b/tests/expectations/tag/using_namespaces.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 namespace root {

--- a/tests/expectations/tag/va_list.c
+++ b/tests/expectations/tag/va_list.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 int32_t va_list_test(va_list ap);

--- a/tests/expectations/tag/va_list.compat.c
+++ b/tests/expectations/tag/va_list.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/tag/workspace.c
+++ b/tests/expectations/tag/workspace.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXT_CONST 0
 

--- a/tests/expectations/tag/workspace.compat.c
+++ b/tests/expectations/tag/workspace.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXT_CONST 0
 

--- a/tests/expectations/transform-op.c
+++ b/tests/expectations/transform-op.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t x;

--- a/tests/expectations/transform-op.compat.c
+++ b/tests/expectations/transform-op.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t x;

--- a/tests/expectations/transparent.c
+++ b/tests/expectations/transparent.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct DummyStruct DummyStruct;
 

--- a/tests/expectations/transparent.compat.c
+++ b/tests/expectations/transparent.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct DummyStruct DummyStruct;
 

--- a/tests/expectations/typedef.c
+++ b/tests/expectations/typedef.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t x;

--- a/tests/expectations/typedef.compat.c
+++ b/tests/expectations/typedef.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct {
   int32_t x;

--- a/tests/expectations/union.c
+++ b/tests/expectations/union.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/union.compat.c
+++ b/tests/expectations/union.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 typedef struct Opaque Opaque;
 

--- a/tests/expectations/using_namespaces.c
+++ b/tests/expectations/using_namespaces.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 void root(void);

--- a/tests/expectations/using_namespaces.compat.c
+++ b/tests/expectations/using_namespaces.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 namespace root {

--- a/tests/expectations/va_list.c
+++ b/tests/expectations/va_list.c
@@ -2,5 +2,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 int32_t va_list_test(va_list ap);

--- a/tests/expectations/va_list.compat.c
+++ b/tests/expectations/va_list.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/workspace.c
+++ b/tests/expectations/workspace.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXT_CONST 0
 

--- a/tests/expectations/workspace.compat.c
+++ b/tests/expectations/workspace.compat.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <uchar.h>
 
 #define EXT_CONST 0
 

--- a/tests/rust/char.rs
+++ b/tests/rust/char.rs
@@ -1,0 +1,7 @@
+#[repr(C)]
+struct Foo {
+    a: char,
+}
+
+#[no_mangle]
+pub extern "C" fn root(a: Foo) {}


### PR DESCRIPTION
My apologies, the change that I introduced in #396 failed to consider the generated C header requiring `uchar.h` for the `char32_t` definition. `char32_t` is defined as a fundamental type in C++, so I don't believe it's necessary to do the same.

As an aside, `char32_t` is C11-specific (as already mentioned in #373), will this cause any issues?