### PR TITLE
ir: Add support for Cell and RefCell.

### DIFF
--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -392,6 +392,7 @@ impl Type {
             // FIXME(#223): This is not quite correct.
             "Option" if generic.is_repr_ptr() => Some(generic),
             "NonNull" => Some(Type::Ptr(Box::new(generic))),
+            "Cell" => Some(generic),
             _ => None,
         }
     }

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -387,6 +387,7 @@ impl Parse {
 
         add_opaque("String", vec![]);
         add_opaque("Box", vec!["T"]);
+        add_opaque("RefCell", vec!["T"]);
         add_opaque("Rc", vec!["T"]);
         add_opaque("Arc", vec!["T"]);
         add_opaque("Result", vec!["T", "E"]);

--- a/tests/expectations/both/cell.c
+++ b/tests/expectations/both/cell.c
@@ -1,0 +1,14 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct NotReprC_RefCell_i32 NotReprC_RefCell_i32;
+
+typedef NotReprC_RefCell_i32 Foo;
+
+typedef struct MyStruct {
+  int32_t number;
+} MyStruct;
+
+void root(const Foo *a, const MyStruct *with_cell);

--- a/tests/expectations/both/cell.compat.c
+++ b/tests/expectations/both/cell.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct NotReprC_RefCell_i32 NotReprC_RefCell_i32;
+
+typedef NotReprC_RefCell_i32 Foo;
+
+typedef struct MyStruct {
+  int32_t number;
+} MyStruct;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(const Foo *a, const MyStruct *with_cell);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/cell.c
+++ b/tests/expectations/cell.c
@@ -1,0 +1,14 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct NotReprC_RefCell_i32 NotReprC_RefCell_i32;
+
+typedef NotReprC_RefCell_i32 Foo;
+
+typedef struct {
+  int32_t number;
+} MyStruct;
+
+void root(const Foo *a, const MyStruct *with_cell);

--- a/tests/expectations/cell.compat.c
+++ b/tests/expectations/cell.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct NotReprC_RefCell_i32 NotReprC_RefCell_i32;
+
+typedef NotReprC_RefCell_i32 Foo;
+
+typedef struct {
+  int32_t number;
+} MyStruct;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(const Foo *a, const MyStruct *with_cell);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/cell.cpp
+++ b/tests/expectations/cell.cpp
@@ -1,0 +1,22 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+
+template<typename T>
+struct NotReprC;
+
+template<typename T>
+struct RefCell;
+
+using Foo = NotReprC<RefCell<int32_t>>;
+
+struct MyStruct {
+  int32_t number;
+};
+
+extern "C" {
+
+void root(const Foo *a, const MyStruct *with_cell);
+
+} // extern "C"

--- a/tests/expectations/tag/cell.c
+++ b/tests/expectations/tag/cell.c
@@ -1,0 +1,14 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct NotReprC_RefCell_i32;
+
+typedef struct NotReprC_RefCell_i32 Foo;
+
+struct MyStruct {
+  int32_t number;
+};
+
+void root(const Foo *a, const struct MyStruct *with_cell);

--- a/tests/expectations/tag/cell.compat.c
+++ b/tests/expectations/tag/cell.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct NotReprC_RefCell_i32;
+
+typedef struct NotReprC_RefCell_i32 Foo;
+
+struct MyStruct {
+  int32_t number;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(const Foo *a, const struct MyStruct *with_cell);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/rust/cell.rs
+++ b/tests/rust/cell.rs
@@ -1,0 +1,11 @@
+#[repr(C)]
+pub struct MyStruct {
+    number: std::cell::Cell<i32>,
+}
+
+pub struct NotReprC<T> { inner: T }
+
+pub type Foo = NotReprC<std::cell::RefCell<i32>>;
+
+#[no_mangle]
+pub extern "C" fn root(a: &Foo, with_cell: &MyStruct) {}


### PR DESCRIPTION
RefCell is opaque. Cell is repr(transparent) so can just be the inner type.

Simplify it the same way as we simplify Option<&mut T> and such.

Fixes #488