### PR TITLE
bindgen: enable "void prototype" while writing struct field

### DIFF
--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -286,7 +286,7 @@ pub fn write_func<F: Write>(
 }
 
 pub fn write_field<F: Write>(out: &mut SourceWriter<F>, t: &Type, ident: &str) {
-    CDecl::from_type(t).write(out, Some(ident), false);
+    CDecl::from_type(t).write(out, Some(ident), true);
 }
 
 pub fn write_type<F: Write>(out: &mut SourceWriter<F>, t: &Type) {

--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -285,8 +285,13 @@ pub fn write_func<F: Write>(
     CDecl::from_func(f, layout_vertical).write(out, Some(f.path().name()), void_prototype);
 }
 
-pub fn write_field<F: Write>(out: &mut SourceWriter<F>, t: &Type, ident: &str) {
-    CDecl::from_type(t).write(out, Some(ident), true);
+pub fn write_field<F: Write>(
+    out: &mut SourceWriter<F>,
+    t: &Type,
+    ident: &str,
+    void_prototype: bool,
+) {
+    CDecl::from_type(t).write(out, Some(ident), void_prototype);
 }
 
 pub fn write_type<F: Write>(out: &mut SourceWriter<F>, t: &Type) {

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -8,7 +8,7 @@ use std::io::Write;
 use syn;
 
 use crate::bindgen::cdecl;
-use crate::bindgen::config::Config;
+use crate::bindgen::config::{Config, Language};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{Documentation, GenericParams, GenericPath, Path};
@@ -710,14 +710,16 @@ impl Source for Type {
 }
 
 impl Source for (String, Type) {
-    fn write<F: Write>(&self, _config: &Config, out: &mut SourceWriter<F>) {
-        cdecl::write_field(out, &self.1, &self.0);
+    fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
+        let void_prototype = config.language == Language::C;
+        cdecl::write_field(out, &self.1, &self.0, void_prototype);
     }
 }
 
 impl Source for (String, Type, Documentation) {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
+        let void_prototype = config.language == Language::C;
         self.2.write(config, out);
-        cdecl::write_field(out, &self.1, &self.0);
+        cdecl::write_field(out, &self.1, &self.0, void_prototype);
     }
 }

--- a/tests/expectations/both/cdecl.c
+++ b/tests/expectations/both/cdecl.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef void (*A)();
+typedef void (*A)(void);
 
-typedef void (*B)();
+typedef void (*B)(void);
 
 typedef bool (*C)(int32_t, int32_t);
 
 typedef bool (*(*D)(int32_t))(float);
 
-typedef const int32_t (*(*E)())[16];
+typedef const int32_t (*(*E)(void))[16];
 
 typedef const int32_t *F;
 

--- a/tests/expectations/both/cdecl.compat.c
+++ b/tests/expectations/both/cdecl.compat.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef void (*A)();
+typedef void (*A)(void);
 
-typedef void (*B)();
+typedef void (*B)(void);
 
 typedef bool (*C)(int32_t, int32_t);
 
 typedef bool (*(*D)(int32_t))(float);
 
-typedef const int32_t (*(*E)())[16];
+typedef const int32_t (*(*E)(void))[16];
 
 typedef const int32_t *F;
 

--- a/tests/expectations/both/fns.c
+++ b/tests/expectations/both/fns.c
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 
 typedef struct Fns {
-  void (*noArgs)();
+  void (*noArgs)(void);
   void (*anonymousArg)(int32_t);
-  int32_t (*returnsNumber)();
+  int32_t (*returnsNumber)(void);
   int8_t (*namedArgs)(int32_t first, int16_t snd);
   int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
 } Fns;

--- a/tests/expectations/both/fns.compat.c
+++ b/tests/expectations/both/fns.compat.c
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 
 typedef struct Fns {
-  void (*noArgs)();
+  void (*noArgs)(void);
   void (*anonymousArg)(int32_t);
-  int32_t (*returnsNumber)();
+  int32_t (*returnsNumber)(void);
   int8_t (*namedArgs)(int32_t first, int16_t snd);
   int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
 } Fns;

--- a/tests/expectations/both/simplify-option-ptr.c
+++ b/tests/expectations/both/simplify-option-ptr.c
@@ -8,13 +8,13 @@ typedef struct Opaque Opaque;
 typedef struct Foo {
   const Opaque *x;
   Opaque *y;
-  void (*z)();
+  void (*z)(void);
 } Foo;
 
 typedef union Bar {
   const Opaque *x;
   Opaque *y;
-  void (*z)();
+  void (*z)(void);
 } Bar;
 
 void root(const Opaque *a, Opaque *b, Foo c, Bar d);

--- a/tests/expectations/both/simplify-option-ptr.compat.c
+++ b/tests/expectations/both/simplify-option-ptr.compat.c
@@ -8,13 +8,13 @@ typedef struct Opaque Opaque;
 typedef struct Foo {
   const Opaque *x;
   Opaque *y;
-  void (*z)();
+  void (*z)(void);
 } Foo;
 
 typedef union Bar {
   const Opaque *x;
   Opaque *y;
-  void (*z)();
+  void (*z)(void);
 } Bar;
 
 #ifdef __cplusplus

--- a/tests/expectations/cdecl.c
+++ b/tests/expectations/cdecl.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef void (*A)();
+typedef void (*A)(void);
 
-typedef void (*B)();
+typedef void (*B)(void);
 
 typedef bool (*C)(int32_t, int32_t);
 
 typedef bool (*(*D)(int32_t))(float);
 
-typedef const int32_t (*(*E)())[16];
+typedef const int32_t (*(*E)(void))[16];
 
 typedef const int32_t *F;
 

--- a/tests/expectations/cdecl.compat.c
+++ b/tests/expectations/cdecl.compat.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef void (*A)();
+typedef void (*A)(void);
 
-typedef void (*B)();
+typedef void (*B)(void);
 
 typedef bool (*C)(int32_t, int32_t);
 
 typedef bool (*(*D)(int32_t))(float);
 
-typedef const int32_t (*(*E)())[16];
+typedef const int32_t (*(*E)(void))[16];
 
 typedef const int32_t *F;
 

--- a/tests/expectations/fns.c
+++ b/tests/expectations/fns.c
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 
 typedef struct {
-  void (*noArgs)();
+  void (*noArgs)(void);
   void (*anonymousArg)(int32_t);
-  int32_t (*returnsNumber)();
+  int32_t (*returnsNumber)(void);
   int8_t (*namedArgs)(int32_t first, int16_t snd);
   int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
 } Fns;

--- a/tests/expectations/fns.compat.c
+++ b/tests/expectations/fns.compat.c
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 
 typedef struct {
-  void (*noArgs)();
+  void (*noArgs)(void);
   void (*anonymousArg)(int32_t);
-  int32_t (*returnsNumber)();
+  int32_t (*returnsNumber)(void);
   int8_t (*namedArgs)(int32_t first, int16_t snd);
   int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
 } Fns;

--- a/tests/expectations/fns.cpp
+++ b/tests/expectations/fns.cpp
@@ -4,9 +4,9 @@
 #include <new>
 
 struct Fns {
-  void (*noArgs)(void);
+  void (*noArgs)();
   void (*anonymousArg)(int32_t);
-  int32_t (*returnsNumber)(void);
+  int32_t (*returnsNumber)();
   int8_t (*namedArgs)(int32_t first, int16_t snd);
   int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
 };

--- a/tests/expectations/fns.cpp
+++ b/tests/expectations/fns.cpp
@@ -4,9 +4,9 @@
 #include <new>
 
 struct Fns {
-  void (*noArgs)();
+  void (*noArgs)(void);
   void (*anonymousArg)(int32_t);
-  int32_t (*returnsNumber)();
+  int32_t (*returnsNumber)(void);
   int8_t (*namedArgs)(int32_t first, int16_t snd);
   int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
 };

--- a/tests/expectations/simplify-option-ptr.c
+++ b/tests/expectations/simplify-option-ptr.c
@@ -8,13 +8,13 @@ typedef struct Opaque Opaque;
 typedef struct {
   const Opaque *x;
   Opaque *y;
-  void (*z)();
+  void (*z)(void);
 } Foo;
 
 typedef union {
   const Opaque *x;
   Opaque *y;
-  void (*z)();
+  void (*z)(void);
 } Bar;
 
 void root(const Opaque *a, Opaque *b, Foo c, Bar d);

--- a/tests/expectations/simplify-option-ptr.compat.c
+++ b/tests/expectations/simplify-option-ptr.compat.c
@@ -8,13 +8,13 @@ typedef struct Opaque Opaque;
 typedef struct {
   const Opaque *x;
   Opaque *y;
-  void (*z)();
+  void (*z)(void);
 } Foo;
 
 typedef union {
   const Opaque *x;
   Opaque *y;
-  void (*z)();
+  void (*z)(void);
 } Bar;
 
 #ifdef __cplusplus

--- a/tests/expectations/simplify-option-ptr.cpp
+++ b/tests/expectations/simplify-option-ptr.cpp
@@ -8,13 +8,13 @@ struct Opaque;
 struct Foo {
   const Opaque *x;
   Opaque *y;
-  void (*z)(void);
+  void (*z)();
 };
 
 union Bar {
   const Opaque *x;
   Opaque *y;
-  void (*z)(void);
+  void (*z)();
 };
 
 extern "C" {

--- a/tests/expectations/simplify-option-ptr.cpp
+++ b/tests/expectations/simplify-option-ptr.cpp
@@ -8,13 +8,13 @@ struct Opaque;
 struct Foo {
   const Opaque *x;
   Opaque *y;
-  void (*z)();
+  void (*z)(void);
 };
 
 union Bar {
   const Opaque *x;
   Opaque *y;
-  void (*z)();
+  void (*z)(void);
 };
 
 extern "C" {

--- a/tests/expectations/tag/cdecl.c
+++ b/tests/expectations/tag/cdecl.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef void (*A)();
+typedef void (*A)(void);
 
-typedef void (*B)();
+typedef void (*B)(void);
 
 typedef bool (*C)(int32_t, int32_t);
 
 typedef bool (*(*D)(int32_t))(float);
 
-typedef const int32_t (*(*E)())[16];
+typedef const int32_t (*(*E)(void))[16];
 
 typedef const int32_t *F;
 

--- a/tests/expectations/tag/cdecl.compat.c
+++ b/tests/expectations/tag/cdecl.compat.c
@@ -3,15 +3,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef void (*A)();
+typedef void (*A)(void);
 
-typedef void (*B)();
+typedef void (*B)(void);
 
 typedef bool (*C)(int32_t, int32_t);
 
 typedef bool (*(*D)(int32_t))(float);
 
-typedef const int32_t (*(*E)())[16];
+typedef const int32_t (*(*E)(void))[16];
 
 typedef const int32_t *F;
 

--- a/tests/expectations/tag/fns.c
+++ b/tests/expectations/tag/fns.c
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 
 struct Fns {
-  void (*noArgs)();
+  void (*noArgs)(void);
   void (*anonymousArg)(int32_t);
-  int32_t (*returnsNumber)();
+  int32_t (*returnsNumber)(void);
   int8_t (*namedArgs)(int32_t first, int16_t snd);
   int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
 };

--- a/tests/expectations/tag/fns.compat.c
+++ b/tests/expectations/tag/fns.compat.c
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 
 struct Fns {
-  void (*noArgs)();
+  void (*noArgs)(void);
   void (*anonymousArg)(int32_t);
-  int32_t (*returnsNumber)();
+  int32_t (*returnsNumber)(void);
   int8_t (*namedArgs)(int32_t first, int16_t snd);
   int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
 };

--- a/tests/expectations/tag/simplify-option-ptr.c
+++ b/tests/expectations/tag/simplify-option-ptr.c
@@ -8,13 +8,13 @@ struct Opaque;
 struct Foo {
   const struct Opaque *x;
   struct Opaque *y;
-  void (*z)();
+  void (*z)(void);
 };
 
 union Bar {
   const struct Opaque *x;
   struct Opaque *y;
-  void (*z)();
+  void (*z)(void);
 };
 
 void root(const struct Opaque *a, struct Opaque *b, struct Foo c, union Bar d);

--- a/tests/expectations/tag/simplify-option-ptr.compat.c
+++ b/tests/expectations/tag/simplify-option-ptr.compat.c
@@ -8,13 +8,13 @@ struct Opaque;
 struct Foo {
   const struct Opaque *x;
   struct Opaque *y;
-  void (*z)();
+  void (*z)(void);
 };
 
 union Bar {
   const struct Opaque *x;
   struct Opaque *y;
-  void (*z)();
+  void (*z)(void);
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fix #470 

This `void` in some C++ files should be fine according to standard ([ref][stackoverflow ref])

Let's me know if there's anything I can improve :)

[stackoverflow ref]: https://softwareengineering.stackexchange.com/a/287002