### PR TITLE
Fix a non-C-like-enumeration size mismatch between Rust and C when using `Style::Tag`.

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -682,7 +682,8 @@ impl Source for Enum {
                 out.open_brace();
             }
 
-            if config.language == Language::C && !config.style.generate_typedef() {
+            if config.language == Language::C && !size.is_some() && !config.style.generate_typedef()
+            {
                 out.write("enum ");
             }
 

--- a/tests/expectations/both/enum.c
+++ b/tests/expectations/both/enum.c
@@ -157,6 +157,30 @@ typedef struct I {
   };
 } I;
 
+enum P_Tag {
+  P0,
+  P1,
+};
+typedef uint8_t P_Tag;
+
+typedef struct P0_Body {
+  uint8_t _0;
+} P0_Body;
+
+typedef struct P1_Body {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+} P1_Body;
+
+typedef struct P {
+  P_Tag tag;
+  union {
+    P0_Body p0;
+    P1_Body p1;
+  };
+} P;
+
 void root(Opaque *opaque,
           A a,
           B b,
@@ -172,4 +196,12 @@ void root(Opaque *opaque,
           L l,
           M m,
           N n,
-          O o);
+          O o,
+          P p);
+
+#include <stddef.h>
+#include "testing-helpers.h"
+static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
+static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");

--- a/tests/expectations/both/enum.compat.c
+++ b/tests/expectations/both/enum.compat.c
@@ -217,6 +217,36 @@ typedef struct I {
   };
 } I;
 
+enum P_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  P0,
+  P1,
+};
+#ifndef __cplusplus
+typedef uint8_t P_Tag;
+#endif // __cplusplus
+
+typedef struct P0_Body {
+  uint8_t _0;
+} P0_Body;
+
+typedef struct P1_Body {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+} P1_Body;
+
+typedef struct P {
+  P_Tag tag;
+  union {
+    P0_Body p0;
+    P1_Body p1;
+  };
+} P;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -236,8 +266,16 @@ void root(Opaque *opaque,
           L l,
           M m,
           N n,
-          O o);
+          O o,
+          P p);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus
+
+#include <stddef.h>
+#include "testing-helpers.h"
+static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
+static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");

--- a/tests/expectations/enum.c
+++ b/tests/expectations/enum.c
@@ -157,6 +157,30 @@ typedef struct {
   };
 } I;
 
+enum P_Tag {
+  P0,
+  P1,
+};
+typedef uint8_t P_Tag;
+
+typedef struct {
+  uint8_t _0;
+} P0_Body;
+
+typedef struct {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+} P1_Body;
+
+typedef struct {
+  P_Tag tag;
+  union {
+    P0_Body p0;
+    P1_Body p1;
+  };
+} P;
+
 void root(Opaque *opaque,
           A a,
           B b,
@@ -172,4 +196,12 @@ void root(Opaque *opaque,
           L l,
           M m,
           N n,
-          O o);
+          O o,
+          P p);
+
+#include <stddef.h>
+#include "testing-helpers.h"
+static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
+static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");

--- a/tests/expectations/enum.compat.c
+++ b/tests/expectations/enum.compat.c
@@ -217,6 +217,36 @@ typedef struct {
   };
 } I;
 
+enum P_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  P0,
+  P1,
+};
+#ifndef __cplusplus
+typedef uint8_t P_Tag;
+#endif // __cplusplus
+
+typedef struct {
+  uint8_t _0;
+} P0_Body;
+
+typedef struct {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+} P1_Body;
+
+typedef struct {
+  P_Tag tag;
+  union {
+    P0_Body p0;
+    P1_Body p1;
+  };
+} P;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -236,8 +266,16 @@ void root(Opaque *opaque,
           L l,
           M m,
           N n,
-          O o);
+          O o,
+          P p);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus
+
+#include <stddef.h>
+#include "testing-helpers.h"
+static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
+static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");

--- a/tests/expectations/enum.cpp
+++ b/tests/expectations/enum.cpp
@@ -149,6 +149,29 @@ struct I {
   };
 };
 
