### PR TITLE
tests: Provide style definition to the C / C++ tests.

### DIFF
--- a/tests/testing-helpers.h
+++ b/tests/testing-helpers.h
@@ -1,0 +1,20 @@
+#ifndef testing_helpers_h
+#define  testing_helpers_h
+
+// This is a helper file to easily add static_asserts to C / C++ tests.
+
+#ifndef __cplusplus
+#include <assert.h>
+#endif
+
+#if defined(CBINDGEN_STYLE_TAG) && !defined(__cplusplus)
+#define CBINDGEN_STRUCT(name) struct name
+#define CBINDGEN_UNION(name) union name
+#define CBINDGEN_ENUM(name) enum name
+#else
+#define CBINDGEN_STRUCT(name) name
+#define CBINDGEN_UNION(name) name
+#define CBINDGEN_ENUM(name) name
+#endif
+
+#endif


### PR DESCRIPTION
This will be useful to add static assertion to some tests like #463 wants to do.

For example, in the case of the test for #463, the test would need something
like:

    trailer = """
    #include <assert.h>

    #if defined(CBINDGEN_STYLE_TAG) && !defined(__cplusplus)
    static_assert(sizeof(struct P) == 4, "unexpected size for P");
    #else
    static_assert(sizeof(P) == 4, "unexpected size for P");
    #endif
    """

As more of these tests are added it may be worth just adding a helper header
like this to avoid some duplication:

    #include <assert.h>
    #if defined(CBINDGEN_STYLE_TAG) && !defined(__cplusplus)
    #define CBINDGEN_STRUCT(name) struct name
    #else
    #define CBINDGEN_STRUCT(name) name
    #endif

And so on, so the previous configuration would become just:

    trailer = """
    #include "testing-helpers.h" // Or whatever
    static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
    """

That may or may not be overkill to do as part of #463.