### PR TITLE
Enable most warnings, and fix findings.

### DIFF
--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -160,7 +160,7 @@ impl Literal {
                     syn::Lit::Byte(ref value) => Ok(Literal::Expr(format!("{}", value.value()))),
                     syn::Lit::Char(ref value) => Ok(Literal::Expr(match value.value() as u32 {
                         0..=255 => format!("'{}'", value.value().escape_default()),
-                        other_code => format!(r"L'\u{:X}'", other_code),
+                        other_code => format!(r"L'\U{:08X}'", other_code),
                     })),
                     syn::Lit::Int(ref value) => {
                         Ok(Literal::Expr(value.base10_digits().to_string()))

--- a/tests/expectations/both/constant.c
+++ b/tests/expectations/both/constant.c
@@ -5,11 +5,11 @@
 
 #define DELIMITER ':'
 
-#define EQUID L'\u10083'
+#define EQUID L'\U00010083'
 
 #define FOO 10
 
-#define HEART L'\u2764'
+#define HEART L'\U00002764'
 
 #define LEFTCURLY '{'
 

--- a/tests/expectations/both/constant.compat.c
+++ b/tests/expectations/both/constant.compat.c
@@ -5,11 +5,11 @@
 
 #define DELIMITER ':'
 
-#define EQUID L'\u10083'
+#define EQUID L'\U00010083'
 
 #define FOO 10
 
-#define HEART L'\u2764'
+#define HEART L'\U00002764'
 
 #define LEFTCURLY '{'
 

--- a/tests/expectations/both/prefix.c
+++ b/tests/expectations/both/prefix.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define PREFIX_LEN 42
+#define PREFIX_LEN 22
 
-#define PREFIX_X (42 << 42)
+#define PREFIX_X (22 << 22)
 
 #define PREFIX_Y (PREFIX_X + PREFIX_X)
 
 typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
-typedef int32_t PREFIX_ValuedLenArray[42];
+typedef int32_t PREFIX_ValuedLenArray[22];
 
 enum PREFIX_AbsoluteFontWeight_Tag {
   Weight,

--- a/tests/expectations/both/prefix.compat.c
+++ b/tests/expectations/both/prefix.compat.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define PREFIX_LEN 42
+#define PREFIX_LEN 22
 
-#define PREFIX_X (42 << 42)
+#define PREFIX_X (22 << 22)
 
 #define PREFIX_Y (PREFIX_X + PREFIX_X)
 
 typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
-typedef int32_t PREFIX_ValuedLenArray[42];
+typedef int32_t PREFIX_ValuedLenArray[22];
 
 enum PREFIX_AbsoluteFontWeight_Tag
 #ifdef __cplusplus

--- a/tests/expectations/constant.c
+++ b/tests/expectations/constant.c
@@ -5,11 +5,11 @@
 
 #define DELIMITER ':'
 
-#define EQUID L'\u10083'
+#define EQUID L'\U00010083'
 
 #define FOO 10
 
-#define HEART L'\u2764'
+#define HEART L'\U00002764'
 
 #define LEFTCURLY '{'
 

--- a/tests/expectations/constant.compat.c
+++ b/tests/expectations/constant.compat.c
@@ -5,11 +5,11 @@
 
 #define DELIMITER ':'
 
-#define EQUID L'\u10083'
+#define EQUID L'\U00010083'
 
 #define FOO 10
 
-#define HEART L'\u2764'
+#define HEART L'\U00002764'
 
 #define LEFTCURLY '{'
 

--- a/tests/expectations/constant.cpp
+++ b/tests/expectations/constant.cpp
@@ -5,11 +5,11 @@
 
 static const uint32_t DELIMITER = ':';
 
-static const uint32_t EQUID = L'\u10083';
+static const uint32_t EQUID = L'\U00010083';
 
 static const int32_t FOO = 10;
 
-static const uint32_t HEART = L'\u2764';
+static const uint32_t HEART = L'\U00002764';
 
 static const uint32_t LEFTCURLY = '{';
 

--- a/tests/expectations/prefix.c
+++ b/tests/expectations/prefix.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define PREFIX_LEN 42
+#define PREFIX_LEN 22
 
-#define PREFIX_X (42 << 42)
+#define PREFIX_X (22 << 22)
 
 #define PREFIX_Y (PREFIX_X + PREFIX_X)
 
 typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
-typedef int32_t PREFIX_ValuedLenArray[42];
+typedef int32_t PREFIX_ValuedLenArray[22];
 
 enum PREFIX_AbsoluteFontWeight_Tag {
   Weight,

--- a/tests/expectations/prefix.compat.c
+++ b/tests/expectations/prefix.compat.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define PREFIX_LEN 42
+#define PREFIX_LEN 22
 
-#define PREFIX_X (42 << 42)
+#define PREFIX_X (22 << 22)
 
 #define PREFIX_Y (PREFIX_X + PREFIX_X)
 
 typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
-typedef int32_t PREFIX_ValuedLenArray[42];
+typedef int32_t PREFIX_ValuedLenArray[22];
 
 enum PREFIX_AbsoluteFontWeight_Tag
 #ifdef __cplusplus

--- a/tests/expectations/prefix.cpp
+++ b/tests/expectations/prefix.cpp
@@ -3,15 +3,15 @@
 #include <cstdlib>
 #include <new>
 
-static const int32_t PREFIX_LEN = 42;
+static const int32_t PREFIX_LEN = 22;
 
-static const int64_t PREFIX_X = (42 << 42);
+static const int64_t PREFIX_X = (22 << 22);
 
 static const int64_t PREFIX_Y = (PREFIX_X + PREFIX_X);
 
 using PREFIX_NamedLenArray = int32_t[PREFIX_LEN];
 
-using PREFIX_ValuedLenArray = int32_t[42];
+using PREFIX_ValuedLenArray = int32_t[22];
 
 union PREFIX_AbsoluteFontWeight {
   enum class Tag : uint8_t {

--- a/tests/expectations/tag/constant.c
+++ b/tests/expectations/tag/constant.c
@@ -5,11 +5,11 @@
 
 #define DELIMITER ':'
 
-#define EQUID L'\u10083'
+#define EQUID L'\U00010083'
 
 #define FOO 10
 
-#define HEART L'\u2764'
+#define HEART L'\U00002764'
 
 #define LEFTCURLY '{'
 

--- a/tests/expectations/tag/constant.compat.c
+++ b/tests/expectations/tag/constant.compat.c
@@ -5,11 +5,11 @@
 
 #define DELIMITER ':'
 
-#define EQUID L'\u10083'
+#define EQUID L'\U00010083'
 
 #define FOO 10
 
-#define HEART L'\u2764'
+#define HEART L'\U00002764'
 
 #define LEFTCURLY '{'
 

--- a/tests/expectations/tag/prefix.c
+++ b/tests/expectations/tag/prefix.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define PREFIX_LEN 42
+#define PREFIX_LEN 22
 
-#define PREFIX_X (42 << 42)
+#define PREFIX_X (22 << 22)
 
 #define PREFIX_Y (PREFIX_X + PREFIX_X)
 
 typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
-typedef int32_t PREFIX_ValuedLenArray[42];
+typedef int32_t PREFIX_ValuedLenArray[22];
 
 enum PREFIX_AbsoluteFontWeight_Tag {
   Weight,

--- a/tests/expectations/tag/prefix.compat.c
+++ b/tests/expectations/tag/prefix.compat.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define PREFIX_LEN 42
+#define PREFIX_LEN 22
 
-#define PREFIX_X (42 << 42)
+#define PREFIX_X (22 << 22)
 
 #define PREFIX_Y (PREFIX_X + PREFIX_X)
 
 typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
-typedef int32_t PREFIX_ValuedLenArray[42];
+typedef int32_t PREFIX_ValuedLenArray[22];
 
 enum PREFIX_AbsoluteFontWeight_Tag
 #ifdef __cplusplus

--- a/tests/rust/prefix.rs
+++ b/tests/rust/prefix.rs
@@ -1,7 +1,7 @@
-pub const LEN: i32 = 42;
+pub const LEN: i32 = 22;
 
 pub type NamedLenArray = [i32; LEN];
-pub type ValuedLenArray = [i32; 42];
+pub type ValuedLenArray = [i32; 22];
 
 #[repr(u8)]
 pub enum AbsoluteFontWeight {
@@ -14,7 +14,7 @@ pub enum AbsoluteFontWeight {
 pub extern "C" fn root(x: NamedLenArray, y: ValuedLenArray, z: AbsoluteFontWeight) { }
 
 #[no_mangle]
-pub const X: i64 = 42 << 42;
+pub const X: i64 = 22 << 22;
 
 #[no_mangle]
 pub const Y: i64 = X + X;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -72,6 +72,10 @@ fn compile(cbindgen_output: &Path, language: Language) {
     command.arg("-D").arg("DEFINED");
     command.arg("-c").arg(cbindgen_output);
     command.arg("-o").arg(&object);
+    command.arg("-Wall");
+    command.arg("-Werror");
+    // `swift_name` is not recognzied by gcc.
+    command.arg("-Wno-attributes");
     if let Language::Cxx = language {
         // enum class is a c++11 extension which makes g++ on macos 10.14 error out
         // inline variables are are a c++17 extension

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -74,7 +74,8 @@ fn compile(cbindgen_output: &Path, language: Language) {
     command.arg("-o").arg(&object);
     if let Language::Cxx = language {
         // enum class is a c++11 extension which makes g++ on macos 10.14 error out
-        command.arg("-std=c++11");
+        // inline variables are are a c++17 extension
+        command.arg("-std=c++17");
     }
 
     println!("Running: {:?}", command);


### PR DESCRIPTION
This PR enables `-Wall -Werror -Wno-attributes` when compiling C++ and C. With these warnings in place, several warnings are generated.

# C++ universal character name warning

```
/cbindgen/tests/expectations/constant.cpp:8:31: error: character constant too long for its type [-Werror]
    8 | static const uint32_t EQUID = L'\u10083';
      |                               ^~~~~~~~~~
cc1plus: all warnings being treated as errors
```

This is fixed by replacing the `L'\u10083'` syntax with `L'\U00010083'`. The `U` variant supports 8 digits, while `\u` only supports 4.

# C++17 inline variables warning

```
/cbindgen/tests/expectations/associated_in_body.cpp:45:1: error: inline variables are only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Werror]
   45 | inline const StyleAlignFlags StyleAlignFlags::AUTO = StyleAlignFlags{ /* .bits = */ 0 };
      | ^~~~~~
/Dev/cbindgen/tests/expectations/associated_in_body.cpp:46:1: error: inline variables are only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Werror]
   46 | inline const StyleAlignFlags StyleAlignFlags::NORMAL = StyleAlignFlags{ /* .bits = */ 1 };
      | ^~~~~~
/Dev/cbindgen/tests/expectations/associated_in_body.cpp:47:1: error: inline variables are only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Werror]
   47 | inline const StyleAlignFlags StyleAlignFlags::START = StyleAlignFlags{ /* .bits = */ (1 << 1) };
      | ^~~~~~
/Dev/cbindgen/tests/expectations/associated_in_body.cpp:48:1: error: inline variables are only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Werror]
   48 | inline const StyleAlignFlags StyleAlignFlags::END = StyleAlignFlags{ /* .bits = */ (1 << 2) };
      | ^~~~~~
/Dev/cbindgen/tests/expectations/associated_in_body.cpp:49:1: error: inline variables are only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Werror]
   49 | inline const StyleAlignFlags StyleAlignFlags::FLEX_START = StyleAlignFlags{ /* .bits = */ (1 << 3) };
      | ^~~~~~
```

Inline variables are only supported in C++17. This PR changes the `--std=c++11` C++ compilation option to `--std=c++17`.

# C++ left shift count >= width of type warning

```
/Dev/cbindgen/tests/expectations/prefix.cpp:8:40: error: left shift count >= width of type [-Werror=shift-count-overflow]
    8 | static const int64_t PREFIX_X = (42 << 42);
      | 
```

In the `prefix` test, a "random" value of 42 appears to have been used. It doesn't seem to have meaning to the `prefix` test. When left shifting 42 by 42 in C and C++, the left hand side of the shift is treated as an integer unless a suffix is specified. Left-shifting a 32 bit integer by 42 results in a value of 0. The compiler points out the programmer doesn't intend this, and, indeed, the surrounding code seems to indicate we expected the left hand side to be treated as a 64 bit integer.