### PR TITLE
ir: support #[repr(*64)] enums

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -494,10 +494,12 @@ impl Source for Enum {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         let size = self.repr.ty.map(|ty| match ty {
             ReprType::USize => "uintptr_t",
+            ReprType::U64 => "uint64_t",
             ReprType::U32 => "uint32_t",
             ReprType::U16 => "uint16_t",
             ReprType::U8 => "uint8_t",
             ReprType::ISize => "intptr_t",
+            ReprType::I64 => "int64_t",
             ReprType::I32 => "int32_t",
             ReprType::I16 => "int16_t",
             ReprType::I8 => "int8_t",

--- a/src/bindgen/ir/repr.rs
+++ b/src/bindgen/ir/repr.rs
@@ -22,10 +22,12 @@ pub enum ReprType {
     U8,
     U16,
     U32,
+    U64,
     USize,
     I8,
     I16,
     I32,
+    I64,
     ISize,
 }
 
@@ -88,10 +90,12 @@ impl Repr {
                 ("u8", None) => ReprType::U8,
                 ("u16", None) => ReprType::U16,
                 ("u32", None) => ReprType::U32,
+                ("u64", None) => ReprType::U64,
                 ("usize", None) => ReprType::USize,
                 ("i8", None) => ReprType::I8,
                 ("i16", None) => ReprType::I16,
                 ("i32", None) => ReprType::I32,
+                ("i64", None) => ReprType::I64,
                 ("isize", None) => ReprType::ISize,
                 ("C", None) => {
                     repr.style = ReprStyle::C;

--- a/tests/expectations/both/enum.c
+++ b/tests/expectations/both/enum.c
@@ -9,7 +9,7 @@ enum A {
   a3,
   a4 = 5,
 };
-typedef uint32_t A;
+typedef uint64_t A;
 
 enum B {
   b1 = 0,
@@ -17,7 +17,7 @@ enum B {
   b3,
   b4 = 5,
 };
-typedef uint16_t B;
+typedef uint32_t B;
 
 enum C {
   c1 = 0,
@@ -25,7 +25,7 @@ enum C {
   c3,
   c4 = 5,
 };
-typedef uint8_t C;
+typedef uint16_t C;
 
 enum D {
   d1 = 0,
@@ -33,7 +33,7 @@ enum D {
   d3,
   d4 = 5,
 };
-typedef uintptr_t D;
+typedef uint8_t D;
 
 enum E {
   e1 = 0,
@@ -41,81 +41,65 @@ enum E {
   e3,
   e4 = 5,
 };
-typedef intptr_t E;
+typedef uintptr_t E;
 
-typedef enum K {
-  k1,
-  k2,
-  k3,
-  k4,
-} K;
-
-enum L {
-  l1 = -1,
-  l2 = 0,
-  l3 = 1,
+enum F {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
 };
-typedef int8_t L;
+typedef intptr_t F;
 
-typedef struct I I;
+typedef enum L {
+  l1,
+  l2,
+  l3,
+  l4,
+} L;
+
+enum M {
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
+};
+typedef int8_t M;
 
 typedef struct J J;
 
+typedef struct K K;
+
 typedef struct Opaque Opaque;
 
-enum F_Tag {
+enum G_Tag {
   Foo,
   Bar,
   Baz,
 };
-typedef uint8_t F_Tag;
+typedef uint8_t G_Tag;
 
 typedef struct Foo_Body {
-  F_Tag tag;
+  G_Tag tag;
   int16_t _0;
 } Foo_Body;
 
 typedef struct Bar_Body {
-  F_Tag tag;
+  G_Tag tag;
   uint8_t x;
   int16_t y;
 } Bar_Body;
 
-typedef union F {
-  F_Tag tag;
+typedef union G {
+  G_Tag tag;
   Foo_Body foo;
   Bar_Body bar;
-} F;
-
-typedef enum G_Tag {
-  G_Foo,
-  G_Bar,
-  G_Baz,
-} G_Tag;
-
-typedef struct G_Foo_Body {
-  int16_t _0;
-} G_Foo_Body;
-
-typedef struct G_Bar_Body {
-  uint8_t x;
-  int16_t y;
-} G_Bar_Body;
-
-typedef struct G {
-  G_Tag tag;
-  union {
-    G_Foo_Body foo;
-    G_Bar_Body bar;
-  };
 } G;
 
-enum H_Tag {
+typedef enum H_Tag {
   H_Foo,
   H_Bar,
   H_Baz,
-};
-typedef uint8_t H_Tag;
+} H_Tag;
 
 typedef struct H_Foo_Body {
   int16_t _0;
@@ -134,4 +118,28 @@ typedef struct H {
   };
 } H;
 
-void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l);
+enum I_Tag {
+  I_Foo,
+  I_Bar,
+  I_Baz,
+};
+typedef uint8_t I_Tag;
+
+typedef struct I_Foo_Body {
+  int16_t _0;
+} I_Foo_Body;
+
+typedef struct I_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} I_Bar_Body;
+
+typedef struct I {
+  I_Tag tag;
+  union {
+    I_Foo_Body foo;
+    I_Bar_Body bar;
+  };
+} I;
+
+void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m);

--- a/tests/expectations/both/enum.compat.c
+++ b/tests/expectations/both/enum.compat.c
@@ -5,7 +5,7 @@
 
 enum A
 #ifdef __cplusplus
-  : uint32_t
+  : uint64_t
 #endif // __cplusplus
  {
   a1 = 0,
@@ -14,12 +14,12 @@ enum A
   a4 = 5,
 };
 #ifndef __cplusplus
-typedef uint32_t A;
+typedef uint64_t A;
 #endif // __cplusplus
 
 enum B
 #ifdef __cplusplus
-  : uint16_t
+  : uint32_t
 #endif // __cplusplus
  {
   b1 = 0,
@@ -28,12 +28,12 @@ enum B
   b4 = 5,
 };
 #ifndef __cplusplus
-typedef uint16_t B;
+typedef uint32_t B;
 #endif // __cplusplus
 
 enum C
 #ifdef __cplusplus
-  : uint8_t
+  : uint16_t
 #endif // __cplusplus
  {
   c1 = 0,
@@ -42,12 +42,12 @@ enum C
   c4 = 5,
 };
 #ifndef __cplusplus
-typedef uint8_t C;
+typedef uint16_t C;
 #endif // __cplusplus
 
 enum D
 #ifdef __cplusplus
-  : uintptr_t
+  : uint8_t
 #endif // __cplusplus
  {
   d1 = 0,
@@ -56,12 +56,12 @@ enum D
   d4 = 5,
 };
 #ifndef __cplusplus
-typedef uintptr_t D;
+typedef uint8_t D;
 #endif // __cplusplus
 
 enum E
 #ifdef __cplusplus
-  : intptr_t
+  : uintptr_t
 #endif // __cplusplus
  {
   e1 = 0,
@@ -70,36 +70,50 @@ enum E
   e4 = 5,
 };
 #ifndef __cplusplus
-typedef intptr_t E;
+typedef uintptr_t E;
 #endif // __cplusplus
 
-typedef enum K {
-  k1,
-  k2,
-  k3,
-  k4,
-} K;
+enum F
+#ifdef __cplusplus
+  : intptr_t
+#endif // __cplusplus
+ {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
+};
+#ifndef __cplusplus
+typedef intptr_t F;
+#endif // __cplusplus
 
-enum L
+typedef enum L {
+  l1,
+  l2,
+  l3,
+  l4,
+} L;
+
+enum M
 #ifdef __cplusplus
   : int8_t
 #endif // __cplusplus
  {
-  l1 = -1,
-  l2 = 0,
-  l3 = 1,
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
 };
 #ifndef __cplusplus
-typedef int8_t L;
+typedef int8_t M;
 #endif // __cplusplus
-
-typedef struct I I;
 
 typedef struct J J;
 
+typedef struct K K;
+
 typedef struct Opaque Opaque;
 
-enum F_Tag
+enum G_Tag
 #ifdef __cplusplus
   : uint8_t
 #endif // __cplusplus
@@ -109,61 +123,31 @@ enum F_Tag
   Baz,
 };
 #ifndef __cplusplus
-typedef uint8_t F_Tag;
+typedef uint8_t G_Tag;
 #endif // __cplusplus
 
 typedef struct Foo_Body {
-  F_Tag tag;
+  G_Tag tag;
   int16_t _0;
 } Foo_Body;
 
 typedef struct Bar_Body {
-  F_Tag tag;
+  G_Tag tag;
   uint8_t x;
   int16_t y;
 } Bar_Body;
 
-typedef union F {
-  F_Tag tag;
+typedef union G {
+  G_Tag tag;
   Foo_Body foo;
   Bar_Body bar;
-} F;
-
-typedef enum G_Tag {
-  G_Foo,
-  G_Bar,
-  G_Baz,
-} G_Tag;
-
-typedef struct G_Foo_Body {
-  int16_t _0;
-} G_Foo_Body;
-
-typedef struct G_Bar_Body {
-  uint8_t x;
-  int16_t y;
-} G_Bar_Body;
-
-typedef struct G {
-  G_Tag tag;
-  union {
-    G_Foo_Body foo;
-    G_Bar_Body bar;
-  };
 } G;
 
-enum H_Tag
-#ifdef __cplusplus
-  : uint8_t
-#endif // __cplusplus
- {
+typedef enum H_Tag {
   H_Foo,
   H_Bar,
   H_Baz,
-};
-#ifndef __cplusplus
-typedef uint8_t H_Tag;
-#endif // __cplusplus
+} H_Tag;
 
 typedef struct H_Foo_Body {
   int16_t _0;
@@ -182,11 +166,41 @@ typedef struct H {
   };
 } H;
 
+enum I_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  I_Foo,
+  I_Bar,
+  I_Baz,
+};
+#ifndef __cplusplus
+typedef uint8_t I_Tag;
+#endif // __cplusplus
+
+typedef struct I_Foo_Body {
+  int16_t _0;
+} I_Foo_Body;
+
+typedef struct I_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} I_Bar_Body;
+
+typedef struct I {
+  I_Tag tag;
+  union {
+    I_Foo_Body foo;
+    I_Bar_Body bar;
+  };
+} I;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l);
+void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/enum.c
+++ b/tests/expectations/enum.c
@@ -9,7 +9,7 @@ enum A {
   a3,
   a4 = 5,
 };
-typedef uint32_t A;
+typedef uint64_t A;
 
 enum B {
   b1 = 0,
@@ -17,7 +17,7 @@ enum B {
   b3,
   b4 = 5,
 };
-typedef uint16_t B;
+typedef uint32_t B;
 
 enum C {
   c1 = 0,
@@ -25,7 +25,7 @@ enum C {
   c3,
   c4 = 5,
 };
-typedef uint8_t C;
+typedef uint16_t C;
 
 enum D {
   d1 = 0,
@@ -33,7 +33,7 @@ enum D {
   d3,
   d4 = 5,
 };
-typedef uintptr_t D;
+typedef uint8_t D;
 
 enum E {
   e1 = 0,
@@ -41,81 +41,65 @@ enum E {
   e3,
   e4 = 5,
 };
-typedef intptr_t E;
+typedef uintptr_t E;
+
+enum F {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
+};
+typedef intptr_t F;
 
 typedef enum {
-  k1,
-  k2,
-  k3,
-  k4,
-} K;
+  l1,
+  l2,
+  l3,
+  l4,
+} L;
 
-enum L {
-  l1 = -1,
-  l2 = 0,
-  l3 = 1,
+enum M {
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
 };
-typedef int8_t L;
-
-typedef struct I I;
+typedef int8_t M;
 
 typedef struct J J;
 
+typedef struct K K;
+
 typedef struct Opaque Opaque;
 
-enum F_Tag {
+enum G_Tag {
   Foo,
   Bar,
   Baz,
 };
-typedef uint8_t F_Tag;
+typedef uint8_t G_Tag;
 
 typedef struct {
-  F_Tag tag;
+  G_Tag tag;
   int16_t _0;
 } Foo_Body;
 
 typedef struct {
-  F_Tag tag;
+  G_Tag tag;
   uint8_t x;
   int16_t y;
 } Bar_Body;
 
 typedef union {
-  F_Tag tag;
+  G_Tag tag;
   Foo_Body foo;
   Bar_Body bar;
-} F;
-
-typedef enum {
-  G_Foo,
-  G_Bar,
-  G_Baz,
-} G_Tag;
-
-typedef struct {
-  int16_t _0;
-} G_Foo_Body;
-
-typedef struct {
-  uint8_t x;
-  int16_t y;
-} G_Bar_Body;
-
-typedef struct {
-  G_Tag tag;
-  union {
-    G_Foo_Body foo;
-    G_Bar_Body bar;
-  };
 } G;
 
-enum H_Tag {
+typedef enum {
   H_Foo,
   H_Bar,
   H_Baz,
-};
-typedef uint8_t H_Tag;
+} H_Tag;
 
 typedef struct {
   int16_t _0;
@@ -134,4 +118,28 @@ typedef struct {
   };
 } H;
 
-void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l);
+enum I_Tag {
+  I_Foo,
+  I_Bar,
+  I_Baz,
+};
+typedef uint8_t I_Tag;
+
+typedef struct {
+  int16_t _0;
+} I_Foo_Body;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} I_Bar_Body;
+
+typedef struct {
+  I_Tag tag;
+  union {
+    I_Foo_Body foo;
+    I_Bar_Body bar;
+  };
+} I;
+
+void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m);

--- a/tests/expectations/enum.compat.c
+++ b/tests/expectations/enum.compat.c
@@ -5,7 +5,7 @@
 
 enum A
 #ifdef __cplusplus
-  : uint32_t
+  : uint64_t
 #endif // __cplusplus
  {
   a1 = 0,
@@ -14,12 +14,12 @@ enum A
   a4 = 5,
 };
 #ifndef __cplusplus
-typedef uint32_t A;
+typedef uint64_t A;
 #endif // __cplusplus
 
 enum B
 #ifdef __cplusplus
-  : uint16_t
+  : uint32_t
 #endif // __cplusplus
  {
   b1 = 0,
@@ -28,12 +28,12 @@ enum B
   b4 = 5,
 };
 #ifndef __cplusplus
-typedef uint16_t B;
+typedef uint32_t B;
 #endif // __cplusplus
 
 enum C
 #ifdef __cplusplus
-  : uint8_t
+  : uint16_t
 #endif // __cplusplus
  {
   c1 = 0,
@@ -42,12 +42,12 @@ enum C
   c4 = 5,
 };
 #ifndef __cplusplus
-typedef uint8_t C;
+typedef uint16_t C;
 #endif // __cplusplus
 
 enum D
 #ifdef __cplusplus
-  : uintptr_t
+  : uint8_t
 #endif // __cplusplus
  {
   d1 = 0,
@@ -56,12 +56,12 @@ enum D
   d4 = 5,
 };
 #ifndef __cplusplus
-typedef uintptr_t D;
+typedef uint8_t D;
 #endif // __cplusplus
 
 enum E
 #ifdef __cplusplus
-  : intptr_t
+  : uintptr_t
 #endif // __cplusplus
  {
   e1 = 0,
@@ -70,36 +70,50 @@ enum E
   e4 = 5,
 };
 #ifndef __cplusplus
-typedef intptr_t E;
+typedef uintptr_t E;
+#endif // __cplusplus
+
+enum F
+#ifdef __cplusplus
+  : intptr_t
+#endif // __cplusplus
+ {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
+};
+#ifndef __cplusplus
+typedef intptr_t F;
 #endif // __cplusplus
 
 typedef enum {
-  k1,
-  k2,
-  k3,
-  k4,
-} K;
+  l1,
+  l2,
+  l3,
+  l4,
+} L;
 
-enum L
+enum M
 #ifdef __cplusplus
   : int8_t
 #endif // __cplusplus
  {
-  l1 = -1,
-  l2 = 0,
-  l3 = 1,
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
 };
 #ifndef __cplusplus
-typedef int8_t L;
+typedef int8_t M;
 #endif // __cplusplus
-
-typedef struct I I;
 
 typedef struct J J;
 
+typedef struct K K;
+
 typedef struct Opaque Opaque;
 
-enum F_Tag
+enum G_Tag
 #ifdef __cplusplus
   : uint8_t
 #endif // __cplusplus
@@ -109,61 +123,31 @@ enum F_Tag
   Baz,
 };
 #ifndef __cplusplus
-typedef uint8_t F_Tag;
+typedef uint8_t G_Tag;
 #endif // __cplusplus
 
 typedef struct {
-  F_Tag tag;
+  G_Tag tag;
   int16_t _0;
 } Foo_Body;
 
 typedef struct {
-  F_Tag tag;
+  G_Tag tag;
   uint8_t x;
   int16_t y;
 } Bar_Body;
 
 typedef union {
-  F_Tag tag;
+  G_Tag tag;
   Foo_Body foo;
   Bar_Body bar;
-} F;
-
-typedef enum {
-  G_Foo,
-  G_Bar,
-  G_Baz,
-} G_Tag;
-
-typedef struct {
-  int16_t _0;
-} G_Foo_Body;
-
-typedef struct {
-  uint8_t x;
-  int16_t y;
-} G_Bar_Body;
-
-typedef struct {
-  G_Tag tag;
-  union {
-    G_Foo_Body foo;
-    G_Bar_Body bar;
-  };
 } G;
 
-enum H_Tag
-#ifdef __cplusplus
-  : uint8_t
-#endif // __cplusplus
- {
+typedef enum {
   H_Foo,
   H_Bar,
   H_Baz,
-};
-#ifndef __cplusplus
-typedef uint8_t H_Tag;
-#endif // __cplusplus
+} H_Tag;
 
 typedef struct {
   int16_t _0;
@@ -182,11 +166,41 @@ typedef struct {
   };
 } H;
 
+enum I_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  I_Foo,
+  I_Bar,
+  I_Baz,
+};
+#ifndef __cplusplus
+typedef uint8_t I_Tag;
+#endif // __cplusplus
+
+typedef struct {
+  int16_t _0;
+} I_Foo_Body;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} I_Bar_Body;
+
+typedef struct {
+  I_Tag tag;
+  union {
+    I_Foo_Body foo;
+    I_Bar_Body bar;
+  };
+} I;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l);
+void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/enum.cpp
+++ b/tests/expectations/enum.cpp
@@ -3,61 +3,68 @@
 #include <cstdlib>
 #include <new>
 
-enum class A : uint32_t {
+enum class A : uint64_t {
   a1 = 0,
   a2 = 2,
   a3,
   a4 = 5,
 };
 
-enum class B : uint16_t {
+enum class B : uint32_t {
   b1 = 0,
   b2 = 2,
   b3,
   b4 = 5,
 };
 
-enum class C : uint8_t {
+enum class C : uint16_t {
   c1 = 0,
   c2 = 2,
   c3,
   c4 = 5,
 };
 
-enum class D : uintptr_t {
+enum class D : uint8_t {
   d1 = 0,
   d2 = 2,
   d3,
   d4 = 5,
 };
 
-enum class E : intptr_t {
+enum class E : uintptr_t {
   e1 = 0,
   e2 = 2,
   e3,
   e4 = 5,
 };
 
-enum class K {
-  k1,
-  k2,
-  k3,
-  k4,
+enum class F : intptr_t {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
 };
 
-enum class L : int8_t {
-  l1 = -1,
-  l2 = 0,
-  l3 = 1,
+enum class L {
+  l1,
+  l2,
+  l3,
+  l4,
 };
 
-struct I;
+enum class M : int8_t {
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
+};
 
 struct J;
 
+struct K;
+
 struct Opaque;
 
-union F {
+union G {
   enum class Tag : uint8_t {
     Foo,
     Bar,
@@ -82,31 +89,8 @@ union F {
   Bar_Body bar;
 };
 
-struct G {
-  enum class Tag {
-    G_Foo,
-    G_Bar,
-    G_Baz,
-  };
-
-  struct G_Foo_Body {
-    int16_t _0;
-  };
-
-  struct G_Bar_Body {
-    uint8_t x;
-    int16_t y;
-  };
-
-  Tag tag;
-  union {
-    G_Foo_Body foo;
-    G_Bar_Body bar;
-  };
-};
-
 struct H {
-  enum class Tag : uint8_t {
+  enum class Tag {
     H_Foo,
     H_Bar,
     H_Baz,
@@ -128,8 +112,31 @@ struct H {
   };
 };
 
+struct I {
+  enum class Tag : uint8_t {
+    I_Foo,
+    I_Bar,
+    I_Baz,
+  };
+
+  struct I_Foo_Body {
+    int16_t _0;
+  };
+
+  struct I_Bar_Body {
+    uint8_t x;
+    int16_t y;
+  };
+
+  Tag tag;
+  union {
+    I_Foo_Body foo;
+    I_Bar_Body bar;
+  };
+};
+
 extern "C" {
 
-void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l);
+void root(Opaque *o, A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m);
 
 } // extern "C"

--- a/tests/expectations/tag/enum.c
+++ b/tests/expectations/tag/enum.c
@@ -9,7 +9,7 @@ enum A {
   a3,
   a4 = 5,
 };
-typedef uint32_t A;
+typedef uint64_t A;
 
 enum B {
   b1 = 0,
@@ -17,7 +17,7 @@ enum B {
   b3,
   b4 = 5,
 };
-typedef uint16_t B;
+typedef uint32_t B;
 
 enum C {
   c1 = 0,
@@ -25,7 +25,7 @@ enum C {
   c3,
   c4 = 5,
 };
-typedef uint8_t C;
+typedef uint16_t C;
 
 enum D {
   d1 = 0,
@@ -33,7 +33,7 @@ enum D {
   d3,
   d4 = 5,
 };
-typedef uintptr_t D;
+typedef uint8_t D;
 
 enum E {
   e1 = 0,
@@ -41,73 +41,58 @@ enum E {
   e3,
   e4 = 5,
 };
-typedef intptr_t E;
+typedef uintptr_t E;
 
-enum K {
-  k1,
-  k2,
-  k3,
-  k4,
+enum F {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
 };
+typedef intptr_t F;
 
 enum L {
-  l1 = -1,
-  l2 = 0,
-  l3 = 1,
+  l1,
+  l2,
+  l3,
+  l4,
 };
-typedef int8_t L;
 
-struct I;
+enum M {
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
+};
+typedef int8_t M;
 
 struct J;
 
+struct K;
+
 struct Opaque;
 
-enum F_Tag {
+enum G_Tag {
   Foo,
   Bar,
   Baz,
 };
-typedef uint8_t F_Tag;
+typedef uint8_t G_Tag;
 
 struct Foo_Body {
-  F_Tag tag;
+  G_Tag tag;
   int16_t _0;
 };
 
 struct Bar_Body {
-  F_Tag tag;
+  G_Tag tag;
   uint8_t x;
   int16_t y;
 };
 
-union F {
-  enum F_Tag tag;
+union G {
+  enum G_Tag tag;
   struct Foo_Body foo;
   struct Bar_Body bar;
-};
-
-enum G_Tag {
-  G_Foo,
-  G_Bar,
-  G_Baz,
-};
-
-struct G_Foo_Body {
-  int16_t _0;
-};
-
-struct G_Bar_Body {
-  uint8_t x;
-  int16_t y;
-};
-
-struct G {
-  enum G_Tag tag;
-  union {
-    struct G_Foo_Body foo;
-    struct G_Bar_Body bar;
-  };
 };
 
 enum H_Tag {
@@ -115,7 +100,6 @@ enum H_Tag {
   H_Bar,
   H_Baz,
 };
-typedef uint8_t H_Tag;
 
 struct H_Foo_Body {
   int16_t _0;
@@ -134,16 +118,41 @@ struct H {
   };
 };
 
+enum I_Tag {
+  I_Foo,
+  I_Bar,
+  I_Baz,
+};
+typedef uint8_t I_Tag;
+
+struct I_Foo_Body {
+  int16_t _0;
+};
+
+struct I_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct I {
+  enum I_Tag tag;
+  union {
+    struct I_Foo_Body foo;
+    struct I_Bar_Body bar;
+  };
+};
+
 void root(struct Opaque *o,
           A a,
           B b,
           C c,
           D d,
           E e,
-          union F f,
-          struct G g,
+          F f,
+          union G g,
           struct H h,
           struct I i,
           struct J j,
-          enum K k,
-          L l);
+          struct K k,
+          enum L l,
+          M m);

--- a/tests/expectations/tag/enum.compat.c
+++ b/tests/expectations/tag/enum.compat.c
@@ -5,7 +5,7 @@
 
 enum A
 #ifdef __cplusplus
-  : uint32_t
+  : uint64_t
 #endif // __cplusplus
  {
   a1 = 0,
@@ -14,12 +14,12 @@ enum A
   a4 = 5,
 };
 #ifndef __cplusplus
-typedef uint32_t A;
+typedef uint64_t A;
 #endif // __cplusplus
 
 enum B
 #ifdef __cplusplus
-  : uint16_t
+  : uint32_t
 #endif // __cplusplus
  {
   b1 = 0,
@@ -28,12 +28,12 @@ enum B
   b4 = 5,
 };
 #ifndef __cplusplus
-typedef uint16_t B;
+typedef uint32_t B;
 #endif // __cplusplus
 
 enum C
 #ifdef __cplusplus
-  : uint8_t
+  : uint16_t
 #endif // __cplusplus
  {
   c1 = 0,
@@ -42,12 +42,12 @@ enum C
   c4 = 5,
 };
 #ifndef __cplusplus
-typedef uint8_t C;
+typedef uint16_t C;
 #endif // __cplusplus
 
 enum D
 #ifdef __cplusplus
-  : uintptr_t
+  : uint8_t
 #endif // __cplusplus
  {
   d1 = 0,
@@ -56,12 +56,12 @@ enum D
   d4 = 5,
 };
 #ifndef __cplusplus
-typedef uintptr_t D;
+typedef uint8_t D;
 #endif // __cplusplus
 
 enum E
 #ifdef __cplusplus
-  : intptr_t
+  : uintptr_t
 #endif // __cplusplus
  {
   e1 = 0,
@@ -70,36 +70,50 @@ enum E
   e4 = 5,
 };
 #ifndef __cplusplus
-typedef intptr_t E;
+typedef uintptr_t E;
 #endif // __cplusplus
 
-enum K {
-  k1,
-  k2,
-  k3,
-  k4,
+enum F
+#ifdef __cplusplus
+  : intptr_t
+#endif // __cplusplus
+ {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
+};
+#ifndef __cplusplus
+typedef intptr_t F;
+#endif // __cplusplus
+
+enum L {
+  l1,
+  l2,
+  l3,
+  l4,
 };
 
-enum L
+enum M
 #ifdef __cplusplus
   : int8_t
 #endif // __cplusplus
  {
-  l1 = -1,
-  l2 = 0,
-  l3 = 1,
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
 };
 #ifndef __cplusplus
-typedef int8_t L;
+typedef int8_t M;
 #endif // __cplusplus
-
-struct I;
 
 struct J;
 
+struct K;
+
 struct Opaque;
 
-enum F_Tag
+enum G_Tag
 #ifdef __cplusplus
   : uint8_t
 #endif // __cplusplus
@@ -109,61 +123,31 @@ enum F_Tag
   Baz,
 };
 #ifndef __cplusplus
-typedef uint8_t F_Tag;
+typedef uint8_t G_Tag;
 #endif // __cplusplus
 
 struct Foo_Body {
-  F_Tag tag;
+  G_Tag tag;
   int16_t _0;
 };
 
 struct Bar_Body {
-  F_Tag tag;
+  G_Tag tag;
   uint8_t x;
   int16_t y;
 };
 
-union F {
-  enum F_Tag tag;
+union G {
+  enum G_Tag tag;
   struct Foo_Body foo;
   struct Bar_Body bar;
 };
 
-enum G_Tag {
-  G_Foo,
-  G_Bar,
-  G_Baz,
-};
-
-struct G_Foo_Body {
-  int16_t _0;
-};
-
-struct G_Bar_Body {
-  uint8_t x;
-  int16_t y;
-};
-
-struct G {
-  enum G_Tag tag;
-  union {
-    struct G_Foo_Body foo;
-    struct G_Bar_Body bar;
-  };
-};
-
-enum H_Tag
-#ifdef __cplusplus
-  : uint8_t
-#endif // __cplusplus
- {
+enum H_Tag {
   H_Foo,
   H_Bar,
   H_Baz,
 };
-#ifndef __cplusplus
-typedef uint8_t H_Tag;
-#endif // __cplusplus
 
 struct H_Foo_Body {
   int16_t _0;
@@ -182,6 +166,36 @@ struct H {
   };
 };
 
+enum I_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  I_Foo,
+  I_Bar,
+  I_Baz,
+};
+#ifndef __cplusplus
+typedef uint8_t I_Tag;
+#endif // __cplusplus
+
+struct I_Foo_Body {
+  int16_t _0;
+};
+
+struct I_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct I {
+  enum I_Tag tag;
+  union {
+    struct I_Foo_Body foo;
+    struct I_Bar_Body bar;
+  };
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -192,13 +206,14 @@ void root(struct Opaque *o,
           C c,
           D d,
           E e,
-          union F f,
-          struct G g,
+          F f,
+          union G g,
           struct H h,
           struct I i,
           struct J j,
-          enum K k,
-          L l);
+          struct K k,
+          enum L l,
+          M m);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/rust/enum.rs
+++ b/tests/rust/enum.rs
@@ -1,9 +1,9 @@
 enum Opaque {
     Foo(i32),
-    Bar
+    Bar,
 }
 
-#[repr(u32)]
+#[repr(u64)]
 enum A {
     a1 = 0,
     a2 = 2,
@@ -11,7 +11,7 @@ enum A {
     a4 = 5,
 }
 
-#[repr(u16)]
+#[repr(u32)]
 enum B {
     b1 = 0,
     b2 = 2,
@@ -19,7 +19,7 @@ enum B {
     b4 = 5,
 }
 
-#[repr(u8)]
+#[repr(u16)]
 enum C {
     c1 = 0,
     c2 = 2,
@@ -27,7 +27,7 @@ enum C {
     c4 = 5,
 }
 
-#[repr(usize)]
+#[repr(u8)]
 enum D {
     d1 = 0,
     d2 = 2,
@@ -35,7 +35,7 @@ enum D {
     d4 = 5,
 }
 
-#[repr(isize)]
+#[repr(usize)]
 enum E {
     e1 = 0,
     e2 = 2,
@@ -43,56 +43,64 @@ enum E {
     e4 = 5,
 }
 
-#[repr(u8)]
+#[repr(isize)]
 enum F {
+    f1 = 0,
+    f2 = 2,
+    f3,
+    f4 = 5,
+}
+
+#[repr(u8)]
+enum G {
     Foo(i16),
     Bar { x: u8, y: i16 },
-    Baz
+    Baz,
 }
 
 /// cbindgen:prefix-with-name
 #[repr(C)]
-enum G {
+enum H {
     Foo(i16),
     Bar { x: u8, y: i16 },
-    Baz
+    Baz,
 }
 
 /// cbindgen:prefix-with-name
 #[repr(C, u8)]
-enum H {
-    Foo(i16),
-    Bar { x: u8, y: i16 },
-    Baz
-}
-
-#[repr(C, u8, u16)]
 enum I {
     Foo(i16),
     Bar { x: u8, y: i16 },
-    Baz
+    Baz,
 }
 
-#[repr(C, u8, unknown_hint)]
+#[repr(C, u8, u16)]
 enum J {
     Foo(i16),
     Bar { x: u8, y: i16 },
-    Baz
+    Baz,
+}
+
+#[repr(C, u8, unknown_hint)]
+enum K {
+    Foo(i16),
+    Bar { x: u8, y: i16 },
+    Baz,
 }
 
 #[repr(C)]
-enum K {
-    k1,
-    k2,
-    k3,
-    k4,
+enum L {
+    l1,
+    l2,
+    l3,
+    l4,
 }
 
 #[repr(i8)]
-enum L {
-    l1 = -1,
-    l2 = 0,
-    l3 = 1,
+enum M {
+    m1 = -1,
+    m2 = 0,
+    m3 = 1,
 }
 
 #[no_mangle]
@@ -110,4 +118,6 @@ pub extern "C" fn root(
     j: J,
     k: K,
     l: L,
-) { }
+    m: M,
+) {
+}


### PR DESCRIPTION
Since there is a native C type for 64-bit integers (*int64_t), we can
just add support for them. Support for larger enums (u128) are currently
unstable and don't have a reasonable (standard-enough) C representation
to support at the moment.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>