### PR TITLE
Escape type name and field name of generated tagged union

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -17,6 +17,7 @@ use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
 use crate::bindgen::monomorph::Monomorphs;
 use crate::bindgen::rename::{IdentifierType, RenameRule};
+use crate::bindgen::reserved;
 use crate::bindgen::utilities::find_first_some;
 use crate::bindgen::writer::{ListType, Source, SourceWriter};
 
@@ -421,8 +422,9 @@ impl Item for Enum {
         }
 
         for variant in &mut self.variants {
-            if let Some((_, ref mut body)) = variant.body {
+            if let Some((ref mut field_name, ref mut body)) = variant.body {
                 body.rename_for_config(config);
+                reserved::escape(field_name);
             }
         }
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -422,6 +422,8 @@ impl Item for Enum {
         }
 
         for variant in &mut self.variants {
+            reserved::escape(&mut variant.export_name);
+
             if let Some((ref mut field_name, ref mut body)) = variant.body {
                 body.rename_for_config(config);
                 reserved::escape(field_name);

--- a/tests/expectations/both/reserved.c
+++ b/tests/expectations/both/reserved.c
@@ -30,4 +30,26 @@ typedef struct C {
   };
 } C;
 
-void root(A a, B b, C c, int32_t namespace_, float float_);
+enum E_Tag {
+  Double,
+  Float,
+};
+typedef uint8_t E_Tag;
+
+typedef struct Double_Body {
+  double _0;
+} Double_Body;
+
+typedef struct Float_Body {
+  float _0;
+} Float_Body;
+
+typedef struct E {
+  E_Tag tag;
+  union {
+    Double_Body double_;
+    Float_Body float_;
+  };
+} E;
+
+void root(A a, B b, C c, E e, int32_t namespace_, float float_);

--- a/tests/expectations/both/reserved.c
+++ b/tests/expectations/both/reserved.c
@@ -52,4 +52,26 @@ typedef struct E {
   };
 } E;
 
-void root(A a, B b, C c, E e, int32_t namespace_, float float_);
+enum F_Tag {
+  double_,
+  float_,
+};
+typedef uint8_t F_Tag;
+
+typedef struct double_Body {
+  double _0;
+} double_Body;
+
+typedef struct float_Body {
+  float _0;
+} float_Body;
+
+typedef struct F {
+  F_Tag tag;
+  union {
+    double_Body double_;
+    float_Body float_;
+  };
+} F;
+
+void root(A a, B b, C c, E e, F f, int32_t namespace_, float float_);

--- a/tests/expectations/both/reserved.compat.c
+++ b/tests/expectations/both/reserved.compat.c
@@ -64,11 +64,39 @@ typedef struct E {
   };
 } E;
 
+enum F_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  double_,
+  float_,
+};
+#ifndef __cplusplus
+typedef uint8_t F_Tag;
+#endif // __cplusplus
+
+typedef struct double_Body {
+  double _0;
+} double_Body;
+
+typedef struct float_Body {
+  float _0;
+} float_Body;
+
+typedef struct F {
+  F_Tag tag;
+  union {
+    double_Body double_;
+    float_Body float_;
+  };
+} F;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(A a, B b, C c, E e, int32_t namespace_, float float_);
+void root(A a, B b, C c, E e, F f, int32_t namespace_, float float_);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/both/reserved.compat.c
+++ b/tests/expectations/both/reserved.compat.c
@@ -36,11 +36,39 @@ typedef struct C {
   };
 } C;
 
+enum E_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Double,
+  Float,
+};
+#ifndef __cplusplus
+typedef uint8_t E_Tag;
+#endif // __cplusplus
+
+typedef struct Double_Body {
+  double _0;
+} Double_Body;
+
+typedef struct Float_Body {
+  float _0;
+} Float_Body;
+
+typedef struct E {
+  E_Tag tag;
+  union {
+    Double_Body double_;
+    Float_Body float_;
+  };
+} E;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(A a, B b, C c, int32_t namespace_, float float_);
+void root(A a, B b, C c, E e, int32_t namespace_, float float_);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/reserved.c
+++ b/tests/expectations/reserved.c
@@ -52,4 +52,26 @@ typedef struct {
   };
 } E;
 
