### PR TITLE
Support 'swift_name' attributes on generated functions

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -293,7 +293,15 @@ All function attributes are just local overrides for the same options found in t
 * prefix
 * postfix
 
+## Generating Swift Bindings
 
+In addition to parsing function names in C/C++ header files, the Swift compiler can make use of the `swift_name` attribute on functions to generate more idiomatic names for imported functions and methods.
+
+This attribute is commonly used in Objective-C/C/C++ via the `NS_SWIFT_NAME` and `CF_SWIFT_NAME` macros.
+
+Given configuration in the cbindgen.toml, `cbindgen` can generate these attributes for you by guessing an appropriate method signature based on the existing function name (and type, if it is a method in an `impl` block).
+
+This is controlled by the `swift_name_macro` option in the cbindgen.toml.
 
 
 ## cbindgen.toml
@@ -544,6 +552,13 @@ args = "horizontal"
 # platform-specific way. e.g. "MUST_USE_FUNC"
 # default: nothing is emitted for must_use functions
 must_use = "MUST_USE_FUNC"
+
+# An optional string that, if present, will be used to generate Swift function
+# and method signatures for generated functions, for example "CF_SWIFT_NAME".
+# If no such macro is available in your toolchain, you can define one using the
+# `header` option in cbindgen.toml
+# default: no swift_name function attributes are generated 
+swift_name_macro = "CF_SWIFT_NAME"
 
 # A rule to use to rename function argument names. The renaming assumes the input
 # is the Rust standard snake_case, however it accepts all the different rename_args

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -279,12 +279,14 @@ pub struct FunctionConfig {
     pub prefix: Option<String>,
     /// Optional text to output after each function declaration
     pub postfix: Option<String>,
-    /// The way to annotation this function as #[must_use].
+    /// The way to annotation this function as #[must_use]
     pub must_use: Option<String>,
     /// The style to layout the args
     pub args: Layout,
     /// The rename rule to apply to function args
     pub rename_args: Option<RenameRule>,
+    /// An optional macro to use when generating Swift function name attributes
+    pub swift_name_macro: Option<String>,
 }
 
 impl Default for FunctionConfig {
@@ -295,6 +297,7 @@ impl Default for FunctionConfig {
             must_use: None,
             args: Layout::Auto,
             rename_args: None,
+            swift_name_macro: None,
         }
     }
 }

--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -57,6 +57,20 @@ impl SynItemFnHelpers for syn::ItemFn {
     }
 }
 
