### PR TITLE
ir: write declaration of global variable like struct fields

### DIFF
--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -6,6 +6,7 @@ use std::io::Write;
 
 use syn;
 
+use crate::bindgen::cdecl;
 use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
@@ -112,7 +113,7 @@ impl Source for Static {
         } else if !self.mutable {
             out.write("const ");
         }
-        self.ty.write(config, out);
-        write!(out, " {};", self.export_name());
+        cdecl::write_field(out, &self.ty, &self.export_name, config);
+        out.write(";");
     }
 }

--- a/tests/expectations/both/global_variable.c
+++ b/tests/expectations/both/global_variable.c
@@ -1,0 +1,8 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern const char CONST_GLOBAL_ARRAY[128];
+
+extern char MUT_GLOBAL_ARRAY[128];

--- a/tests/expectations/both/global_variable.compat.c
+++ b/tests/expectations/both/global_variable.compat.c
@@ -1,0 +1,16 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+extern const char CONST_GLOBAL_ARRAY[128];
+
+extern char MUT_GLOBAL_ARRAY[128];
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/global_variable.c
+++ b/tests/expectations/global_variable.c
@@ -1,0 +1,8 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern const char CONST_GLOBAL_ARRAY[128];
+
+extern char MUT_GLOBAL_ARRAY[128];

--- a/tests/expectations/global_variable.compat.c
+++ b/tests/expectations/global_variable.compat.c
@@ -1,0 +1,16 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+extern const char CONST_GLOBAL_ARRAY[128];
+
+extern char MUT_GLOBAL_ARRAY[128];
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/global_variable.cpp
+++ b/tests/expectations/global_variable.cpp
@@ -1,0 +1,12 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+
+extern "C" {
+
+extern const char CONST_GLOBAL_ARRAY[128];
+
+extern char MUT_GLOBAL_ARRAY[128];
+
+} // extern "C"

--- a/tests/expectations/tag/global_variable.c
+++ b/tests/expectations/tag/global_variable.c
@@ -1,0 +1,8 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern const char CONST_GLOBAL_ARRAY[128];
+
+extern char MUT_GLOBAL_ARRAY[128];

--- a/tests/expectations/tag/global_variable.compat.c
+++ b/tests/expectations/tag/global_variable.compat.c
@@ -1,0 +1,16 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+extern const char CONST_GLOBAL_ARRAY[128];
+
+extern char MUT_GLOBAL_ARRAY[128];
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/rust/global_variable.rs
+++ b/tests/rust/global_variable.rs
@@ -1,0 +1,5 @@
+#[no_mangle]
+pub static mut MUT_GLOBAL_ARRAY: [c_char; 128] = [0; 128];
+
+#[no_mangle]
+pub static CONST_GLOBAL_ARRAY: [c_char; 128] = [0; 128];


### PR DESCRIPTION
fix #476 

Just wondering, should I use `Source::write of (String, Type)` or `cdecl::write_field` directly?