+struct P {
+  enum class Tag : uint8_t {
+    P0,
+    P1,
+  };
+
+  struct P0_Body {
+    uint8_t _0;
+  };
+
+  struct P1_Body {
+    uint8_t _0;
+    uint8_t _1;
+    uint8_t _2;
+  };
+
+  Tag tag;
+  union {
+    P0_Body p0;
+    P1_Body p1;
+  };
+};
+
 extern "C" {
 
 void root(Opaque *opaque,
@@ -166,6 +189,14 @@ void root(Opaque *opaque,
           L l,
           M m,
           N n,
-          O o);
+          O o,
+          P p);
 
 } // extern "C"
+
+#include <stddef.h>
+#include "testing-helpers.h"
+static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
+static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");

--- a/tests/expectations/tag/annotation.c
+++ b/tests/expectations/tag/annotation.c
@@ -37,7 +37,7 @@ struct Bar_Body {
 };
 
 union F {
-  enum F_Tag tag;
+  F_Tag tag;
   struct Foo_Body foo;
   struct Bar_Body bar;
 };
@@ -59,7 +59,7 @@ struct There_Body {
 };
 
 struct H {
-  enum H_Tag tag;
+  H_Tag tag;
   union {
     struct Hello_Body hello;
     struct There_Body there;

--- a/tests/expectations/tag/annotation.compat.c
+++ b/tests/expectations/tag/annotation.compat.c
@@ -49,7 +49,7 @@ struct Bar_Body {
 };
 
 union F {
-  enum F_Tag tag;
+  F_Tag tag;
   struct Foo_Body foo;
   struct Bar_Body bar;
 };
@@ -77,7 +77,7 @@ struct There_Body {
 };
 
 struct H {
-  enum H_Tag tag;
+  H_Tag tag;
   union {
     struct Hello_Body hello;
     struct There_Body there;

--- a/tests/expectations/tag/asserted-cast.c
+++ b/tests/expectations/tag/asserted-cast.c
@@ -25,7 +25,7 @@ struct H_Bar_Body {
 };
 
 struct H {
-  enum H_Tag tag;
+  H_Tag tag;
   union {
     struct H_Foo_Body foo;
     struct H_Bar_Body bar;
@@ -49,7 +49,7 @@ struct J_Bar_Body {
 };
 
 struct J {
-  enum J_Tag tag;
+  J_Tag tag;
   union {
     struct J_Foo_Body foo;
     struct J_Bar_Body bar;
@@ -75,7 +75,7 @@ struct K_Bar_Body {
 };
 
 union K {
-  enum K_Tag tag;
+  K_Tag tag;
   struct K_Foo_Body foo;
   struct K_Bar_Body bar;
 };

--- a/tests/expectations/tag/asserted-cast.compat.c
+++ b/tests/expectations/tag/asserted-cast.compat.c
@@ -31,7 +31,7 @@ struct H_Bar_Body {
 };
 
 struct H {
-  enum H_Tag tag;
+  H_Tag tag;
   union {
     struct H_Foo_Body foo;
     struct H_Bar_Body bar;
@@ -61,7 +61,7 @@ struct J_Bar_Body {
 };
 
 struct J {
-  enum J_Tag tag;
+  J_Tag tag;
   union {
     struct J_Foo_Body foo;
     struct J_Bar_Body bar;
@@ -93,7 +93,7 @@ struct K_Bar_Body {
 };
 
 union K {
-  enum K_Tag tag;
+  K_Tag tag;
   struct K_Foo_Body foo;
   struct K_Bar_Body bar;
 };

--- a/tests/expectations/tag/derive-eq.c
+++ b/tests/expectations/tag/derive-eq.c
@@ -34,7 +34,7 @@ struct FooParen_Body {
 };
 
 union Bar {
-  enum Bar_Tag tag;
+  Bar_Tag tag;
   struct Bazz_Body bazz;
   struct FooNamed_Body foo_named;
   struct FooParen_Body foo_paren;

--- a/tests/expectations/tag/derive-eq.compat.c
+++ b/tests/expectations/tag/derive-eq.compat.c
@@ -40,7 +40,7 @@ struct FooParen_Body {
 };
 
 union Bar {
-  enum Bar_Tag tag;
+  Bar_Tag tag;
   struct Bazz_Body bazz;
   struct FooNamed_Body foo_named;
   struct FooParen_Body foo_paren;

--- a/tests/expectations/tag/destructor-and-copy-ctor.c
+++ b/tests/expectations/tag/destructor-and-copy-ctor.c
@@ -65,7 +65,7 @@ struct Slice4_Body_u32 {
 };
 
 struct Foo_u32 {
-  enum Foo_u32_Tag tag;
+  Foo_u32_Tag tag;
   union {
     struct Polygon1_Body_u32 polygon1;
     struct Slice1_Body_u32 slice1;
@@ -118,7 +118,7 @@ struct Slice24_Body_i32 {
 };
 
 union Baz_i32 {
-  enum Baz_i32_Tag tag;
+  Baz_i32_Tag tag;
   struct Polygon21_Body_i32 polygon21;
   struct Slice21_Body_i32 slice21;
   struct Slice22_Body_i32 slice22;
@@ -144,7 +144,7 @@ struct Taz3_Body {
 };
 
 union Taz {
-  enum Taz_Tag tag;
+  Taz_Tag tag;
   struct Taz1_Body taz1;
   struct Taz3_Body taz3;
 };
@@ -161,7 +161,7 @@ struct Taz2_Body {
 };
 
 union Tazz {
-  enum Tazz_Tag tag;
+  Tazz_Tag tag;
   struct Taz2_Body taz2;
 };
 

--- a/tests/expectations/tag/destructor-and-copy-ctor.compat.c
+++ b/tests/expectations/tag/destructor-and-copy-ctor.compat.c
@@ -77,7 +77,7 @@ struct Slice4_Body_u32 {
 };
 
 struct Foo_u32 {
-  enum Foo_u32_Tag tag;
+  Foo_u32_Tag tag;
   union {
     struct Polygon1_Body_u32 polygon1;
     struct Slice1_Body_u32 slice1;
@@ -136,7 +136,7 @@ struct Slice24_Body_i32 {
 };
 
 union Baz_i32 {
-  enum Baz_i32_Tag tag;
+  Baz_i32_Tag tag;
   struct Polygon21_Body_i32 polygon21;
   struct Slice21_Body_i32 slice21;
   struct Slice22_Body_i32 slice22;
@@ -168,7 +168,7 @@ struct Taz3_Body {
 };
 
 union Taz {
-  enum Taz_Tag tag;
+  Taz_Tag tag;
   struct Taz1_Body taz1;
   struct Taz3_Body taz3;
 };
@@ -191,7 +191,7 @@ struct Taz2_Body {
 };
 
 union Tazz {
-  enum Tazz_Tag tag;
+  Tazz_Tag tag;
   struct Taz2_Body taz2;
 };
 

--- a/tests/expectations/tag/display_list.c
+++ b/tests/expectations/tag/display_list.c
@@ -37,7 +37,7 @@ struct Image_Body {
 };
 
 union DisplayItem {
-  enum DisplayItem_Tag tag;
+  DisplayItem_Tag tag;
   struct Fill_Body fill;
   struct Image_Body image;
 };

--- a/tests/expectations/tag/display_list.compat.c
+++ b/tests/expectations/tag/display_list.compat.c
@@ -43,7 +43,7 @@ struct Image_Body {
 };
 
 union DisplayItem {
-  enum DisplayItem_Tag tag;
+  DisplayItem_Tag tag;
   struct Fill_Body fill;
   struct Image_Body image;
 };

--- a/tests/expectations/tag/enum.c
+++ b/tests/expectations/tag/enum.c
@@ -105,7 +105,7 @@ struct Bar_Body {
 };
 
 union G {
-  enum G_Tag tag;
+  G_Tag tag;
   struct Foo_Body foo;
   struct Bar_Body bar;
 };
@@ -150,10 +150,34 @@ struct I_Bar_Body {
 };
 
 struct I {
-  enum I_Tag tag;
+  I_Tag tag;
   union {
     struct I_Foo_Body foo;
     struct I_Bar_Body bar;
+  };
+};
+
+enum P_Tag {
+  P0,
+  P1,
+};
+typedef uint8_t P_Tag;
+
+struct P0_Body {
+  uint8_t _0;
+};
+
+struct P1_Body {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+};
+
+struct P {
+  P_Tag tag;
+  union {
+    struct P0_Body p0;
+    struct P1_Body p1;
   };
 };
 
@@ -172,4 +196,12 @@ void root(struct Opaque *opaque,
           enum L l,
           M m,
           enum N n,
-          O o);
+          O o,
+          struct P p);
+
+#include <stddef.h>
+#include "testing-helpers.h"
+static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
+static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");

--- a/tests/expectations/tag/enum.compat.c
+++ b/tests/expectations/tag/enum.compat.c
@@ -217,6 +217,36 @@ struct I {
   };
 };
 
+enum P_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  P0,
+  P1,
+};
+#ifndef __cplusplus
+typedef uint8_t P_Tag;
+#endif // __cplusplus
+
+struct P0_Body {
+  uint8_t _0;
+};
+
+struct P1_Body {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+};
+
+struct P {
+  enum P_Tag tag;
+  union {
+    struct P0_Body p0;
+    struct P1_Body p1;
+  };
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -236,8 +266,16 @@ void root(struct Opaque *opaque,
           enum L l,
           M m,
           enum N n,
-          O o);
+          O o,
+          struct P p);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus
+
+#include <stddef.h>
+#include "testing-helpers.h"
+static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
+static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");

--- a/tests/expectations/tag/enum.compat.c
+++ b/tests/expectations/tag/enum.compat.c
@@ -159,7 +159,7 @@ struct Bar_Body {
 };
 
 union G {
-  enum G_Tag tag;
+  G_Tag tag;
   struct Foo_Body foo;
   struct Bar_Body bar;
 };
@@ -210,7 +210,7 @@ struct I_Bar_Body {
 };
 
 struct I {
-  enum I_Tag tag;
+  I_Tag tag;
   union {
     struct I_Foo_Body foo;
     struct I_Bar_Body bar;
@@ -240,7 +240,7 @@ struct P1_Body {
 };
 
 struct P {
-  enum P_Tag tag;
+  P_Tag tag;
   union {
     struct P0_Body p0;
     struct P1_Body p1;

--- a/tests/expectations/tag/enum_self.c
+++ b/tests/expectations/tag/enum_self.c
@@ -25,7 +25,7 @@ struct Max_Body {
 };
 
 union Bar {
-  enum Bar_Tag tag;
+  Bar_Tag tag;
   struct Min_Body min;
   struct Max_Body max;
 };

--- a/tests/expectations/tag/enum_self.compat.c
+++ b/tests/expectations/tag/enum_self.compat.c
@@ -31,7 +31,7 @@ struct Max_Body {
 };
 
 union Bar {
-  enum Bar_Tag tag;
+  Bar_Tag tag;
   struct Min_Body min;
   struct Max_Body max;
 };

--- a/tests/expectations/tag/must-use.c
+++ b/tests/expectations/tag/must-use.c
@@ -19,7 +19,7 @@ struct Owned_Body_i32 {
 };
 
 struct MaybeOwnedPtr_i32 {
-  enum MaybeOwnedPtr_i32_Tag tag;
+  MaybeOwnedPtr_i32_Tag tag;
   union {
     struct Owned_Body_i32 owned;
   };

--- a/tests/expectations/tag/must-use.compat.c
+++ b/tests/expectations/tag/must-use.compat.c
@@ -25,7 +25,7 @@ struct Owned_Body_i32 {
 };
 
 struct MaybeOwnedPtr_i32 {
-  enum MaybeOwnedPtr_i32_Tag tag;
+  MaybeOwnedPtr_i32_Tag tag;
   union {
     struct Owned_Body_i32 owned;
   };

--- a/tests/expectations/tag/prefix.c
+++ b/tests/expectations/tag/prefix.c
@@ -26,7 +26,7 @@ struct PREFIX_Weight_Body {
 };
 
 union PREFIX_AbsoluteFontWeight {
-  enum PREFIX_AbsoluteFontWeight_Tag tag;
+  PREFIX_AbsoluteFontWeight_Tag tag;
   struct PREFIX_Weight_Body weight;
 };
 

--- a/tests/expectations/tag/prefix.compat.c
+++ b/tests/expectations/tag/prefix.compat.c
@@ -32,7 +32,7 @@ struct PREFIX_Weight_Body {
 };
 
 union PREFIX_AbsoluteFontWeight {
-  enum PREFIX_AbsoluteFontWeight_Tag tag;
+  PREFIX_AbsoluteFontWeight_Tag tag;
   struct PREFIX_Weight_Body weight;
 };
 

--- a/tests/expectations/tag/reserved.c
+++ b/tests/expectations/tag/reserved.c
@@ -24,7 +24,7 @@ struct D_Body {
 };
 
 struct C {
-  enum C_Tag tag;
+  C_Tag tag;
   union {
     struct D_Body d;
   };

--- a/tests/expectations/tag/reserved.compat.c
+++ b/tests/expectations/tag/reserved.compat.c
@@ -30,7 +30,7 @@ struct D_Body {
 };
 
 struct C {
-  enum C_Tag tag;
+  C_Tag tag;
   union {
     struct D_Body d;
   };

--- a/tests/expectations/tag/sentinel.c
+++ b/tests/expectations/tag/sentinel.c
@@ -47,7 +47,7 @@ struct C_C2_Body {
 };
 
 union C {
-  enum C_Tag tag;
+  C_Tag tag;
   struct C_C1_Body c1;
   struct C_C2_Body c2;
 };

--- a/tests/expectations/tag/sentinel.compat.c
+++ b/tests/expectations/tag/sentinel.compat.c
@@ -65,7 +65,7 @@ struct C_C2_Body {
 };
 
 union C {
-  enum C_Tag tag;
+  C_Tag tag;
   struct C_C1_Body c1;
   struct C_C2_Body c2;
 };

--- a/tests/expectations/tag/transform-op.c
+++ b/tests/expectations/tag/transform-op.c
@@ -39,7 +39,7 @@ struct StyleBaz_Body_i32 {
 };
 
 union StyleFoo_i32 {
-  enum StyleFoo_i32_Tag tag;
+  StyleFoo_i32_Tag tag;
   struct StyleFoo_Body_i32 foo;
   struct StyleBar_Body_i32 bar;
   struct StyleBaz_Body_i32 baz;
@@ -130,7 +130,7 @@ struct StyleBaz2_Body {
 };
 
 union StyleBaz {
-  enum StyleBaz_Tag tag;
+  StyleBaz_Tag tag;
   struct StyleBaz1_Body baz1;
   struct StyleBaz2_Body baz2;
 };
@@ -151,7 +151,7 @@ struct StyleTaz2_Body {
 };
 
 struct StyleTaz {
-  enum StyleTaz_Tag tag;
+  StyleTaz_Tag tag;
   union {
     struct StyleTaz1_Body taz1;
     struct StyleTaz2_Body taz2;

--- a/tests/expectations/tag/transform-op.compat.c
+++ b/tests/expectations/tag/transform-op.compat.c
@@ -45,7 +45,7 @@ struct StyleBaz_Body_i32 {
 };
 
 union StyleFoo_i32 {
-  enum StyleFoo_i32_Tag tag;
+  StyleFoo_i32_Tag tag;
   struct StyleFoo_Body_i32 foo;
   struct StyleBar_Body_i32 bar;
   struct StyleBaz_Body_i32 baz;
@@ -142,7 +142,7 @@ struct StyleBaz2_Body {
 };
 
 union StyleBaz {
-  enum StyleBaz_Tag tag;
+  StyleBaz_Tag tag;
   struct StyleBaz1_Body baz1;
   struct StyleBaz2_Body baz2;
 };
@@ -169,7 +169,7 @@ struct StyleTaz2_Body {
 };
 
 struct StyleTaz {
-  enum StyleTaz_Tag tag;
+  StyleTaz_Tag tag;
   union {
     struct StyleTaz1_Body taz1;
     struct StyleTaz2_Body taz2;

--- a/tests/rust/enum.rs
+++ b/tests/rust/enum.rs
@@ -121,6 +121,12 @@ enum O {
     o4,
 }
 
+#[repr(C, u8)]
+enum P {
+    P0(u8),
+    P1(u8, u8, u8),
+}
+
 #[no_mangle]
 pub extern "C" fn root(
     opaque: *mut Opaque,
@@ -139,5 +145,6 @@ pub extern "C" fn root(
     m: M,
     n: N,
     o: O,
+    p: P,
 ) {
 }

--- a/tests/rust/enum.toml
+++ b/tests/rust/enum.toml
@@ -1,0 +1,8 @@
+trailer = """
+#include <stddef.h>
+#include "testing-helpers.h"
+static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
+static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
+static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
+"""


### PR DESCRIPTION
When using `Style::Tag` with non-C-like-enumerations and discriminant types that do not match the size of enumerations in C (such as those with `#[repr(C, u8)]`), cbindgen emits types that are incompatible between Rust and C.

I have found two problems:

# Inconsistent Padding

Here's the input type:

```rust
#[repr(C, u8)]
enum Tu64 {
    None,
    Some(u64),
}
```

Here's the generated C code:

```c
enum Tu64_Tag {
  None,
  Some,
};
typedef uint8_t Tu64_Tag;

struct Some_Body {
  uint64_t _0;
};

struct Tu64 {
  enum Tu64_Tag tag;
  union {
    struct Some_Body some;
  };
};
```

In this case, both C and Rust agree that `Tu64` is sized as 16 bytes. The `u64` forces its alignment to 8 bytes, so Rust designates the first byte as the discriminant, and the following 7 bytes as padding.

However, C has the tag defined as an `enum Tu64_Tag`. This means that the tag is sized the same way enumerations are on the host system. In our case, that's likely going to be 4 bytes. In C, the first 4 bytes are discriminant, and the following 4 are padding.

This means the interface between Rust and C is unsafe since the discriminant C reads may be influenced by noise in padding bytes that Rust may not initialize. For example, allocating a `Tu64` in C, setting it all to `0xFF`, then passing it by reference into Rust for initialization will result in a corrupted discriminant when C looks at the initialization result.

# Inconsistent Sizes

We'll use an example similar to the one above, but replace the `u64` with a `u8`.

```rust
#[repr(C, u8)]
enum Tu8 {
    None,
    Some(u8),
}
```

Here's the generated code:

```c
enum Tu8_Tag {
  None,
  Some,
};
typedef uint8_t Tu8_Tag;

struct Some_Body {
  uint8_t _0;
};

struct Tu8 {
  enum Tu8_Tag tag;
  union {
    struct Some_Body some;
  };
};
```

In this case, Rust sees that the value we can hold in the enum and the discriminant are both of size 1, so we can safely pack them in 2 bytes.

However, in C, we can see that we're still using `enum Tu8_Tag` for the discriminant tag type. This means that the size in C is going to be at least the size of an enumeration + 1 byte, and will have an alignment other than the one used by Rust.

Passing a `Tu8` from C to Rust results in Rust reading a corrupted body value. Passing a `Tu8` from Rust to C will almost certainly result in corruption of the tag. Furthermore, any mutation C does to the `Tu8` allocated by Rust can corrupt unrelated structures in Rust's memory by overflowing the bounds of Rust's `Tu8`.

# Solution

In both cases, the solution is to use the `typedef` that's generated as the tag type in C. That is, using `Tu64_Tag tag` instead of `enum Tu64_Tag tag` and `Tu8_Tag tag` instead of `enum Tu8_Tag tag`.

# Testing

This PR includes some extra infrastructure so that tests to verify this sort of thing can be written. The details of this test system are documented in the commit message of ea03db1. The test I added is at `tests/checkers/tag/enum.c`. The body of this test `#include`s the cbindgen generated file, and then verifies the expected size. If bac063e is checked out, this test is seen to fail in `cargo test`.

# Fix

I have created another commit that appears to fix this issue (by not emitting the `enum` before the tag type name when the representation expresses a size), and does not cause any other tests to fail. I'm not convinced this is the best way to fix this, nor is the importance of the change in df0167b  obvious. I would appreciate feedback about alternative ways to fix this that might be more clear to future readers.