+impl SynItemFnHelpers for syn::ImplItemMethod {
+    fn exported_name(&self) -> Option<String> {
+        self.attrs
+            .attr_name_value_lookup("export_name")
+            .or_else(|| {
+                if self.is_no_mangle() {
+                    Some(self.sig.ident.to_string())
+                } else {
+                    None
+                }
+            })
+    }
+}
+
 pub trait SynItemHelpers {
     /// Searches for attributes like `#[test]`.
     /// Example:
@@ -138,6 +152,7 @@ impl_syn_item_helper!(syn::ItemUse);
 impl_syn_item_helper!(syn::ItemStatic);
 impl_syn_item_helper!(syn::ItemConst);
 impl_syn_item_helper!(syn::ItemFn);
+impl_syn_item_helper!(syn::ImplItemMethod);
 impl_syn_item_helper!(syn::ItemMod);
 impl_syn_item_helper!(syn::ItemForeignMod);
 impl_syn_item_helper!(syn::ItemType);

--- a/tests/expectations/both/swift_name.c
+++ b/tests/expectations/both/swift_name.c
@@ -5,18 +5,49 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct Foo Foo;
+typedef struct Box_SelfTypeTestStruct Box_SelfTypeTestStruct;
 
-typedef struct FooRef {
-  Foo *ptr;
-} FooRef;
+typedef struct Opaque Opaque;
 
-FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+typedef struct PointerToOpaque {
+  Opaque *ptr;
+} PointerToOpaque;
 
-int32_t FooRef_doThing(FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+typedef struct SelfTypeTestStruct {
+  uint8_t times;
+} SelfTypeTestStruct;
 
-int32_t FooRef_getBar(FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+PointerToOpaque PointerToOpaque_create(uint8_t times) CF_SWIFT_NAME(PointerToOpaque.create(times:));
 
-void FooRef_setBar(FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+void PointerToOpaque_sayHello(PointerToOpaque self)
+/*a comment!*/ CF_SWIFT_NAME(PointerToOpaque.sayHello(self:));
 
-void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());
+void SelfTypeTestStruct_should_exist_annotated_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_by_name(self:));
+
+void SelfTypeTestStruct_should_exist_annotated_mut_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_by_name(self:));
+
+void SelfTypeTestStruct_should_exist_annotated_mut_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_self(self:));
+
+void SelfTypeTestStruct_should_exist_annotated_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_self(self:));
+
+void SelfTypeTestStruct_should_exist_mut_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_mut_unannotated(self:));
+
+void SelfTypeTestStruct_should_exist_ref(const SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref(self:));
+
+void SelfTypeTestStruct_should_exist_ref_mut(SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref_mut(self:));
+
+void SelfTypeTestStruct_should_exist_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_unannotated(self:));
+
+void SelfTypeTestStruct_should_not_exist_box(Box_SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_box(self:));
+
+void free_function_should_exist_annotated_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_by_name(test_struct:));
+
+void free_function_should_exist_annotated_mut_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_mut_by_name(test_struct:));
+
+void free_function_should_exist_ref(const SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref(test_struct:));
+
+void free_function_should_exist_ref_mut(SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref_mut(test_struct:));
+
+void free_function_should_not_exist_box(Box_SelfTypeTestStruct boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
+
+void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());