-void root(A a, B b, C c, E e, int32_t namespace_, float float_);
+enum F_Tag {
+  double_,
+  float_,
+};
+typedef uint8_t F_Tag;
+
+typedef struct {
+  double _0;
+} double_Body;
+
+typedef struct {
+  float _0;
+} float_Body;
+
+typedef struct {
+  F_Tag tag;
+  union {
+    double_Body double_;
+    float_Body float_;
+  };
+} F;
+
+void root(A a, B b, C c, E e, F f, int32_t namespace_, float float_);

--- a/tests/expectations/reserved.c
+++ b/tests/expectations/reserved.c
@@ -30,4 +30,26 @@ typedef struct {
   };
 } C;
 
-void root(A a, B b, C c, int32_t namespace_, float float_);
+enum E_Tag {
+  Double,
+  Float,
+};
+typedef uint8_t E_Tag;
+
+typedef struct {
+  double _0;
+} Double_Body;
+
+typedef struct {
+  float _0;
+} Float_Body;
+
+typedef struct {
+  E_Tag tag;
+  union {
+    Double_Body double_;
+    Float_Body float_;
+  };
+} E;
+
+void root(A a, B b, C c, E e, int32_t namespace_, float float_);

--- a/tests/expectations/reserved.compat.c
+++ b/tests/expectations/reserved.compat.c
@@ -64,11 +64,39 @@ typedef struct {
   };
 } E;
 
+enum F_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  double_,
+  float_,
+};
+#ifndef __cplusplus
+typedef uint8_t F_Tag;
+#endif // __cplusplus
+
+typedef struct {
+  double _0;
+} double_Body;
+
+typedef struct {
+  float _0;
+} float_Body;
+
+typedef struct {
+  F_Tag tag;
+  union {
+    double_Body double_;
+    float_Body float_;
+  };
+} F;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(A a, B b, C c, E e, int32_t namespace_, float float_);
+void root(A a, B b, C c, E e, F f, int32_t namespace_, float float_);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/reserved.compat.c
+++ b/tests/expectations/reserved.compat.c
@@ -36,11 +36,39 @@ typedef struct {
   };
 } C;
 
+enum E_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Double,
+  Float,
+};
+#ifndef __cplusplus
+typedef uint8_t E_Tag;
+#endif // __cplusplus
+
+typedef struct {
+  double _0;
+} Double_Body;
+
+typedef struct {
+  float _0;
+} Float_Body;
+
+typedef struct {
+  E_Tag tag;
+  union {
+    Double_Body double_;
+    Float_Body float_;
+  };
+} E;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(A a, B b, C c, int32_t namespace_, float float_);
+void root(A a, B b, C c, E e, int32_t namespace_, float float_);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/reserved.cpp
+++ b/tests/expectations/reserved.cpp
@@ -50,8 +50,29 @@ struct E {
   };
 };
 
+struct F {
+  enum class Tag : uint8_t {
+    double_,
+    float_,
+  };
+
+  struct double_Body {
+    double _0;
+  };
+
+  struct float_Body {
+    float _0;
+  };
+
+  Tag tag;
+  union {
+    double_Body double_;
+    float_Body float_;
+  };
+};
+
 extern "C" {
 
-void root(A a, B b, C c, E e, int32_t namespace_, float float_);
+void root(A a, B b, C c, E e, F f, int32_t namespace_, float float_);
 
 } // extern "C"

--- a/tests/expectations/reserved.cpp
+++ b/tests/expectations/reserved.cpp
@@ -29,8 +29,29 @@ struct C {
   };
 };
 
+struct E {
+  enum class Tag : uint8_t {
+    Double,
+    Float,
+  };
+
+  struct Double_Body {
+    double _0;
+  };
+
+  struct Float_Body {
+    float _0;
+  };
+
+  Tag tag;
+  union {
+    Double_Body double_;
+    Float_Body float_;
+  };
+};
+
 extern "C" {
 
-void root(A a, B b, C c, int32_t namespace_, float float_);
+void root(A a, B b, C c, E e, int32_t namespace_, float float_);
 
 } // extern "C"

