### PR TITLE
parser: Don't panic when finding associated constants to a primitive.

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -707,11 +707,22 @@ impl Parse {
                 return;
             }
         };
-        if ty.is_none() {
-            return;
-        }
 
-        let impl_path = ty.unwrap().get_root_path().unwrap();
+        let ty = match ty {
+            Some(ty) => ty,
+            None => return,
+        };
+
+        let impl_path = match ty.get_root_path() {
+            Some(p) => p,
+            None => {
+                warn!(
+                    "Couldn't find path for {:?}, skipping associated constants",
+                    ty
+                );
+                return;
+            }
+        };
 
         for item in items.into_iter() {
             if let syn::Visibility::Public(_) = item.vis {

--- a/tests/expectations/associated_constant_panic.c
+++ b/tests/expectations/associated_constant_panic.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/associated_constant_panic.compat.c
+++ b/tests/expectations/associated_constant_panic.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/associated_constant_panic.cpp
+++ b/tests/expectations/associated_constant_panic.cpp
@@ -1,0 +1,4 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>

--- a/tests/expectations/both/associated_constant_panic.c
+++ b/tests/expectations/both/associated_constant_panic.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/both/associated_constant_panic.compat.c
+++ b/tests/expectations/both/associated_constant_panic.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/tag/associated_constant_panic.c
+++ b/tests/expectations/tag/associated_constant_panic.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/tag/associated_constant_panic.compat.c
+++ b/tests/expectations/tag/associated_constant_panic.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/rust/associated_constant_panic.rs
+++ b/tests/rust/associated_constant_panic.rs
@@ -1,0 +1,7 @@
+pub trait F {
+    const B: u8;
+}
+
+impl F for u16 {
+    const B: u8 = 3;
+}


### PR DESCRIPTION
We don't handle it, but no reason to panic.