--- a/tests/expectations/both/swift_name.c
+++ b/tests/expectations/both/swift_name.c
@@ -1,0 +1,22 @@
+#define CF_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo Foo;
+
+typedef struct FooRef {
+  Foo *ptr;
+} FooRef;
+
+FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+
+int32_t FooRef_doThing(FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+
+int32_t FooRef_getBar(FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+
+void FooRef_setBar(FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+
+void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());

--- a/tests/expectations/both/swift_name.compat.c
+++ b/tests/expectations/both/swift_name.compat.c
@@ -1,0 +1,30 @@
+#define CF_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo Foo;
+
+typedef struct FooRef {
+  Foo *ptr;
+} FooRef;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+
+int32_t FooRef_doThing(FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+
+int32_t FooRef_getBar(FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+
+void FooRef_setBar(FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+
+void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/both/swift_name.compat.c
+++ b/tests/expectations/both/swift_name.compat.c
@@ -5,25 +5,56 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct Foo Foo;
+typedef struct Box_SelfTypeTestStruct Box_SelfTypeTestStruct;
 
-typedef struct FooRef {
-  Foo *ptr;
-} FooRef;
+typedef struct Opaque Opaque;
+
+typedef struct PointerToOpaque {
+  Opaque *ptr;
+} PointerToOpaque;
+
+typedef struct SelfTypeTestStruct {
+  uint8_t times;
+} SelfTypeTestStruct;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+PointerToOpaque PointerToOpaque_create(uint8_t times) CF_SWIFT_NAME(PointerToOpaque.create(times:));
 
-int32_t FooRef_doThing(FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+void PointerToOpaque_sayHello(PointerToOpaque self)
+/*a comment!*/ CF_SWIFT_NAME(PointerToOpaque.sayHello(self:));
 
-int32_t FooRef_getBar(FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+void SelfTypeTestStruct_should_exist_annotated_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_by_name(self:));
 
-void FooRef_setBar(FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+void SelfTypeTestStruct_should_exist_annotated_mut_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_by_name(self:));
 
-void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());
+void SelfTypeTestStruct_should_exist_annotated_mut_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_self(self:));
+
+void SelfTypeTestStruct_should_exist_annotated_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_self(self:));
+
+void SelfTypeTestStruct_should_exist_mut_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_mut_unannotated(self:));
+
+void SelfTypeTestStruct_should_exist_ref(const SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref(self:));
+
+void SelfTypeTestStruct_should_exist_ref_mut(SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref_mut(self:));
+
+void SelfTypeTestStruct_should_exist_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_unannotated(self:));
+
+void SelfTypeTestStruct_should_not_exist_box(Box_SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_box(self:));
+
+void free_function_should_exist_annotated_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_by_name(test_struct:));
+
+void free_function_should_exist_annotated_mut_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_mut_by_name(test_struct:));
+
+void free_function_should_exist_ref(const SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref(test_struct:));
+
+void free_function_should_exist_ref_mut(SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref_mut(test_struct:));
+
+void free_function_should_not_exist_box(Box_SelfTypeTestStruct boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
+
+void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/swift_name.c
+++ b/tests/expectations/swift_name.c
@@ -1,0 +1,22 @@
+#define CF_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo Foo;
+
+typedef struct {
+  Foo *ptr;
+} FooRef;
+
+FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+
+int32_t FooRef_doThing(FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+
+int32_t FooRef_getBar(FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+
+void FooRef_setBar(FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+
+void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());

--- a/tests/expectations/swift_name.c
+++ b/tests/expectations/swift_name.c
@@ -5,18 +5,49 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct Foo Foo;
+typedef struct Box_SelfTypeTestStruct Box_SelfTypeTestStruct;
+
+typedef struct Opaque Opaque;
 
 typedef struct {
-  Foo *ptr;
-} FooRef;
+  Opaque *ptr;
+} PointerToOpaque;
 
-FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+typedef struct {
+  uint8_t times;
+} SelfTypeTestStruct;
 
-int32_t FooRef_doThing(FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+PointerToOpaque PointerToOpaque_create(uint8_t times) CF_SWIFT_NAME(PointerToOpaque.create(times:));
 
-int32_t FooRef_getBar(FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+void PointerToOpaque_sayHello(PointerToOpaque self)
+/*a comment!*/ CF_SWIFT_NAME(PointerToOpaque.sayHello(self:));
 
-void FooRef_setBar(FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+void SelfTypeTestStruct_should_exist_annotated_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_by_name(self:));
 
-void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());
+void SelfTypeTestStruct_should_exist_annotated_mut_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_by_name(self:));
+
+void SelfTypeTestStruct_should_exist_annotated_mut_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_self(self:));
+
+void SelfTypeTestStruct_should_exist_annotated_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_self(self:));
+
+void SelfTypeTestStruct_should_exist_mut_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_mut_unannotated(self:));
+
+void SelfTypeTestStruct_should_exist_ref(const SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref(self:));
+
+void SelfTypeTestStruct_should_exist_ref_mut(SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref_mut(self:));
+
+void SelfTypeTestStruct_should_exist_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_unannotated(self:));
+
+void SelfTypeTestStruct_should_not_exist_box(Box_SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_box(self:));
+
+void free_function_should_exist_annotated_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_by_name(test_struct:));
+
+void free_function_should_exist_annotated_mut_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_mut_by_name(test_struct:));
+
+void free_function_should_exist_ref(const SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref(test_struct:));
+
+void free_function_should_exist_ref_mut(SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref_mut(test_struct:));
+
+void free_function_should_not_exist_box(Box_SelfTypeTestStruct boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
+
+void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());

