### PR TITLE
Add support for after_includes

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -392,6 +392,8 @@ no_includes = false
 # default: false
 cpp_compat = false
 
+# A list of lines to add verbatim after the includes block
+after_includes = "#define VERSION 1"
 
 
 

--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -151,6 +151,7 @@ impl Bindings {
         if self.config.no_includes
             && self.config.sys_includes.is_empty()
             && self.config.includes.is_empty()
+            && self.config.after_includes.is_none()
         {
             return;
         }
@@ -193,6 +194,11 @@ impl Bindings {
 
         for include in &self.config.includes {
             write!(out, "#include \"{}\"", include);
+            out.new_line();
+        }
+
+        if let Some(ref line) = self.config.after_includes {
+            write!(out, "{}", line);
             out.new_line();
         }
     }

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -61,6 +61,12 @@ impl Builder {
     }
 
     #[allow(unused)]
+    pub fn with_after_include<S: AsRef<str>>(mut self, line: S) -> Builder {
+        self.config.after_includes = Some(String::from(line.as_ref()));
+        self
+    }
+
+    #[allow(unused)]
     pub fn with_trailer<S: AsRef<str>>(mut self, trailer: S) -> Builder {
         self.config.trailer = Some(String::from(trailer.as_ref()));
         self

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -701,6 +701,8 @@ pub struct Config {
     pub includes: Vec<String>,
     /// A list of additional system includes to put at the beginning of the generated header
     pub sys_includes: Vec<String>,
+    /// Optional verbatim code added after the include blocks
+    pub after_includes: Option<String>,
     /// Optional text to output at the end of the file
     pub trailer: Option<String>,
     /// Optional name to use for an include guard
@@ -766,6 +768,7 @@ impl Default for Config {
             header: None,
             includes: Vec::new(),
             sys_includes: Vec::new(),
+            after_includes: None,
             trailer: None,
             include_guard: None,
             autogen_warning: None,

--- a/template.toml
+++ b/template.toml
@@ -23,6 +23,7 @@ using_namespaces = []
 sys_includes = []
 includes = []
 no_includes = false
+after_includes = ""
 
 
 

--- a/tests/expectations/both/raw_lines.c
+++ b/tests/expectations/both/raw_lines.c
@@ -1,0 +1,12 @@
+#ifndef INCLUDE_GUARD_H
+#define INCLUDE_GUARD_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#define VERSION 1
+
+void root(void);
+
+#endif /* INCLUDE_GUARD_H */

--- a/tests/expectations/both/raw_lines.compat.c
+++ b/tests/expectations/both/raw_lines.compat.c
@@ -1,0 +1,20 @@
+#ifndef INCLUDE_GUARD_H
+#define INCLUDE_GUARD_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#define VERSION 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#endif /* INCLUDE_GUARD_H */

--- a/tests/expectations/raw_lines.c
+++ b/tests/expectations/raw_lines.c
@@ -1,0 +1,12 @@
+#ifndef INCLUDE_GUARD_H
+#define INCLUDE_GUARD_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#define VERSION 1
+
+void root(void);
+
+#endif /* INCLUDE_GUARD_H */

--- a/tests/expectations/raw_lines.compat.c
+++ b/tests/expectations/raw_lines.compat.c
@@ -1,0 +1,20 @@
+#ifndef INCLUDE_GUARD_H
+#define INCLUDE_GUARD_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#define VERSION 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#endif /* INCLUDE_GUARD_H */

--- a/tests/expectations/raw_lines.cpp
+++ b/tests/expectations/raw_lines.cpp
@@ -1,0 +1,16 @@
+#ifndef INCLUDE_GUARD_H
+#define INCLUDE_GUARD_H
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+#define VERSION 1
+
+extern "C" {
+
+void root();
+
+} // extern "C"
+
+#endif // INCLUDE_GUARD_H

--- a/tests/expectations/tag/raw_lines.c
+++ b/tests/expectations/tag/raw_lines.c
@@ -1,0 +1,12 @@
+#ifndef INCLUDE_GUARD_H
+#define INCLUDE_GUARD_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#define VERSION 1
+
+void root(void);
+
+#endif /* INCLUDE_GUARD_H */

--- a/tests/expectations/tag/raw_lines.compat.c
+++ b/tests/expectations/tag/raw_lines.compat.c
@@ -1,0 +1,20 @@
+#ifndef INCLUDE_GUARD_H
+#define INCLUDE_GUARD_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#define VERSION 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#endif /* INCLUDE_GUARD_H */

--- a/tests/rust/raw_lines.rs
+++ b/tests/rust/raw_lines.rs
@@ -1,0 +1,3 @@
+#[no_mangle]
+pub extern "C" fn root() {
+}

--- a/tests/rust/raw_lines.toml
+++ b/tests/rust/raw_lines.toml
@@ -1,0 +1,3 @@
+include_guard = "INCLUDE_GUARD_H"
+no_includes = false
+after_includes = "#define VERSION 1"


### PR DESCRIPTION
Let the user add raw C code in the generated header after the include
blocks.

It matches what bindgen provides.