--- a/tests/expectations/tag/reserved.c
+++ b/tests/expectations/tag/reserved.c
@@ -30,4 +30,26 @@ struct C {
   };
 };
 
-void root(struct A a, struct B b, struct C c, int32_t namespace_, float float_);
+enum E_Tag {
+  Double,
+  Float,
+};
+typedef uint8_t E_Tag;
+
+struct Double_Body {
+  double _0;
+};
+
+struct Float_Body {
+  float _0;
+};
+
+struct E {
+  E_Tag tag;
+  union {
+    struct Double_Body double_;
+    struct Float_Body float_;
+  };
+};
+
+void root(struct A a, struct B b, struct C c, struct E e, int32_t namespace_, float float_);

--- a/tests/expectations/tag/reserved.c
+++ b/tests/expectations/tag/reserved.c
@@ -52,4 +52,32 @@ struct E {
   };
 };
 
-void root(struct A a, struct B b, struct C c, struct E e, int32_t namespace_, float float_);
+enum F_Tag {
+  double_,
+  float_,
+};
+typedef uint8_t F_Tag;
+
+struct double_Body {
+  double _0;
+};
+
+struct float_Body {
+  float _0;
+};
+
+struct F {
+  F_Tag tag;
+  union {
+    struct double_Body double_;
+    struct float_Body float_;
+  };
+};
+
+void root(struct A a,
+          struct B b,
+          struct C c,
+          struct E e,
+          struct F f,
+          int32_t namespace_,
+          float float_);

--- a/tests/expectations/tag/reserved.compat.c
+++ b/tests/expectations/tag/reserved.compat.c
@@ -36,11 +36,39 @@ struct C {
   };
 };
 
+enum E_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  Double,
+  Float,
+};
+#ifndef __cplusplus
+typedef uint8_t E_Tag;
+#endif // __cplusplus
+
+struct Double_Body {
+  double _0;
+};
+
+struct Float_Body {
+  float _0;
+};
+
+struct E {
+  E_Tag tag;
+  union {
+    struct Double_Body double_;
+    struct Float_Body float_;
+  };
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(struct A a, struct B b, struct C c, int32_t namespace_, float float_);
+void root(struct A a, struct B b, struct C c, struct E e, int32_t namespace_, float float_);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/tag/reserved.compat.c
+++ b/tests/expectations/tag/reserved.compat.c
@@ -64,11 +64,45 @@ struct E {
   };
 };
 
+enum F_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  double_,
+  float_,
+};
+#ifndef __cplusplus
+typedef uint8_t F_Tag;
+#endif // __cplusplus
+
+struct double_Body {
+  double _0;
+};
+
+struct float_Body {
+  float _0;
+};
+
+struct F {
+  F_Tag tag;
+  union {
+    struct double_Body double_;
+    struct float_Body float_;
+  };
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(struct A a, struct B b, struct C c, struct E e, int32_t namespace_, float float_);
+void root(struct A a,
+          struct B b,
+          struct C c,
+          struct E e,
+          struct F f,
+          int32_t namespace_,
+          float float_);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/rust/reserved.rs
+++ b/tests/rust/reserved.rs
@@ -19,12 +19,19 @@ enum E {
     Float(f32),
 }
 
+#[repr(C, u8)]
+enum F {
+    double(f64),
+    float(f32),
+}
+
 #[no_mangle]
 pub extern "C" fn root(
     a: A,
     b: B,
     c: C,
     e: E,
+    f: F,
     namespace: i32,
     float: f32,
 ) { }

--- a/tests/rust/reserved.rs
+++ b/tests/rust/reserved.rs
@@ -13,11 +13,18 @@ enum C {
     D { namespace: i32, float: f32 },
 }
 
+#[repr(C, u8)]
+enum E {
+    Double(f64),
+    Float(f32),
+}
+
 #[no_mangle]
 pub extern "C" fn root(
     a: A,
     b: B,
     c: C,
+    e: E,
     namespace: i32,
     float: f32,
 ) { }


### PR DESCRIPTION
Should fix  #368
I escape the `enum Tag` as well since they are quite relevant.