### PR TITLE
Add support for the export_name function attribute

### DIFF
--- a/tests/expectations/both/export_name.c
+++ b/tests/expectations/both/export_name.c
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void do_the_thing_with_export_name(void);

--- a/tests/expectations/both/export_name.compat.c
+++ b/tests/expectations/both/export_name.compat.c
@@ -1,0 +1,14 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void do_the_thing_with_export_name(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/export_name.c
+++ b/tests/expectations/export_name.c
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void do_the_thing_with_export_name(void);

--- a/tests/expectations/export_name.compat.c
+++ b/tests/expectations/export_name.compat.c
@@ -1,0 +1,14 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void do_the_thing_with_export_name(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/export_name.cpp
+++ b/tests/expectations/export_name.cpp
@@ -1,0 +1,10 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+
+extern "C" {
+
+void do_the_thing_with_export_name();
+
+} // extern "C"

--- a/tests/expectations/tag/export_name.c
+++ b/tests/expectations/tag/export_name.c
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void do_the_thing_with_export_name(void);

--- a/tests/expectations/tag/export_name.compat.c
+++ b/tests/expectations/tag/export_name.compat.c
@@ -1,0 +1,14 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void do_the_thing_with_export_name(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/rust/export_name.rs
+++ b/tests/rust/export_name.rs
@@ -1,0 +1,4 @@
+#[export_name = "do_the_thing_with_export_name"]
+pub extern "C" fn do_the_thing() {
+  println!("doing the thing!");
+}


### PR DESCRIPTION
Fixes #283 

Added a helper trait / methods on `syn::ItemFn` to handle attribute lookup, including:

- `export_name_attr` to lookup the attribute
- `exported_name` to select the correct name (`export_name` if it was set, otherwise the function name if it's `no_mangle`, otherwise `None`)
- `attr_name_value_lookup` added to `SynAttributeHelpers` to factor out attribute lookup