### PR TITLE
Add [export.body_prepend] to config

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -488,7 +488,16 @@ renaming_overrides_prefixing = true
 "MyType" = "my_cool_type"
 "my_function" = "BetterFunctionName"
 
-# Table of things to add to the body of any struct, union, or enum that has the
+# Table of things to prepend to the body of any struct, union, or enum that has the
+# given name. This can be used to add things like methods which don't change ABI,
+# mark fields private, etc
+[export.body_prepend]
+"MyType" = """
+  MyType() = delete;
+private:
+"""
+
+# Table of things to append to the body of any struct, union, or enum that has the
 # given name. This can be used to add things like methods which don't change ABI.
 [export.body]
 "MyType" = """

--- a/docs.md
+++ b/docs.md
@@ -491,7 +491,7 @@ renaming_overrides_prefixing = true
 # Table of things to prepend to the body of any struct, union, or enum that has the
 # given name. This can be used to add things like methods which don't change ABI,
 # mark fields private, etc
-[export.body_prepend]
+[export.pre_body]
 "MyType" = """
   MyType() = delete;
 private:

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -232,9 +232,7 @@ impl ExportConfig {
     }
 
     pub(crate) fn pre_body(&self, path: &Path) -> Option<&str> {
-        self.pre_body
-            .get(path.name())
-            .map(|s| s.trim_matches('\n'))
+        self.pre_body.get(path.name()).map(|s| s.trim_matches('\n'))
     }
 
     pub(crate) fn post_body(&self, path: &Path) -> Option<&str> {

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -214,6 +214,8 @@ pub struct ExportConfig {
     pub exclude: Vec<String>,
     /// Table of name conversions to apply to item names
     pub rename: HashMap<String, String>,
+    /// Table of raw strings to prepend to the body of items.
+    pub body_prepend: HashMap<String, String>,
     /// Table of raw strings to append to the body of items.
     pub body: HashMap<String, String>,
     /// A prefix to add before the name of every item
@@ -229,7 +231,13 @@ impl ExportConfig {
         self.item_types.is_empty() || self.item_types.contains(&item_type)
     }
 
-    pub(crate) fn extra_body(&self, path: &Path) -> Option<&str> {
+    pub(crate) fn body_prepend(&self, path: &Path) -> Option<&str> {
+        self.body_prepend
+            .get(path.name())
+            .map(|s| s.trim_matches('\n'))
+    }
+
+    pub(crate) fn body_append(&self, path: &Path) -> Option<&str> {
         self.body.get(path.name()).map(|s| s.trim_matches('\n'))
     }
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -215,7 +215,7 @@ pub struct ExportConfig {
     /// Table of name conversions to apply to item names
     pub rename: HashMap<String, String>,
     /// Table of raw strings to prepend to the body of items.
-    pub body_prepend: HashMap<String, String>,
+    pub pre_body: HashMap<String, String>,
     /// Table of raw strings to append to the body of items.
     pub body: HashMap<String, String>,
     /// A prefix to add before the name of every item
@@ -231,13 +231,13 @@ impl ExportConfig {
         self.item_types.is_empty() || self.item_types.contains(&item_type)
     }
 
-    pub(crate) fn body_prepend(&self, path: &Path) -> Option<&str> {
-        self.body_prepend
+    pub(crate) fn pre_body(&self, path: &Path) -> Option<&str> {
+        self.pre_body
             .get(path.name())
             .map(|s| s.trim_matches('\n'))
     }
 
-    pub(crate) fn body_append(&self, path: &Path) -> Option<&str> {
+    pub(crate) fn post_body(&self, path: &Path) -> Option<&str> {
         self.body.get(path.name()).map(|s| s.trim_matches('\n'))
     }
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -1024,7 +1024,7 @@ impl Source for Enum {
                 }
             }
 
-            // Emit the body_append section, if relevant
+            // Emit the post_body section, if relevant
             if let Some(body) = config.export.post_body(&self.path) {
                 out.new_line();
                 out.write_raw_block(body);

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -577,6 +577,8 @@ impl Source for Enum {
             }
         }
         out.open_brace();
+
+        // Emit variants
         for (i, variant) in self.variants.iter().enumerate() {
             if i != 0 {
                 out.new_line()
@@ -642,6 +644,12 @@ impl Source for Enum {
                 }
 
                 out.open_brace();
+            }
+
+            // Emit the body_prepend section, if relevant
+            if let Some(body) = config.export.body_prepend(&self.path) {
+                out.write_raw_block(body);
+                out.new_line();
             }
 
             // C++ allows accessing only common initial sequence of union
@@ -1008,7 +1016,9 @@ impl Source for Enum {
                 }
             }
 
-            if let Some(body) = config.export.extra_body(&self.path) {
+            // Emit the body_append section, if relevant
+            if let Some(body) = config.export.body_append(&self.path) {
+                out.new_line();
                 out.write_raw_block(body);
             }
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -645,7 +645,7 @@ impl Source for Enum {
             }
 
             // Emit the body_prepend section, if relevant
-            if let Some(body) = config.export.body_prepend(&self.path) {
+            if let Some(body) = config.export.pre_body(&self.path) {
                 out.write_raw_block(body);
                 out.new_line();
             }
@@ -1015,7 +1015,7 @@ impl Source for Enum {
             }
 
             // Emit the body_append section, if relevant
-            if let Some(body) = config.export.body_append(&self.path) {
+            if let Some(body) = config.export.post_body(&self.path) {
                 out.new_line();
                 out.write_raw_block(body);
             }

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -577,8 +577,6 @@ impl Source for Enum {
             }
         }
         out.open_brace();
-
-        // Emit variants
         for (i, variant) in self.variants.iter().enumerate() {
             if i != 0 {
                 out.new_line()

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -527,6 +527,14 @@ impl Source for Enum {
 
             write!(out, " {}", self.export_name());
             out.open_brace();
+
+            // Emit the pre_body section, if relevant
+            // Only do this here if we're writing C++, since the struct that wraps everything is starting here.
+            // If we're writing C, we aren't wrapping the enum and variant structs definitions, so the actual enum struct willstart down below
+            if let Some(body) = config.export.pre_body(&self.path) {
+                out.write_raw_block(body);
+                out.new_line();
+            }
         }
 
         let enum_name = if let Some(ref tag) = self.tag {
@@ -642,12 +650,14 @@ impl Source for Enum {
                 }
 
                 out.open_brace();
-            }
 
-            // Emit the body_prepend section, if relevant
-            if let Some(body) = config.export.pre_body(&self.path) {
-                out.write_raw_block(body);
-                out.new_line();
+                // Emit the pre_body section, if relevant
+                // Only do this if we're writing C, since the struct is starting right here.
+                // For C++, the struct wraps all of the above variant structs too, and we write the pre_body section at the begining of that
+                if let Some(body) = config.export.pre_body(&self.path) {
+                    out.write_raw_block(body);
+                    out.new_line();
+                }
             }
 
             // C++ allows accessing only common initial sequence of union

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -452,6 +452,12 @@ impl Source for Struct {
 
         out.open_brace();
 
+        // Emit the body_prepend section, if relevant
+        if let Some(body) = config.export.body_prepend(&self.path) {
+            out.write_raw_block(body);
+            out.new_line();
+        }
+
         if config.documentation {
             out.write_vertical_source_list(&self.fields, ListType::Cap(";"));
         } else {
@@ -600,7 +606,9 @@ impl Source for Struct {
             }
         }
 
-        if let Some(body) = config.export.extra_body(&self.path) {
+        // Emit the body_append section, if relevant
+        if let Some(body) = config.export.body_append(&self.path) {
+            out.new_line();
             out.write_raw_block(body);
         }
 

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -452,8 +452,8 @@ impl Source for Struct {
 
         out.open_brace();
 
-        // Emit the body_prepend section, if relevant
-        if let Some(body) = config.export.body_prepend(&self.path) {
+        // Emit the pre_body section, if relevant
+        if let Some(body) = config.export.pre_body(&self.path) {
             out.write_raw_block(body);
             out.new_line();
         }
@@ -607,7 +607,7 @@ impl Source for Struct {
         }
 
         // Emit the body_append section, if relevant
-        if let Some(body) = config.export.body_append(&self.path) {
+        if let Some(body) = config.export.post_body(&self.path) {
             out.new_line();
             out.write_raw_block(body);
         }

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -606,7 +606,7 @@ impl Source for Struct {
             }
         }
 
-        // Emit the body_append section, if relevant
+        // Emit the post_body section, if relevant
         if let Some(body) = config.export.post_body(&self.path) {
             out.new_line();
             out.write_raw_block(body);

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -299,6 +299,12 @@ impl Source for Union {
 
         out.open_brace();
 
+        // Emit the body_prepend section, if relevant
+        if let Some(body) = config.export.body_prepend(&self.path) {
+            out.write_raw_block(body);
+            out.new_line();
+        }
+
         if config.documentation {
             out.write_vertical_source_list(&self.fields, ListType::Cap(";"));
         } else {
@@ -310,7 +316,9 @@ impl Source for Union {
             out.write_vertical_source_list(&vec[..], ListType::Cap(";"));
         }
 
-        if let Some(body) = config.export.extra_body(&self.path) {
+        // Emit the body_append section, if relevant
+        if let Some(body) = config.export.body_append(&self.path) {
+            out.new_line();
             out.write_raw_block(body);
         }
 

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -299,7 +299,7 @@ impl Source for Union {
 
         out.open_brace();
 
-        // Emit the body_prepend section, if relevant
+        // Emit the pre_body section, if relevant
         if let Some(body) = config.export.pre_body(&self.path) {
             out.write_raw_block(body);
             out.new_line();
@@ -316,7 +316,7 @@ impl Source for Union {
             out.write_vertical_source_list(&vec[..], ListType::Cap(";"));
         }
 
-        // Emit the body_append section, if relevant
+        // Emit the post_body section, if relevant
         if let Some(body) = config.export.post_body(&self.path) {
             out.new_line();
             out.write_raw_block(body);

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -300,7 +300,7 @@ impl Source for Union {
         out.open_brace();
 
         // Emit the body_prepend section, if relevant
-        if let Some(body) = config.export.body_prepend(&self.path) {
+        if let Some(body) = config.export.pre_body(&self.path) {
             out.write_raw_block(body);
             out.new_line();
         }
@@ -317,7 +317,7 @@ impl Source for Union {
         }
 
         // Emit the body_append section, if relevant
-        if let Some(body) = config.export.body_append(&self.path) {
+        if let Some(body) = config.export.post_body(&self.path) {
             out.new_line();
             out.write_raw_block(body);
         }

--- a/src/bindgen/writer.rs
+++ b/src/bindgen/writer.rs
@@ -176,7 +176,6 @@ impl<'a, F: Write> SourceWriter<'a, F> {
     }
 
     pub fn write_raw_block(&mut self, block: &str) {
-        self.new_line();
         self.line_started = true;
         write!(self, "{}", block);
     }

--- a/tests/expectations/body.c
+++ b/tests/expectations/body.c
@@ -9,6 +9,12 @@ typedef enum {
   Baz1,
 } MyCLikeEnum;
 
+typedef enum {
+  Foo1_Prepended,
+  Bar1_Prepended,
+  Baz1_Prepended,
+} MyCLikeEnum_Prepended;
+
 typedef struct {
   int32_t i;
 #ifdef __cplusplus
@@ -47,4 +53,48 @@ typedef union {
   int32_t extra_member; // yolo
 } MyUnion;
 
-void root(MyFancyStruct s, MyFancyEnum e, MyCLikeEnum c, MyUnion u);
+typedef struct {
+#ifdef __cplusplus
+  MyFancyStruct_Prepended() = delete;
+private:
+#endif
+  int32_t i;
+} MyFancyStruct_Prepended;
+
+typedef enum {
+  Foo_Prepended,
+  Bar_Prepended,
+  Baz_Prepended,
+} MyFancyEnum_Prepended_Tag;
+
+typedef struct {
+  int32_t _0;
+} Bar_Prepended_Body;
+
+typedef struct {
+  int32_t _0;
+} Baz_Prepended_Body;
+
+typedef struct {
+  // important information about this enum
+  MyFancyEnum_Prepended_Tag tag;
+  union {
+    Bar_Prepended_Body bar_prepended;
+    Baz_Prepended_Body baz_prepended;
+  };
+} MyFancyEnum_Prepended;
+
+typedef union {
+  int32_t extra_member; // yolo
+  float f;
+  uint32_t u;
+} MyUnion_Prepended;
+
+void root(MyFancyStruct s,
+          MyFancyEnum e,
+          MyCLikeEnum c,
+          MyUnion u,
+          MyFancyStruct_Prepended sp,
+          MyFancyEnum_Prepended ep,
+          MyCLikeEnum_Prepended cp,
+          MyUnion_Prepended up);

--- a/tests/expectations/body.c
+++ b/tests/expectations/body.c
@@ -76,7 +76,9 @@ typedef struct {
 } Baz_Prepended_Body;
 
 typedef struct {
-  // important information about this enum
+  #ifdef __cplusplus
+    inline void wohoo();
+  #endif
   MyFancyEnum_Prepended_Tag tag;
   union {
     Bar_Prepended_Body bar_prepended;

--- a/tests/expectations/body.c
+++ b/tests/expectations/body.c
@@ -55,8 +55,7 @@ typedef union {
 
 typedef struct {
 #ifdef __cplusplus
-  MyFancyStruct_Prepended() = delete;
-private:
+  inline void prepended_wohoo();
 #endif
   int32_t i;
 } MyFancyStruct_Prepended;

--- a/tests/expectations/body.compat.c
+++ b/tests/expectations/body.compat.c
@@ -76,7 +76,9 @@ typedef struct {
 } Baz_Prepended_Body;
 
 typedef struct {
-  // important information about this enum
+  #ifdef __cplusplus
+    inline void wohoo();
+  #endif
   MyFancyEnum_Prepended_Tag tag;
   union {
     Bar_Prepended_Body bar_prepended;

--- a/tests/expectations/body.compat.c
+++ b/tests/expectations/body.compat.c
@@ -55,8 +55,7 @@ typedef union {
 
 typedef struct {
 #ifdef __cplusplus
-  MyFancyStruct_Prepended() = delete;
-private:
+  inline void prepended_wohoo();
 #endif
   int32_t i;
 } MyFancyStruct_Prepended;

--- a/tests/expectations/body.compat.c
+++ b/tests/expectations/body.compat.c
@@ -9,6 +9,12 @@ typedef enum {
   Baz1,
 } MyCLikeEnum;
 
+typedef enum {
+  Foo1_Prepended,
+  Bar1_Prepended,
+  Baz1_Prepended,
+} MyCLikeEnum_Prepended;
+
 typedef struct {
   int32_t i;
 #ifdef __cplusplus
@@ -47,11 +53,55 @@ typedef union {
   int32_t extra_member; // yolo
 } MyUnion;
 
+typedef struct {
+#ifdef __cplusplus
+  MyFancyStruct_Prepended() = delete;
+private:
+#endif
+  int32_t i;
+} MyFancyStruct_Prepended;
+
+typedef enum {
+  Foo_Prepended,
+  Bar_Prepended,
+  Baz_Prepended,
+} MyFancyEnum_Prepended_Tag;
+
+typedef struct {
+  int32_t _0;
+} Bar_Prepended_Body;
+
+typedef struct {
+  int32_t _0;
+} Baz_Prepended_Body;
+
+typedef struct {
+  // important information about this enum
+  MyFancyEnum_Prepended_Tag tag;
+  union {
+    Bar_Prepended_Body bar_prepended;
+    Baz_Prepended_Body baz_prepended;
+  };
+} MyFancyEnum_Prepended;
+
+typedef union {
+  int32_t extra_member; // yolo
+  float f;
+  uint32_t u;
+} MyUnion_Prepended;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(MyFancyStruct s, MyFancyEnum e, MyCLikeEnum c, MyUnion u);
+void root(MyFancyStruct s,
+          MyFancyEnum e,
+          MyCLikeEnum c,
+          MyUnion u,
+          MyFancyStruct_Prepended sp,
+          MyFancyEnum_Prepended ep,
+          MyCLikeEnum_Prepended cp,
+          MyUnion_Prepended up);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/body.cpp
+++ b/tests/expectations/body.cpp
@@ -9,6 +9,12 @@ enum class MyCLikeEnum {
   Baz1,
 };
 
+enum class MyCLikeEnum_Prepended {
+  Foo1_Prepended,
+  Bar1_Prepended,
+  Baz1_Prepended,
+};
+
 struct MyFancyStruct {
   int32_t i;
 #ifdef __cplusplus
@@ -47,8 +53,52 @@ union MyUnion {
   int32_t extra_member; // yolo
 };
 
+struct MyFancyStruct_Prepended {
+#ifdef __cplusplus
+  MyFancyStruct_Prepended() = delete;
+private:
+#endif
+  int32_t i;
+};
+
+struct MyFancyEnum_Prepended {
+  enum class Tag {
+    Foo_Prepended,
+    Bar_Prepended,
+    Baz_Prepended,
+  };
+
+  struct Bar_Prepended_Body {
+    int32_t _0;
+  };
+
+  struct Baz_Prepended_Body {
+    int32_t _0;
+  };
+
+  // important information about this enum
+  Tag tag;
+  union {
+    Bar_Prepended_Body bar_prepended;
+    Baz_Prepended_Body baz_prepended;
+  };
+};
+
+union MyUnion_Prepended {
+  int32_t extra_member; // yolo
+  float f;
+  uint32_t u;
+};
+
 extern "C" {
 
-void root(MyFancyStruct s, MyFancyEnum e, MyCLikeEnum c, MyUnion u);
+void root(MyFancyStruct s,
+          MyFancyEnum e,
+          MyCLikeEnum c,
+          MyUnion u,
+          MyFancyStruct_Prepended sp,
+          MyFancyEnum_Prepended ep,
+          MyCLikeEnum_Prepended cp,
+          MyUnion_Prepended up);
 
 } // extern "C"

--- a/tests/expectations/body.cpp
+++ b/tests/expectations/body.cpp
@@ -61,6 +61,9 @@ struct MyFancyStruct_Prepended {
 };
 
 struct MyFancyEnum_Prepended {
+  #ifdef __cplusplus
+    inline void wohoo();
+  #endif
   enum class Tag {
     Foo_Prepended,
     Bar_Prepended,
@@ -75,9 +78,6 @@ struct MyFancyEnum_Prepended {
     int32_t _0;
   };
 
-  #ifdef __cplusplus
-    inline void wohoo();
-  #endif
   Tag tag;
   union {
     Bar_Prepended_Body bar_prepended;

--- a/tests/expectations/body.cpp
+++ b/tests/expectations/body.cpp
@@ -76,7 +76,9 @@ struct MyFancyEnum_Prepended {
     int32_t _0;
   };
 
-  // important information about this enum
+  #ifdef __cplusplus
+    inline void wohoo();
+  #endif
   Tag tag;
   union {
     Bar_Prepended_Body bar_prepended;

--- a/tests/expectations/body.cpp
+++ b/tests/expectations/body.cpp
@@ -55,8 +55,7 @@ union MyUnion {
 
 struct MyFancyStruct_Prepended {
 #ifdef __cplusplus
-  MyFancyStruct_Prepended() = delete;
-private:
+  inline void prepended_wohoo();
 #endif
   int32_t i;
 };

--- a/tests/expectations/both/body.c
+++ b/tests/expectations/both/body.c
@@ -9,6 +9,12 @@ typedef enum MyCLikeEnum {
   Baz1,
 } MyCLikeEnum;
 
+typedef enum MyCLikeEnum_Prepended {
+  Foo1_Prepended,
+  Bar1_Prepended,
+  Baz1_Prepended,
+} MyCLikeEnum_Prepended;
+
 typedef struct MyFancyStruct {
   int32_t i;
 #ifdef __cplusplus
@@ -47,4 +53,50 @@ typedef union MyUnion {
   int32_t extra_member; // yolo
 } MyUnion;
 
-void root(MyFancyStruct s, MyFancyEnum e, MyCLikeEnum c, MyUnion u);
+typedef struct MyFancyStruct_Prepended {
+#ifdef __cplusplus
+  MyFancyStruct_Prepended() = delete;
+private:
+#endif
+  int32_t i;
+} MyFancyStruct_Prepended;
+
+typedef enum MyFancyEnum_Prepended_Tag {
+  Foo_Prepended,
+  Bar_Prepended,
+  Baz_Prepended,
+} MyFancyEnum_Prepended_Tag;
+
+typedef struct Bar_Prepended_Body {
+  int32_t _0;
+} Bar_Prepended_Body;
+
+typedef struct Baz_Prepended_Body {
+  int32_t _0;
+} Baz_Prepended_Body;
+
+typedef struct MyFancyEnum_Prepended {
+  #ifdef __cplusplus
+    inline void wohoo();
+  #endif
+  MyFancyEnum_Prepended_Tag tag;
+  union {
+    Bar_Prepended_Body bar_prepended;
+    Baz_Prepended_Body baz_prepended;
+  };
+} MyFancyEnum_Prepended;
+
+typedef union MyUnion_Prepended {
+  int32_t extra_member; // yolo
+  float f;
+  uint32_t u;
+} MyUnion_Prepended;
+
+void root(MyFancyStruct s,
+          MyFancyEnum e,
+          MyCLikeEnum c,
+          MyUnion u,
+          MyFancyStruct_Prepended sp,
+          MyFancyEnum_Prepended ep,
+          MyCLikeEnum_Prepended cp,
+          MyUnion_Prepended up);

--- a/tests/expectations/both/body.c
+++ b/tests/expectations/both/body.c
@@ -55,8 +55,7 @@ typedef union MyUnion {
 
 typedef struct MyFancyStruct_Prepended {
 #ifdef __cplusplus
-  MyFancyStruct_Prepended() = delete;
-private:
+  inline void prepended_wohoo();
 #endif
   int32_t i;
 } MyFancyStruct_Prepended;

--- a/tests/expectations/both/body.compat.c
+++ b/tests/expectations/both/body.compat.c
@@ -55,8 +55,7 @@ typedef union MyUnion {
 
 typedef struct MyFancyStruct_Prepended {
 #ifdef __cplusplus
-  MyFancyStruct_Prepended() = delete;
-private:
+  inline void prepended_wohoo();
 #endif
   int32_t i;
 } MyFancyStruct_Prepended;

--- a/tests/expectations/both/body.compat.c
+++ b/tests/expectations/both/body.compat.c
@@ -9,6 +9,12 @@ typedef enum MyCLikeEnum {
   Baz1,
 } MyCLikeEnum;
 
+typedef enum MyCLikeEnum_Prepended {
+  Foo1_Prepended,
+  Bar1_Prepended,
+  Baz1_Prepended,
+} MyCLikeEnum_Prepended;
+
 typedef struct MyFancyStruct {
   int32_t i;
 #ifdef __cplusplus
@@ -47,11 +53,57 @@ typedef union MyUnion {
   int32_t extra_member; // yolo
 } MyUnion;
 
+typedef struct MyFancyStruct_Prepended {
+#ifdef __cplusplus
+  MyFancyStruct_Prepended() = delete;
+private:
+#endif
+  int32_t i;
+} MyFancyStruct_Prepended;
+
+typedef enum MyFancyEnum_Prepended_Tag {
+  Foo_Prepended,
+  Bar_Prepended,
+  Baz_Prepended,
+} MyFancyEnum_Prepended_Tag;
+
+typedef struct Bar_Prepended_Body {
+  int32_t _0;
+} Bar_Prepended_Body;
+
+typedef struct Baz_Prepended_Body {
+  int32_t _0;
+} Baz_Prepended_Body;
+
+typedef struct MyFancyEnum_Prepended {
+  #ifdef __cplusplus
+    inline void wohoo();
+  #endif
+  MyFancyEnum_Prepended_Tag tag;
+  union {
+    Bar_Prepended_Body bar_prepended;
+    Baz_Prepended_Body baz_prepended;
+  };
+} MyFancyEnum_Prepended;
+
+typedef union MyUnion_Prepended {
+  int32_t extra_member; // yolo
+  float f;
+  uint32_t u;
+} MyUnion_Prepended;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(MyFancyStruct s, MyFancyEnum e, MyCLikeEnum c, MyUnion u);
+void root(MyFancyStruct s,
+          MyFancyEnum e,
+          MyCLikeEnum c,
+          MyUnion u,
+          MyFancyStruct_Prepended sp,
+          MyFancyEnum_Prepended ep,
+          MyCLikeEnum_Prepended cp,
+          MyUnion_Prepended up);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/tag/body.c
+++ b/tests/expectations/tag/body.c
@@ -9,6 +9,12 @@ enum MyCLikeEnum {
   Baz1,
 };
 
+enum MyCLikeEnum_Prepended {
+  Foo1_Prepended,
+  Bar1_Prepended,
+  Baz1_Prepended,
+};
+
 struct MyFancyStruct {
   int32_t i;
 #ifdef __cplusplus
@@ -47,4 +53,50 @@ union MyUnion {
   int32_t extra_member; // yolo
 };
 
-void root(struct MyFancyStruct s, struct MyFancyEnum e, enum MyCLikeEnum c, union MyUnion u);
+struct MyFancyStruct_Prepended {
+#ifdef __cplusplus
+  MyFancyStruct_Prepended() = delete;
+private:
+#endif
+  int32_t i;
+};
+
+enum MyFancyEnum_Prepended_Tag {
+  Foo_Prepended,
+  Bar_Prepended,
+  Baz_Prepended,
+};
+
+struct Bar_Prepended_Body {
+  int32_t _0;
+};
+
+struct Baz_Prepended_Body {
+  int32_t _0;
+};
+
+struct MyFancyEnum_Prepended {
+  #ifdef __cplusplus
+    inline void wohoo();
+  #endif
+  enum MyFancyEnum_Prepended_Tag tag;
+  union {
+    struct Bar_Prepended_Body bar_prepended;
+    struct Baz_Prepended_Body baz_prepended;
+  };
+};
+
+union MyUnion_Prepended {
+  int32_t extra_member; // yolo
+  float f;
+  uint32_t u;
+};
+
+void root(struct MyFancyStruct s,
+          struct MyFancyEnum e,
+          enum MyCLikeEnum c,
+          union MyUnion u,
+          struct MyFancyStruct_Prepended sp,
+          struct MyFancyEnum_Prepended ep,
+          enum MyCLikeEnum_Prepended cp,
+          union MyUnion_Prepended up);

--- a/tests/expectations/tag/body.c
+++ b/tests/expectations/tag/body.c
@@ -55,8 +55,7 @@ union MyUnion {
 
 struct MyFancyStruct_Prepended {
 #ifdef __cplusplus
-  MyFancyStruct_Prepended() = delete;
-private:
+  inline void prepended_wohoo();
 #endif
   int32_t i;
 };

--- a/tests/expectations/tag/body.compat.c
+++ b/tests/expectations/tag/body.compat.c
@@ -9,6 +9,12 @@ enum MyCLikeEnum {
   Baz1,
 };
 
+enum MyCLikeEnum_Prepended {
+  Foo1_Prepended,
+  Bar1_Prepended,
+  Baz1_Prepended,
+};
+
 struct MyFancyStruct {
   int32_t i;
 #ifdef __cplusplus
@@ -47,11 +53,57 @@ union MyUnion {
   int32_t extra_member; // yolo
 };
 
+struct MyFancyStruct_Prepended {
+#ifdef __cplusplus
+  MyFancyStruct_Prepended() = delete;
+private:
+#endif
+  int32_t i;
+};
+
+enum MyFancyEnum_Prepended_Tag {
+  Foo_Prepended,
+  Bar_Prepended,
+  Baz_Prepended,
+};
+
+struct Bar_Prepended_Body {
+  int32_t _0;
+};
+
+struct Baz_Prepended_Body {
+  int32_t _0;
+};
+
+struct MyFancyEnum_Prepended {
+  #ifdef __cplusplus
+    inline void wohoo();
+  #endif
+  enum MyFancyEnum_Prepended_Tag tag;
+  union {
+    struct Bar_Prepended_Body bar_prepended;
+    struct Baz_Prepended_Body baz_prepended;
+  };
+};
+
+union MyUnion_Prepended {
+  int32_t extra_member; // yolo
+  float f;
+  uint32_t u;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(struct MyFancyStruct s, struct MyFancyEnum e, enum MyCLikeEnum c, union MyUnion u);
+void root(struct MyFancyStruct s,
+          struct MyFancyEnum e,
+          enum MyCLikeEnum c,
+          union MyUnion u,
+          struct MyFancyStruct_Prepended sp,
+          struct MyFancyEnum_Prepended ep,
+          enum MyCLikeEnum_Prepended cp,
+          union MyUnion_Prepended up);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/tag/body.compat.c
+++ b/tests/expectations/tag/body.compat.c
@@ -55,8 +55,7 @@ union MyUnion {
 
 struct MyFancyStruct_Prepended {
 #ifdef __cplusplus
-  MyFancyStruct_Prepended() = delete;
-private:
+  inline void prepended_wohoo();
 #endif
   int32_t i;
 };

--- a/tests/rust/body.rs
+++ b/tests/rust/body.rs
@@ -24,5 +24,32 @@ pub union MyUnion {
     pub u: u32,
 }
 
+
+#[repr(C)]
+pub struct MyFancyStruct_Prepended {
+    i: i32,
+}
+
+#[repr(C)]
+pub enum MyFancyEnum_Prepended {
+    Foo_Prepended,
+    Bar_Prepended(i32),
+    Baz_Prepended(i32),
+}
+
+#[repr(C)]
+pub enum MyCLikeEnum_Prepended {
+    Foo1_Prepended,
+    Bar1_Prepended,
+    Baz1_Prepended,
+}
+
+#[repr(C)]
+pub union MyUnion_Prepended {
+    pub f: f32,
+    pub u: u32,
+}
+
+
 #[no_mangle]
-pub extern "C" fn root(s: MyFancyStruct, e: MyFancyEnum, c: MyCLikeEnum, u: MyUnion) {}
+pub extern "C" fn root(s: MyFancyStruct, e: MyFancyEnum, c: MyCLikeEnum, u: MyUnion, sp: MyFancyStruct_Prepended, ep: MyFancyEnum_Prepended, cp: MyCLikeEnum_Prepended, up: MyUnion_Prepended) {}

--- a/tests/rust/body.toml
+++ b/tests/rust/body.toml
@@ -19,7 +19,7 @@
   int32_t extra_member; // yolo
 """
 
-[export.body_prepend]
+[export.pre_body]
 "MyFancyStruct_Prepended" = """
 #ifdef __cplusplus
   inline void prepended_wohoo();

--- a/tests/rust/body.toml
+++ b/tests/rust/body.toml
@@ -18,3 +18,26 @@
 "MyUnion" = """
   int32_t extra_member; // yolo
 """
+
+[export.body_prepend]
+"MyFancyStruct_Prepended" = """
+#ifdef __cplusplus
+  MyFancyStruct_Prepended() = delete;
+private:
+#endif
+"""
+
+"MyFancyEnum_Prepended" = """
+  #ifdef __cplusplus
+    inline void wohoo();
+  #endif
+"""
+
+"MyCLikeEnum_Prepended" = """
+  BogusVariantForSerializationForExample,
+"""
+
+"MyUnion_Prepended" = """
+  int32_t extra_member; // yolo
+"""
+

--- a/tests/rust/body.toml
+++ b/tests/rust/body.toml
@@ -22,8 +22,7 @@
 [export.body_prepend]
 "MyFancyStruct_Prepended" = """
 #ifdef __cplusplus
-  MyFancyStruct_Prepended() = delete;
-private:
+  inline void prepended_wohoo();
 #endif
 """
 


### PR DESCRIPTION
This change allows users to prepend text to the body of structs etc. Previously, users could only append, and this change allows both.

While working on this, I noticed that appending for untagged enums doesn't seem to work:

It's in the test toml file:
```
"MyCLikeEnum" = """
  BogusVariantForSerializationForExample,
"""
```

But I looked through the history and `BogusVariantForSerializationForExample` has never appeared in any of the expected outputs. If this is a bug, I can open another pull request to fix it.

Fixes #448 