--- a/tests/expectations/swift_name.compat.c
+++ b/tests/expectations/swift_name.compat.c
@@ -1,0 +1,30 @@
+#define CF_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo Foo;
+
+typedef struct {
+  Foo *ptr;
+} FooRef;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+
+int32_t FooRef_doThing(FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+
+int32_t FooRef_getBar(FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+
+void FooRef_setBar(FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+
+void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/swift_name.compat.c
+++ b/tests/expectations/swift_name.compat.c
@@ -5,25 +5,56 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct Foo Foo;
+typedef struct Box_SelfTypeTestStruct Box_SelfTypeTestStruct;
+
+typedef struct Opaque Opaque;
 
 typedef struct {
-  Foo *ptr;
-} FooRef;
+  Opaque *ptr;
+} PointerToOpaque;
+
+typedef struct {
+  uint8_t times;
+} SelfTypeTestStruct;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+PointerToOpaque PointerToOpaque_create(uint8_t times) CF_SWIFT_NAME(PointerToOpaque.create(times:));
 
-int32_t FooRef_doThing(FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+void PointerToOpaque_sayHello(PointerToOpaque self)
+/*a comment!*/ CF_SWIFT_NAME(PointerToOpaque.sayHello(self:));
 
-int32_t FooRef_getBar(FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+void SelfTypeTestStruct_should_exist_annotated_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_by_name(self:));
 
-void FooRef_setBar(FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+void SelfTypeTestStruct_should_exist_annotated_mut_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_by_name(self:));
 
-void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());
+void SelfTypeTestStruct_should_exist_annotated_mut_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_self(self:));
+
+void SelfTypeTestStruct_should_exist_annotated_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_self(self:));
+
+void SelfTypeTestStruct_should_exist_mut_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_mut_unannotated(self:));
+
+void SelfTypeTestStruct_should_exist_ref(const SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref(self:));
+
+void SelfTypeTestStruct_should_exist_ref_mut(SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref_mut(self:));
+
+void SelfTypeTestStruct_should_exist_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_unannotated(self:));
+
+void SelfTypeTestStruct_should_not_exist_box(Box_SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_box(self:));
+
+void free_function_should_exist_annotated_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_by_name(test_struct:));
+
+void free_function_should_exist_annotated_mut_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_mut_by_name(test_struct:));
+
+void free_function_should_exist_ref(const SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref(test_struct:));
+
+void free_function_should_exist_ref_mut(SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref_mut(test_struct:));
+
+void free_function_should_not_exist_box(Box_SelfTypeTestStruct boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
+
+void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/swift_name.cpp
+++ b/tests/expectations/swift_name.cpp
@@ -5,22 +5,54 @@
 #include <cstdlib>
 #include <new>
 
-struct Foo;
+template<typename T>
+struct Box;
 
-struct FooRef {
-  Foo *ptr;
+struct Opaque;
+
+struct PointerToOpaque {
+  Opaque *ptr;
+};
+
+struct SelfTypeTestStruct {
+  uint8_t times;
 };
 
 extern "C" {
 
-FooRef FooRef_create() CF_SWIFT_NAME(FooRef.create());
+PointerToOpaque PointerToOpaque_create(uint8_t times) CF_SWIFT_NAME(PointerToOpaque.create(times:));
 
-int32_t FooRef_doThing(FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+void PointerToOpaque_sayHello(PointerToOpaque self)
+/*a comment!*/ CF_SWIFT_NAME(PointerToOpaque.sayHello(self:));
 
-int32_t FooRef_getBar(FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+void SelfTypeTestStruct_should_exist_annotated_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_by_name(self:));
 
-void FooRef_setBar(FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+void SelfTypeTestStruct_should_exist_annotated_mut_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_by_name(self:));
 
-void do_the_thing() CF_SWIFT_NAME(do_the_thing());
+void SelfTypeTestStruct_should_exist_annotated_mut_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_self(self:));
+
+void SelfTypeTestStruct_should_exist_annotated_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_self(self:));
+
+void SelfTypeTestStruct_should_exist_mut_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_mut_unannotated(self:));
+
+void SelfTypeTestStruct_should_exist_ref(const SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref(self:));
+
+void SelfTypeTestStruct_should_exist_ref_mut(SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref_mut(self:));
+
+void SelfTypeTestStruct_should_exist_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_unannotated(self:));
+
+void SelfTypeTestStruct_should_not_exist_box(Box<SelfTypeTestStruct> self) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_box(self:));
+
+void free_function_should_exist_annotated_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_by_name(test_struct:));
+
+void free_function_should_exist_annotated_mut_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_mut_by_name(test_struct:));
+
+void free_function_should_exist_ref(const SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref(test_struct:));
+
+void free_function_should_exist_ref_mut(SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref_mut(test_struct:));
+
+void free_function_should_not_exist_box(Box<SelfTypeTestStruct> boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
+
+void rust_print_hello_world() CF_SWIFT_NAME(rust_print_hello_world());
 
 } // extern "C"

