### PR TITLE
ty: Simplify Box<T> to *T

### DIFF
--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -389,6 +389,7 @@ impl Type {
         generic.simplify_standard_types();
 
         match path.name() {
+            "Box" => Some(Type::Ptr(Box::new(generic))),
             // FIXME(#223): This is not quite correct.
             "Option" if generic.is_repr_ptr() => Some(generic),
             "NonNull" => Some(Type::Ptr(Box::new(generic))),

--- a/tests/expectations/both/box.c
+++ b/tests/expectations/both/box.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct Foo_u64 {
+  float *a;
+  uint64_t *b;
+  Opaque *c;
+  uint64_t **d;
+  float **e;
+  Opaque **f;
+  uint64_t *g;
+  int32_t *h;
+} Foo_u64;
+
+void root(int32_t *arg, Foo_u64 *foo, Opaque **d);

--- a/tests/expectations/both/box.compat.c
+++ b/tests/expectations/both/box.compat.c
@@ -1,0 +1,27 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct Foo_u64 {
+  float *a;
+  uint64_t *b;
+  Opaque *c;
+  uint64_t **d;
+  float **e;
+  Opaque **f;
+  uint64_t *g;
+  int32_t *h;
+} Foo_u64;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(int32_t *arg, Foo_u64 *foo, Opaque **d);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/box.c
+++ b/tests/expectations/box.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct {
+  float *a;
+  uint64_t *b;
+  Opaque *c;
+  uint64_t **d;
+  float **e;
+  Opaque **f;
+  uint64_t *g;
+  int32_t *h;
+} Foo_u64;
+
+void root(int32_t *arg, Foo_u64 *foo, Opaque **d);

--- a/tests/expectations/box.compat.c
+++ b/tests/expectations/box.compat.c
@@ -1,0 +1,27 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct {
+  float *a;
+  uint64_t *b;
+  Opaque *c;
+  uint64_t **d;
+  float **e;
+  Opaque **f;
+  uint64_t *g;
+  int32_t *h;
+} Foo_u64;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(int32_t *arg, Foo_u64 *foo, Opaque **d);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/box.cpp
+++ b/tests/expectations/box.cpp
@@ -1,0 +1,24 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+
+struct Opaque;
+
+template<typename T>
+struct Foo {
+  float *a;
+  T *b;
+  Opaque *c;
+  T **d;
+  float **e;
+  Opaque **f;
+  T *g;
+  int32_t *h;
+};
+
+extern "C" {
+
+void root(int32_t *arg, Foo<uint64_t> *foo, Opaque **d);
+
+} // extern "C"

--- a/tests/expectations/tag/box.c
+++ b/tests/expectations/tag/box.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Opaque;
+
+struct Foo_u64 {
+  float *a;
+  uint64_t *b;
+  struct Opaque *c;
+  uint64_t **d;
+  float **e;
+  struct Opaque **f;
+  uint64_t *g;
+  int32_t *h;
+};
+
+void root(int32_t *arg, struct Foo_u64 *foo, struct Opaque **d);

--- a/tests/expectations/tag/box.compat.c
+++ b/tests/expectations/tag/box.compat.c
@@ -1,0 +1,27 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Opaque;
+
+struct Foo_u64 {
+  float *a;
+  uint64_t *b;
+  struct Opaque *c;
+  uint64_t **d;
+  float **e;
+  struct Opaque **f;
+  uint64_t *g;
+  int32_t *h;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(int32_t *arg, struct Foo_u64 *foo, struct Opaque **d);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/rust/box.rs
+++ b/tests/rust/box.rs
@@ -1,0 +1,16 @@
+struct Opaque;
+
+#[repr(C)]
+pub struct Foo<T> {
+    a: Box<f32>,
+    b: Box<T>,
+    c: Box<Opaque>,
+    d: Box<Box<T>>,
+    e: Box<Box<f32>>,
+    f: Box<Box<Opaque>>,
+    g: Option<Box<T>>,
+    h: Option<Box<i32>>,
+}
+
+#[no_mangle]
+pub extern "C" fn root(arg: Box<i32>, foo: *mut Foo<u64>, d: Box<Box<Opaque>>) {}


### PR DESCRIPTION
This simplifies `Box<T>` to `*T`, which enables use cases not previously supported.

`Box<T>` is guaranteed to have the same layout as `*T` as long as `T` is sized. This is documented in the current Rust beta. (See https://github.com/rust-lang/rust/pull/62514 and https://doc.rust-lang.org/beta/std/boxed/index.html#memory-layout.)

This does mean that the declarations we're emitting are incorrect for unsized types (eg `Box<[u8]>`), but it still seems like a strict improvement over old behavior.

This can also be a recipe for memory leaks if not handled carefully, but again, still seems better than previously.

Test cases are shamelessly copied and modified from the `NonNull` simplification.