### PR TITLE
Omit or display more detailed warning message while trying to generate declaration from Rust functions

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -637,8 +637,11 @@ impl Parse {
         };
 
         if let syn::Visibility::Public(_) = vis {
-            if sig.abi.is_omitted() || sig.abi.is_c() {
-                if let Some(exported_name) = named_symbol.exported_name() {
+            let is_extern_c = sig.abi.is_omitted() || sig.abi.is_c();
+            let exported_name = named_symbol.exported_name();
+
+            if is_extern_c {
+                if let Some(exported_name) = exported_name {
                     let path = Path::new(exported_name);
                     match Function::load(path, self_type, &sig, false, &attrs, mod_cfg) {
                         Ok(func) => {

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -659,9 +659,10 @@ impl Parse {
                         loggable_item_name()
                     );
                 }
-                (false, _) => {
+                (false, Some(_exported_name)) => {
                     warn!("Skipping {} - (not `extern \"C\"`", loggable_item_name());
                 }
+                (false, None) => {}
             }
         } else {
             warn!("Skipping {} - (not `pub`)", loggable_item_name());

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -640,8 +640,8 @@ impl Parse {
             let is_extern_c = sig.abi.is_omitted() || sig.abi.is_c();
             let exported_name = named_symbol.exported_name();
 
-            if is_extern_c {
-                if let Some(exported_name) = exported_name {
+            match (is_extern_c, exported_name) {
+                (true, Some(exported_name)) => {
                     let path = Path::new(exported_name);
                     match Function::load(path, self_type, &sig, false, &attrs, mod_cfg) {
                         Ok(func) => {
@@ -652,14 +652,16 @@ impl Parse {
                             error!("Cannot use fn {} ({}).", loggable_item_name(), msg);
                         }
                     }
-                } else {
+                }
+                (true, None) => {
                     warn!(
                         "Skipping {} - (not `no_mangle`, and has no `export_name` attribute)",
                         loggable_item_name()
                     );
                 }
-            } else {
-                warn!("Skipping {} - (not `extern \"C\"`", loggable_item_name());
+                (false, _) => {
+                    warn!("Skipping {} - (not `extern \"C\"`", loggable_item_name());
+                }
             }
         } else {
             warn!("Skipping {} - (not `pub`)", loggable_item_name());

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -636,10 +636,10 @@ impl Parse {
             items.join("::")
         };
 
-        if let syn::Visibility::Public(_) = vis {
-            let is_extern_c = sig.abi.is_omitted() || sig.abi.is_c();
-            let exported_name = named_symbol.exported_name();
+        let is_extern_c = sig.abi.is_omitted() || sig.abi.is_c();
+        let exported_name = named_symbol.exported_name();
 
+        if let syn::Visibility::Public(_) = vis {
             match (is_extern_c, exported_name) {
                 (true, Some(exported_name)) => {
                     let path = Path::new(exported_name);
@@ -665,7 +665,27 @@ impl Parse {
                 (false, None) => {}
             }
         } else {
-            warn!("Skipping {} - (not `pub`)", loggable_item_name());
+            match (is_extern_c, exported_name) {
+                (true, Some(exported_name)) => {
+                    warn!(
+                        "Skipping {} - (not `pub` but is `extern \"C\"` and `no_mangle`)",
+                        loggable_item_name()
+                    );
+                }
+                (true, None) => {
+                    warn!(
+                        "Skipping {} - (not `pub` but is `extern \"C\"`)",
+                        loggable_item_name()
+                    );
+                }
+                (false, Some(_exported_name)) => {
+                    warn!(
+                        "Skipping {} - (not `pub` but is `no_mangle`)",
+                        loggable_item_name()
+                    );
+                }
+                (false, None) => {}
+            }
         }
     }
 


### PR DESCRIPTION
fix #467

I'd like to hear your opinion about my implementation.

- are these warning messages okay in each case?
- is the "match in if-else statement" okay? or should I write it in a single match statement?

Please let me know what's the suitable way to go :)