--- a/tests/expectations/swift_name.cpp
+++ b/tests/expectations/swift_name.cpp
@@ -1,0 +1,26 @@
+#define CF_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+
+struct Foo;
+
+struct FooRef {
+  Foo *ptr;
+};
+
+extern "C" {
+
+FooRef FooRef_create() CF_SWIFT_NAME(FooRef.create());
+
+int32_t FooRef_doThing(FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+
+int32_t FooRef_getBar(FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+
+void FooRef_setBar(FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+
+void do_the_thing() CF_SWIFT_NAME(do_the_thing());
+
+} // extern "C"

--- a/tests/expectations/tag/swift_name.c
+++ b/tests/expectations/tag/swift_name.c
@@ -1,0 +1,22 @@
+#define CF_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo;
+
+struct FooRef {
+  struct Foo *ptr;
+};
+
+struct FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+
+int32_t FooRef_doThing(struct FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+
+int32_t FooRef_getBar(struct FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+
+void FooRef_setBar(struct FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+
+void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());

--- a/tests/expectations/tag/swift_name.c
+++ b/tests/expectations/tag/swift_name.c
@@ -5,18 +5,49 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-struct Foo;
+struct Box_SelfTypeTestStruct;
 
-struct FooRef {
-  struct Foo *ptr;
+struct Opaque;
+
+struct PointerToOpaque {
+  struct Opaque *ptr;
 };
 
-struct FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+struct SelfTypeTestStruct {
+  uint8_t times;
+};
 
-int32_t FooRef_doThing(struct FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+struct PointerToOpaque PointerToOpaque_create(uint8_t times) CF_SWIFT_NAME(PointerToOpaque.create(times:));
 
-int32_t FooRef_getBar(struct FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+void PointerToOpaque_sayHello(struct PointerToOpaque self)
+/*a comment!*/ CF_SWIFT_NAME(PointerToOpaque.sayHello(self:));
 
-void FooRef_setBar(struct FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+void SelfTypeTestStruct_should_exist_annotated_by_name(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_by_name(self:));
 
-void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());
+void SelfTypeTestStruct_should_exist_annotated_mut_by_name(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_by_name(self:));
+
+void SelfTypeTestStruct_should_exist_annotated_mut_self(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_self(self:));
+
+void SelfTypeTestStruct_should_exist_annotated_self(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_self(self:));
+
+void SelfTypeTestStruct_should_exist_mut_unannotated(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_mut_unannotated(self:));
+
+void SelfTypeTestStruct_should_exist_ref(const struct SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref(self:));
+
+void SelfTypeTestStruct_should_exist_ref_mut(struct SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref_mut(self:));
+
+void SelfTypeTestStruct_should_exist_unannotated(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_unannotated(self:));
+
+void SelfTypeTestStruct_should_not_exist_box(struct Box_SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_box(self:));
+
+void free_function_should_exist_annotated_by_name(struct SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_by_name(test_struct:));
+
+void free_function_should_exist_annotated_mut_by_name(struct SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_mut_by_name(test_struct:));
+
+void free_function_should_exist_ref(const struct SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref(test_struct:));
+
+void free_function_should_exist_ref_mut(struct SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref_mut(test_struct:));
+
+void free_function_should_not_exist_box(struct Box_SelfTypeTestStruct boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
+
+void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());

--- a/tests/expectations/tag/swift_name.compat.c
+++ b/tests/expectations/tag/swift_name.compat.c
@@ -1,0 +1,30 @@
+#define CF_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo;
+
+struct FooRef {
+  struct Foo *ptr;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+struct FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+
+int32_t FooRef_doThing(struct FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+
+int32_t FooRef_getBar(struct FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+
+void FooRef_setBar(struct FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+
+void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/tag/swift_name.compat.c
+++ b/tests/expectations/tag/swift_name.compat.c
@@ -5,25 +5,56 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-struct Foo;
+struct Box_SelfTypeTestStruct;
 
-struct FooRef {
-  struct Foo *ptr;
+struct Opaque;
+
+struct PointerToOpaque {
+  struct Opaque *ptr;
+};
+
+struct SelfTypeTestStruct {
+  uint8_t times;
 };
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-struct FooRef FooRef_create(void) CF_SWIFT_NAME(FooRef.create());
+struct PointerToOpaque PointerToOpaque_create(uint8_t times) CF_SWIFT_NAME(PointerToOpaque.create(times:));
 
-int32_t FooRef_doThing(struct FooRef self) /*a comment!*/ CF_SWIFT_NAME(FooRef.doThing(self:));
+void PointerToOpaque_sayHello(struct PointerToOpaque self)
+/*a comment!*/ CF_SWIFT_NAME(PointerToOpaque.sayHello(self:));
 
-int32_t FooRef_getBar(struct FooRef self) CF_SWIFT_NAME(FooRef.getBar(self:));
+void SelfTypeTestStruct_should_exist_annotated_by_name(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_by_name(self:));
 
-void FooRef_setBar(struct FooRef self, int32_t bar) CF_SWIFT_NAME(FooRef.setBar(self:bar:));
+void SelfTypeTestStruct_should_exist_annotated_mut_by_name(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_by_name(self:));
 
-void do_the_thing(void) CF_SWIFT_NAME(do_the_thing());
+void SelfTypeTestStruct_should_exist_annotated_mut_self(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_self(self:));
+
+void SelfTypeTestStruct_should_exist_annotated_self(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_self(self:));
+
+void SelfTypeTestStruct_should_exist_mut_unannotated(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_mut_unannotated(self:));
+
+void SelfTypeTestStruct_should_exist_ref(const struct SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref(self:));
+
+void SelfTypeTestStruct_should_exist_ref_mut(struct SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref_mut(self:));
+
+void SelfTypeTestStruct_should_exist_unannotated(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_unannotated(self:));
+
+void SelfTypeTestStruct_should_not_exist_box(struct Box_SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_box(self:));
+
+void free_function_should_exist_annotated_by_name(struct SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_by_name(test_struct:));
+
+void free_function_should_exist_annotated_mut_by_name(struct SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_mut_by_name(test_struct:));
+
+void free_function_should_exist_ref(const struct SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref(test_struct:));
+
+void free_function_should_exist_ref_mut(struct SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref_mut(test_struct:));
+
+void free_function_should_not_exist_box(struct Box_SelfTypeTestStruct boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
+
+void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/rust/swift_name.rs
+++ b/tests/rust/swift_name.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+struct Foo {
+  bar: i32,
+}
+
+#[repr(C)]
+struct FooRef {
+  ptr: *mut Foo
+}
+
+impl FooRef {
+  #[export_name="FooRef_create"]
+  pub extern fn create() -> FooRef {
+    Box::into_raw(Box::new(Foo {
+      bar: 0
+    }))
+  }
+
+  #[export_name="FooRef_setBar"]
+  pub extern fn set_bar(self: FooRef, bar: i32) {
+    if let Some(nonnull) = std::ptr::NonNull::new(self.ptr) {
+      nonnull.as_mut().bar = bar;
+    }
+  }
+
+  #[export_name="FooRef_getBar"]
+  pub extern fn get_bar(self: FooRef) -> i32 {
+    if let Some(nonnull) = std::ptr::NonNull::new(self.ptr) {
+      nonnull.as_ref().bar
+    }
+  }
+
+  /// cbindgen:postfix=/*a comment!*/
+  #[export_name="FooRef_doThing"]
+  pub extern fn do_thing(self: FooRef) -> i32 {
+    if let Some(nonnull) = std::ptr::NonNull::new(self.ptr) {
+      nonnull.as_ref().bar
+    }
+  }
+}
+
+#[no_mangle]
+pub extern fn do_the_thing() {
+
+}

--- a/tests/rust/swift_name.rs
+++ b/tests/rust/swift_name.rs
@@ -1,46 +1,123 @@
-use std::sync::Arc;
-
-struct Foo {
-  bar: i32,
+#[export_name="rust_print_hello_world"]
+pub extern fn say_hello() {
+  println!("Hello, World!");
 }
 
 #[repr(C)]
-struct FooRef {
-  ptr: *mut Foo
+pub struct SelfTypeTestStruct {
+  times: u8,
 }
 
-impl FooRef {
-  #[export_name="FooRef_create"]
-  pub extern fn create() -> FooRef {
-    Box::into_raw(Box::new(Foo {
-      bar: 0
-    }))
+impl SelfTypeTestStruct {
+  #[export_name="SelfTypeTestStruct_should_exist_ref"]
+  #[no_mangle]
+  pub extern fn should_exist_ref(&self) {
+    println!("should_exist_ref");
   }
 
-  #[export_name="FooRef_setBar"]
-  pub extern fn set_bar(self: FooRef, bar: i32) {
-    if let Some(nonnull) = std::ptr::NonNull::new(self.ptr) {
-      nonnull.as_mut().bar = bar;
-    }
+  #[export_name="SelfTypeTestStruct_should_exist_ref_mut"]
+  #[no_mangle]
+  pub extern fn should_exist_ref_mut(&mut self) {
+    println!("should_exist_ref_mut");
   }
 
-  #[export_name="FooRef_getBar"]
-  pub extern fn get_bar(self: FooRef) -> i32 {
-    if let Some(nonnull) = std::ptr::NonNull::new(self.ptr) {
-      nonnull.as_ref().bar
-    }
+  #[export_name="SelfTypeTestStruct_should_not_exist_box"]
+  #[no_mangle]
+  pub extern fn should_not_exist_box(self: Box<SelfTypeTestStruct>) {
+    println!("should_not_exist_box");
   }
 
-  /// cbindgen:postfix=/*a comment!*/
-  #[export_name="FooRef_doThing"]
-  pub extern fn do_thing(self: FooRef) -> i32 {
-    if let Some(nonnull) = std::ptr::NonNull::new(self.ptr) {
-      nonnull.as_ref().bar
-    }
+  #[export_name="SelfTypeTestStruct_should_exist_annotated_self"]
+  #[no_mangle]
+  pub extern fn should_exist_annotated_self(self: Self) {
+    println!("should_exist_annotated_self");
+  }
+
+  #[export_name="SelfTypeTestStruct_should_exist_annotated_mut_self"]
+  #[no_mangle]
+  #[allow(unused_mut)]
+  pub extern fn should_exist_annotated_mut_self(mut self: Self) {
+    println!("should_exist_annotated_mut_self");
+  }
+
+  #[export_name="SelfTypeTestStruct_should_exist_annotated_by_name"]
+  #[no_mangle]
+  pub extern fn should_exist_annotated_by_name(self: SelfTypeTestStruct) {
+    println!("should_exist_annotated_by_name");
+  }
+
+  #[export_name="SelfTypeTestStruct_should_exist_annotated_mut_by_name"]
+  #[no_mangle]
+  #[allow(unused_mut)]
+  pub extern fn should_exist_annotated_mut_by_name(mut self: SelfTypeTestStruct) {
+    println!("should_exist_annotated_mut_by_name");
+  }
+
+  #[export_name="SelfTypeTestStruct_should_exist_unannotated"]
+  #[no_mangle]
+  pub extern fn should_exist_unannotated(self) {
+    println!("should_exist_unannotated");
+  }
+
+  #[export_name="SelfTypeTestStruct_should_exist_mut_unannotated"]
+  #[no_mangle]
+  #[allow(unused_mut)]
+  pub extern fn should_exist_mut_unannotated(mut self) {
+    println!("should_exist_mut_unannotated");
   }
 }
 
 #[no_mangle]
-pub extern fn do_the_thing() {
+#[allow(unused_variables)]
+pub extern fn free_function_should_exist_ref(test_struct: &SelfTypeTestStruct) {
+  println!("free_function_should_exist_ref");
+}
 
+#[no_mangle]
+#[allow(unused_variables)]
+pub extern fn free_function_should_exist_ref_mut(test_struct: &mut SelfTypeTestStruct) {
+  println!("free_function_should_exist_ref_mut");
+}
+
+#[no_mangle]
+#[allow(unused_variables)]
+pub extern fn free_function_should_not_exist_box(boxed: Box<SelfTypeTestStruct>) {
+  println!("free_function_should_not_exist_box");
+}
+
+#[no_mangle]
+#[allow(unused_variables)]
+pub extern fn free_function_should_exist_annotated_by_name(test_struct: SelfTypeTestStruct) {
+  println!("free_function_should_exist_annotated_by_name");
+}
+
+#[no_mangle]
+#[allow(unused_mut)]
+#[allow(unused_variables)]
+pub extern fn free_function_should_exist_annotated_mut_by_name(mut test_struct: SelfTypeTestStruct) {
+  println!("free_function_should_exist_annotated_mut_by_name");
+}
+
+struct Opaque {
+  times: u8
+}
+
+#[repr(C)]
+pub struct PointerToOpaque { ptr: *mut Opaque }
+
+impl PointerToOpaque {
+  #[export_name="PointerToOpaque_create"]
+  pub extern fn create(times: u8) -> PointerToOpaque {
+    PointerToOpaque { ptr: Box::into_raw(Box::new(Opaque { times })) }
+  }
+
+  /// cbindgen:postfix=/*a comment!*/
+  #[export_name="PointerToOpaque_sayHello"]
+  pub extern fn say_hello(self: PointerToOpaque) {
+    if let Some(nonnull) = std::ptr::NonNull::new(self.ptr) {
+      for _ in 0 .. unsafe { nonnull.as_ref().times } {
+        println!("Hello!")
+      }
+    }
+  }
 }

--- a/tests/rust/swift_name.toml
+++ b/tests/rust/swift_name.toml
@@ -1,0 +1,4 @@
+header = "#define CF_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))"
+
+[fn]
+swift_name_macro = "CF_SWIFT_NAME"


### PR DESCRIPTION
Fixes #420

- Added a parameter to `bindgen::ir::Function` to track attributes on generated functions. This is in addition to the existing `postfix` annotation, which seems to be used exclusively for user-provided strings, and so seems like a bad fit for auto-generated code.
- Added a config parameter under `FunctionConfig` to control whether swift function names are generated

No support for documentation annotations, but adding support for something like the following may be a good follow-up task:

```rust
impl FooRef {
  // cbindgen:swift-name=FooRef.doTheThing(with arg:)
  fn do_thing(arg: u8) {
  }
}
```