### PR TITLE
Force nightly for cargo expand

### DIFF
--- a/src/bindgen/cargo/cargo_expand.rs
+++ b/src/bindgen/cargo/cargo_expand.rs
@@ -87,6 +87,7 @@ pub fn expand(
     // cbindgen
     cmd.env("_CBINDGEN_IS_RUNNING", "1");
 
+    cmd.arg("+nightly");
     cmd.arg("rustc");
     cmd.arg("--lib");
     cmd.arg("--manifest-path");


### PR DESCRIPTION
# Problem
The "cargo expand" functionality requires a nightly compiler (see #38). However, if running `cbindgen` against a crate on a stable toolchain then cbindgen will fail with the following error: 

```
error: the option `Z` is only accepted on the nightly compiler
```
# Solution
The solution is to force "cargo expand" to run using an installed nightly toolchain by adding an additional argument to the command line: `+nightly`. This allows one to run cbindgen's expand macros logic using an installed nightly toolchain while keeping the actual crate on a stable toolchain.