### PR TITLE
Add option for `mangling_separator` in ExportConfig

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -247,7 +247,7 @@ pub struct ExportConfig {
     /// Whether renaming overrides or extends prefixing.
     pub renaming_overrides_prefixing: bool,
     /// Name mangling character. Defaults to `_`
-    pub mangling_separator: Option<String>,
+    pub mangle_separator: Option<String>,
 }
 
 impl ExportConfig {

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -246,6 +246,8 @@ pub struct ExportConfig {
     pub item_types: Vec<ItemType>,
     /// Whether renaming overrides or extends prefixing.
     pub renaming_overrides_prefixing: bool,
+    /// Name mangling character. Defaults to `_`
+    pub mangling_separator: Option<String>,
 }
 
 impl ExportConfig {

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -227,7 +227,7 @@ impl EnumVariant {
 
     fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], config: &Config) -> Self {
         Self::new(
-            mangle::mangle_name(&self.name, generic_values, config.export.mangling_separator.as_deref()),
+            mangle::mangle_name(&self.name, generic_values, config.export.mangle_separator.as_deref()),
             self.discriminant,
             self.body.specialize(generic_values, mappings, config),
             self.cfg.clone(),
@@ -547,7 +547,7 @@ impl Item for Enum {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangling_separator.as_deref());
+            library.get_config().export.mangle_separator.as_deref());
 
         let monomorph = Enum::new(
             mangled_path,

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -51,7 +51,12 @@ impl VariantBody {
         }
     }
 
-    fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], config: &Config) -> Self {
+    fn specialize(
+        &self,
+        generic_values: &[Type],
+        mappings: &[(&Path, &Type)],
+        config: &Config,
+    ) -> Self {
         match *self {
             Self::Empty(ref annos) => Self::Empty(annos.clone()),
             Self::Body { ref name, ref body } => Self::Body {
@@ -225,9 +230,18 @@ impl EnumVariant {
         }
     }
 
-    fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], config: &Config) -> Self {
+    fn specialize(
+        &self,
+        generic_values: &[Type],
+        mappings: &[(&Path, &Type)],
+        config: &Config,
+    ) -> Self {
         Self::new(
-            mangle::mangle_name(&self.name, generic_values, config.export.mangle_separator.as_deref()),
+            mangle::mangle_name(
+                &self.name,
+                generic_values,
+                config.export.mangle_separator.as_deref(),
+            ),
             self.discriminant,
             self.body.specialize(generic_values, mappings, config),
             self.cfg.clone(),
@@ -547,7 +561,8 @@ impl Item for Enum {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangle_separator.as_deref());
+            library.get_config().export.mangle_separator.as_deref(),
+        );
 
         let monomorph = Enum::new(
             mangled_path,
@@ -1055,8 +1070,8 @@ impl Source for Enum {
 
             if config.language == Language::Cxx
                 && config
-                .enumeration
-                .private_default_tagged_enum_constructor(&self.annotations)
+                    .enumeration
+                    .private_default_tagged_enum_constructor(&self.annotations)
             {
                 out.new_line();
                 out.new_line();
@@ -1072,8 +1087,8 @@ impl Source for Enum {
 
             if config.language == Language::Cxx
                 && config
-                .enumeration
-                .derive_tagged_enum_destructor(&self.annotations)
+                    .enumeration
+                    .derive_tagged_enum_destructor(&self.annotations)
             {
                 out.new_line();
                 out.new_line();
@@ -1110,8 +1125,8 @@ impl Source for Enum {
 
             if config.language == Language::Cxx
                 && config
-                .enumeration
-                .derive_tagged_enum_copy_constructor(&self.annotations)
+                    .enumeration
+                    .derive_tagged_enum_copy_constructor(&self.annotations)
             {
                 out.new_line();
                 out.new_line();
@@ -1155,8 +1170,8 @@ impl Source for Enum {
 
                 if config.language == Language::Cxx
                     && config
-                    .enumeration
-                    .derive_tagged_enum_copy_assignment(&self.annotations)
+                        .enumeration
+                        .derive_tagged_enum_copy_assignment(&self.annotations)
                 {
                     out.new_line();
                     write_attrs!("copy-assignment");

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -51,12 +51,12 @@ impl VariantBody {
         }
     }
 
-    fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], mangling_separator: &Option<String>) -> Self {
+    fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], config: &Config) -> Self {
         match *self {
             Self::Empty(ref annos) => Self::Empty(annos.clone()),
             Self::Body { ref name, ref body } => Self::Body {
                 name: name.clone(),
-                body: body.specialize(generic_values, mappings, mangling_separator),
+                body: body.specialize(generic_values, mappings, config),
             },
         }
     }
@@ -225,11 +225,11 @@ impl EnumVariant {
         }
     }
 
-    fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], mangling_separator: &Option<String>) -> Self {
+    fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], config: &Config) -> Self {
         Self::new(
-            mangle::mangle_name(&self.name, generic_values, mangling_separator),
+            mangle::mangle_name(&self.name, generic_values, &config.export.mangling_separator),
             self.discriminant,
-            self.body.specialize(generic_values, mappings, mangling_separator),
+            self.body.specialize(generic_values, mappings, config),
             self.cfg.clone(),
             self.documentation.clone(),
         )
@@ -544,14 +544,14 @@ impl Item for Enum {
             }
         }
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, &library.get_mangling_separator());
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, &library.get_config().export.mangling_separator);
         let monomorph = Enum::new(
             mangled_path,
             GenericParams::default(),
             self.repr,
             self.variants
                 .iter()
-                .map(|v| v.specialize(generic_values, &mappings, library.get_mangling_separator()))
+                .map(|v| v.specialize(generic_values, &mappings, library.get_config()))
                 .collect(),
             self.tag.clone(),
             self.cfg.clone(),

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -544,7 +544,11 @@ impl Item for Enum {
             }
         }
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, library.get_config().export.mangling_separator.as_deref());
+        let mangled_path = mangle::mangle_path(
+            &self.path,
+            generic_values,
+            library.get_config().export.mangling_separator.as_deref());
+
         let monomorph = Enum::new(
             mangled_path,
             GenericParams::default(),
@@ -1051,8 +1055,8 @@ impl Source for Enum {
 
             if config.language == Language::Cxx
                 && config
-                    .enumeration
-                    .private_default_tagged_enum_constructor(&self.annotations)
+                .enumeration
+                .private_default_tagged_enum_constructor(&self.annotations)
             {
                 out.new_line();
                 out.new_line();
@@ -1068,8 +1072,8 @@ impl Source for Enum {
 
             if config.language == Language::Cxx
                 && config
-                    .enumeration
-                    .derive_tagged_enum_destructor(&self.annotations)
+                .enumeration
+                .derive_tagged_enum_destructor(&self.annotations)
             {
                 out.new_line();
                 out.new_line();
@@ -1106,8 +1110,8 @@ impl Source for Enum {
 
             if config.language == Language::Cxx
                 && config
-                    .enumeration
-                    .derive_tagged_enum_copy_constructor(&self.annotations)
+                .enumeration
+                .derive_tagged_enum_copy_constructor(&self.annotations)
             {
                 out.new_line();
                 out.new_line();
@@ -1151,8 +1155,8 @@ impl Source for Enum {
 
                 if config.language == Language::Cxx
                     && config
-                        .enumeration
-                        .derive_tagged_enum_copy_assignment(&self.annotations)
+                    .enumeration
+                    .derive_tagged_enum_copy_assignment(&self.annotations)
                 {
                     out.new_line();
                     write_attrs!("copy-assignment");

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -149,17 +149,17 @@ impl EnumVariant {
                 VariantBody::Body {
                     name,
                     body: Struct::new(
-                        path,
-                        generic_params,
-                        parse_fields(is_tagged, &fields.named, self_path)?,
-                        is_tagged,
-                        true,
-                        None,
-                        false,
-                        false,
-                        None,
+                    path,
+                    generic_params,
+                    parse_fields(is_tagged, &fields.named, self_path)?,
+                    is_tagged,
+                    true,
+                    None,
+                    false,
+                    false,
+                    None,
                         annotations,
-                        Documentation::none(),
+                    Documentation::none(),
                     ),
                 }
             }
@@ -170,17 +170,17 @@ impl EnumVariant {
                 VariantBody::Body {
                     name,
                     body: Struct::new(
-                        path,
-                        generic_params,
-                        parse_fields(is_tagged, &fields.unnamed, self_path)?,
-                        is_tagged,
-                        true,
-                        None,
-                        false,
-                        true,
-                        None,
+                    path,
+                    generic_params,
+                    parse_fields(is_tagged, &fields.unnamed, self_path)?,
+                    is_tagged,
+                    true,
+                    None,
+                    false,
+                    true,
+                    None,
                         annotations,
-                        Documentation::none(),
+                    Documentation::none(),
                     ),
                 }
             }
@@ -189,7 +189,7 @@ impl EnumVariant {
         Ok(EnumVariant::new(
             variant.ident.to_string(),
             discriminant,
-            body,
+                    body,
             variant_cfg,
             Documentation::load(&variant.attrs),
         ))
@@ -225,11 +225,11 @@ impl EnumVariant {
         }
     }
 
-    fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)]) -> Self {
+    fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], mangling_separator: &Option<String>) -> Self {
         Self::new(
-            mangle::mangle_name(&self.name, generic_values),
+            mangle::mangle_name(&self.name, generic_values, mangling_separator),
             self.discriminant,
-            self.body.specialize(generic_values, mappings),
+            self.body.specialize(generic_values, mappings, mangling_separator),
             self.cfg.clone(),
             self.documentation.clone(),
         )
@@ -544,14 +544,14 @@ impl Item for Enum {
             }
         }
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values);
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, &library.get_mangling_separator());
         let monomorph = Enum::new(
             mangled_path,
             GenericParams::default(),
             self.repr,
             self.variants
                 .iter()
-                .map(|v| v.specialize(generic_values, &mappings))
+                .map(|v| v.specialize(generic_values, &mappings, library.get_mangling_separator()))
                 .collect(),
             self.tag.clone(),
             self.cfg.clone(),

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -227,7 +227,7 @@ impl EnumVariant {
 
     fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], config: &Config) -> Self {
         Self::new(
-            mangle::mangle_name(&self.name, generic_values, &config.export.mangling_separator),
+            mangle::mangle_name(&self.name, generic_values, config.export.mangling_separator.as_deref()),
             self.discriminant,
             self.body.specialize(generic_values, mappings, config),
             self.cfg.clone(),
@@ -544,7 +544,7 @@ impl Item for Enum {
             }
         }
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, &library.get_config().export.mangling_separator);
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, library.get_config().export.mangling_separator.as_deref());
         let monomorph = Enum::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -149,17 +149,17 @@ impl EnumVariant {
                 VariantBody::Body {
                     name,
                     body: Struct::new(
-                    path,
-                    generic_params,
-                    parse_fields(is_tagged, &fields.named, self_path)?,
-                    is_tagged,
-                    true,
-                    None,
-                    false,
-                    false,
-                    None,
+                        path,
+                        generic_params,
+                        parse_fields(is_tagged, &fields.named, self_path)?,
+                        is_tagged,
+                        true,
+                        None,
+                        false,
+                        false,
+                        None,
                         annotations,
-                    Documentation::none(),
+                        Documentation::none(),
                     ),
                 }
             }
@@ -170,17 +170,17 @@ impl EnumVariant {
                 VariantBody::Body {
                     name,
                     body: Struct::new(
-                    path,
-                    generic_params,
-                    parse_fields(is_tagged, &fields.unnamed, self_path)?,
-                    is_tagged,
-                    true,
-                    None,
-                    false,
-                    true,
-                    None,
+                        path,
+                        generic_params,
+                        parse_fields(is_tagged, &fields.unnamed, self_path)?,
+                        is_tagged,
+                        true,
+                        None,
+                        false,
+                        true,
+                        None,
                         annotations,
-                    Documentation::none(),
+                        Documentation::none(),
                     ),
                 }
             }
@@ -189,7 +189,7 @@ impl EnumVariant {
         Ok(EnumVariant::new(
             variant.ident.to_string(),
             discriminant,
-                    body,
+            body,
             variant_cfg,
             Documentation::load(&variant.attrs),
         ))

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -51,12 +51,12 @@ impl VariantBody {
         }
     }
 
-    fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)]) -> Self {
+    fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], mangling_separator: &Option<String>) -> Self {
         match *self {
             Self::Empty(ref annos) => Self::Empty(annos.clone()),
             Self::Body { ref name, ref body } => Self::Body {
                 name: name.clone(),
-                body: body.specialize(generic_values, mappings),
+                body: body.specialize(generic_values, mappings, mangling_separator),
             },
         }
     }

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -101,7 +101,7 @@ impl Item for OpaqueItem {
     fn instantiate_monomorph(
         &self,
         generic_values: &[Type],
-        _library: &Library,
+        library: &Library,
         out: &mut Monomorphs,
     ) {
         assert!(
@@ -117,7 +117,7 @@ impl Item for OpaqueItem {
             generic_values.len(),
         );
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values);
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, library.get_mangling_separator());
         let monomorph = OpaqueItem::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -120,7 +120,8 @@ impl Item for OpaqueItem {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangle_separator.as_deref());
+            library.get_config().export.mangle_separator.as_deref(),
+        );
 
         let monomorph = OpaqueItem::new(
             mangled_path,

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -117,7 +117,11 @@ impl Item for OpaqueItem {
             generic_values.len(),
         );
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, &library.get_config().export.mangling_separator);
+        let mangled_path = mangle::mangle_path(
+            &self.path,
+            generic_values,
+            library.get_config().export.mangling_separator.as_deref());
+
         let monomorph = OpaqueItem::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -120,7 +120,7 @@ impl Item for OpaqueItem {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangling_separator.as_deref());
+            library.get_config().export.mangle_separator.as_deref());
 
         let monomorph = OpaqueItem::new(
             mangled_path,

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -117,7 +117,7 @@ impl Item for OpaqueItem {
             generic_values.len(),
         );
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, library.get_mangling_separator());
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, &library.get_config().export.mangling_separator);
         let monomorph = OpaqueItem::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -172,8 +172,8 @@ impl Struct {
         }
     }
 
-    pub fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], mangling_separator: &Option<String>) -> Self {
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, mangling_separator);
+    pub fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], config: &Config) -> Self {
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, &config.export.mangling_separator);
         Struct::new(
             mangled_path,
             GenericParams::default(),
@@ -377,7 +377,7 @@ impl Item for Struct {
             .zip(generic_values.iter())
             .collect::<Vec<_>>();
 
-        let monomorph = self.specialize(generic_values, &mappings, library.get_mangling_separator());
+        let monomorph = self.specialize(generic_values, &mappings, library.get_config());
 
         // Instantiate any monomorphs for any generic paths we may have just created.
         monomorph.add_monomorphs(library, out);

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -173,7 +173,7 @@ impl Struct {
     }
 
     pub fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], config: &Config) -> Self {
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, &config.export.mangling_separator);
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, config.export.mangling_separator.as_deref());
         Struct::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -172,8 +172,17 @@ impl Struct {
         }
     }
 
-    pub fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], config: &Config) -> Self {
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, config.export.mangle_separator.as_deref());
+    pub fn specialize(
+        &self,
+        generic_values: &[Type],
+        mappings: &[(&Path, &Type)],
+        config: &Config,
+    ) -> Self {
+        let mangled_path = mangle::mangle_path(
+            &self.path,
+            generic_values,
+            config.export.mangle_separator.as_deref(),
+        );
         Struct::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -173,7 +173,7 @@ impl Struct {
     }
 
     pub fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], config: &Config) -> Self {
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, config.export.mangling_separator.as_deref());
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, config.export.mangle_separator.as_deref());
         Struct::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -172,8 +172,8 @@ impl Struct {
         }
     }
 
-    pub fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)]) -> Self {
-        let mangled_path = mangle::mangle_path(&self.path, generic_values);
+    pub fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)], mangling_separator: &Option<String>) -> Self {
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, mangling_separator);
         Struct::new(
             mangled_path,
             GenericParams::default(),
@@ -377,7 +377,7 @@ impl Item for Struct {
             .zip(generic_values.iter())
             .collect::<Vec<_>>();
 
-        let monomorph = self.specialize(generic_values, &mappings);
+        let monomorph = self.specialize(generic_values, &mappings, library.get_mangling_separator());
 
         // Instantiate any monomorphs for any generic paths we may have just created.
         monomorph.add_monomorphs(library, out);

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -174,7 +174,7 @@ impl Item for Typedef {
             .zip(generic_values.iter())
             .collect::<Vec<_>>();
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values);
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, library.get_mangling_separator());
         let monomorph = Typedef::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -174,7 +174,7 @@ impl Item for Typedef {
             .zip(generic_values.iter())
             .collect::<Vec<_>>();
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, library.get_mangling_separator());
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, &library.get_config().export.mangling_separator);
         let monomorph = Typedef::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -174,7 +174,11 @@ impl Item for Typedef {
             .zip(generic_values.iter())
             .collect::<Vec<_>>();
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, &library.get_config().export.mangling_separator);
+        let mangled_path = mangle::mangle_path(
+            &self.path,
+            generic_values,
+            library.get_config().export.mangling_separator.as_deref());
+
         let monomorph = Typedef::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -177,7 +177,8 @@ impl Item for Typedef {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangle_separator.as_deref());
+            library.get_config().export.mangle_separator.as_deref(),
+        );
 
         let monomorph = Typedef::new(
             mangled_path,

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -177,7 +177,7 @@ impl Item for Typedef {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangling_separator.as_deref());
+            library.get_config().export.mangle_separator.as_deref());
 
         let monomorph = Typedef::new(
             mangled_path,

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -236,7 +236,7 @@ impl Item for Union {
             .zip(generic_values.iter())
             .collect::<Vec<_>>();
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values);
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, library.get_mangling_separator());
         let monomorph = Union::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -236,7 +236,11 @@ impl Item for Union {
             .zip(generic_values.iter())
             .collect::<Vec<_>>();
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, &library.get_config().export.mangling_separator);
+        let mangled_path = mangle::mangle_path(
+            &self.path,
+            generic_values,
+            library.get_config().export.mangling_separator.as_deref());
+
         let monomorph = Union::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -239,7 +239,8 @@ impl Item for Union {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangle_separator.as_deref());
+            library.get_config().export.mangle_separator.as_deref(),
+        );
 
         let monomorph = Union::new(
             mangled_path,

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -236,7 +236,7 @@ impl Item for Union {
             .zip(generic_values.iter())
             .collect::<Vec<_>>();
 
-        let mangled_path = mangle::mangle_path(&self.path, generic_values, library.get_mangling_separator());
+        let mangled_path = mangle::mangle_path(&self.path, generic_values, &library.get_config().export.mangling_separator);
         let monomorph = Union::new(
             mangled_path,
             GenericParams::default(),

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -239,7 +239,7 @@ impl Item for Union {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangling_separator.as_deref());
+            library.get_config().export.mangle_separator.as_deref());
 
         let monomorph = Union::new(
             mangled_path,

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -149,6 +149,10 @@ impl Library {
         None
     }
 
+    pub fn get_mangling_separator(&self) -> &Option<String> {
+        &self.config.export.mangling_separator
+    }
+
     fn remove_excluded(&mut self) {
         let config = &self.config;
         // FIXME: interpret `config.export.exclude` as `Path`s.

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -149,8 +149,8 @@ impl Library {
         None
     }
 
-    pub fn get_mangling_separator(&self) -> &Option<String> {
-        &self.config.export.mangling_separator
+    pub fn get_config(&self) -> &Config {
+        &self.config
     }
 
     fn remove_excluded(&mut self) {

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -9,7 +9,13 @@ pub fn mangle_path(path: &Path, generic_values: &[Type], mangle_separator: Optio
 }
 
 pub fn mangle_name(name: &str, generic_values: &[Type], mangle_separator: Option<&str>) -> String {
-    Mangler::new(name, generic_values, /* last = */ true, mangle_separator).mangle()
+    Mangler::new(
+        name,
+        generic_values,
+        /* last = */ true,
+        mangle_separator,
+    )
+    .mangle()
 }
 
 enum Separator {
@@ -29,7 +35,12 @@ struct Mangler<'a> {
 }
 
 impl<'a> Mangler<'a> {
-    fn new(input: &'a str, generic_values: &'a [Type], last: bool, mangle_separator: Option<&'a str>) -> Self {
+    fn new(
+        input: &'a str,
+        generic_values: &'a [Type],
+        last: bool,
+        mangle_separator: Option<&'a str>,
+    ) -> Self {
         let separator = match mangle_separator {
             Some(s) => s,
             None => "_",
@@ -50,14 +61,20 @@ impl<'a> Mangler<'a> {
 
     fn push(&mut self, id: Separator) {
         let count = id as usize;
-        self.output.extend(std::iter::repeat(self.mangle_separator).take(count));
+        self.output
+            .extend(std::iter::repeat(self.mangle_separator).take(count));
     }
 
     fn append_mangled_type(&mut self, ty: &Type, last: bool) {
         match *ty {
             Type::Path(ref generic) => {
-                let sub_path =
-                    Mangler::new(generic.export_name(), generic.generics(), last, Some(self.mangle_separator)).mangle();
+                let sub_path = Mangler::new(
+                    generic.export_name(),
+                    generic.generics(),
+                    last,
+                    Some(self.mangle_separator),
+                )
+                .mangle();
                 self.output.push_str(&sub_path);
             }
             Type::Primitive(ref primitive) => {
@@ -132,7 +149,11 @@ fn generics() {
 
     // Foo<Bar<f32>> => Foo_Bar_f32
     assert_eq!(
-        mangle_path(&Path::new("Foo"), &vec![generic_path("Bar", &[float()])], None),
+        mangle_path(
+            &Path::new("Foo"),
+            &vec![generic_path("Bar", &[float()])],
+            None
+        ),
         Path::new("Foo_Bar_f32")
     );
 
@@ -150,7 +171,11 @@ fn generics() {
 
     // Foo<Bar<T>> => Foo_Bar_T
     assert_eq!(
-        mangle_path(&Path::new("Foo"), &[generic_path("Bar", &[path("T")])], None),
+        mangle_path(
+            &Path::new("Foo"),
+            &[generic_path("Bar", &[path("T")])],
+            None
+        ),
         Path::new("Foo_Bar_T")
     );
 

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -4,8 +4,8 @@
 
 use crate::bindgen::ir::{Path, Type};
 
-pub fn mangle_path(path: &Path, generic_values: &[Type], mangle_seperator: Option<&str>) -> Path {
-    Path::new(mangle_name(path.name(), generic_values, mangle_seperator))
+pub fn mangle_path(path: &Path, generic_values: &[Type], mangle_separator: Option<&str>) -> Path {
+    Path::new(mangle_name(path.name(), generic_values, mangle_separator))
 }
 
 pub fn mangle_name(name: &str, generic_values: &[Type], mangle_separator: Option<&str>) -> String {

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -4,12 +4,12 @@
 
 use crate::bindgen::ir::{Path, Type};
 
-pub fn mangle_path(path: &Path, generic_values: &[Type]) -> Path {
-    Path::new(mangle_name(path.name(), generic_values))
+pub fn mangle_path(path: &Path, generic_values: &[Type], mangle_seperator: &Option<String>) -> Path {
+    Path::new(mangle_name(path.name(), generic_values, mangle_seperator))
 }
 
-pub fn mangle_name(name: &str, generic_values: &[Type]) -> String {
-    Mangler::new(name, generic_values, /* last = */ true).mangle()
+pub fn mangle_name(name: &str, generic_values: &[Type], mangle_seperator: &Option<String>) -> String {
+    Mangler::new(name, generic_values, /* last = */ true, mangle_seperator).mangle()
 }
 
 enum Separator {
@@ -25,6 +25,7 @@ struct Mangler<'a> {
     generic_values: &'a [Type],
     output: String,
     last: bool,
+    mangle_separator: Option<String>
 }
 
 impl<'a> Mangler<'a> {
@@ -34,7 +35,7 @@ impl<'a> Mangler<'a> {
             generic_values,
             output: String::new(),
             last,
-            mangle_separator: &Option<String>,
+            mangle_separator: mangle_separator.clone(),
         }
     }
 
@@ -44,7 +45,7 @@ impl<'a> Mangler<'a> {
     }
 
     fn push(&mut self, id: Separator) {
-        let separator = match mangle_separator {
+        let separator = match &self.mangle_separator {
             Some(s) => s.to_owned(),
             None => "_".to_string()
         };
@@ -104,14 +105,6 @@ impl<'a> Mangler<'a> {
         }
         }
     }
-
-fn concat_separators(separator: &str, number: u8) -> String {
-    let mut result: String = "".to_string();
-    for _ in 0..number {
-        result += separator;
-    }
-    result
-}
 
 fn concat_separators(separator: &str, number: u8) -> String {
     let mut result: String = "".to_string();

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -102,7 +102,15 @@ impl<'a> Mangler<'a> {
         if !self.last {
             self.push(Separator::ClosingAngleBracket)
         }
+        }
     }
+
+fn concat_separators(separator: &str, number: u8) -> String {
+    let mut result: String = "".to_string();
+    for _ in 0..number {
+        result += separator;
+    }
+    result
 }
 
 fn concat_separators(separator: &str, number: u8) -> String {

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -25,7 +25,7 @@ struct Mangler<'a> {
     generic_values: &'a [Type],
     output: String,
     last: bool,
-    mangle_separator: &'a str
+    mangle_separator: &'a str,
 }
 
 impl<'a> Mangler<'a> {
@@ -39,7 +39,7 @@ impl<'a> Mangler<'a> {
             generic_values,
             output: String::new(),
             last,
-            mangle_separator: seperator
+            mangle_separator: seperator,
         }
     }
 
@@ -103,8 +103,8 @@ impl<'a> Mangler<'a> {
         if !self.last {
             self.push(Separator::ClosingAngleBracket)
         }
-        }
     }
+}
 
 #[test]
 fn generics() {


### PR DESCRIPTION
Addresses #437 

I'm not sure if `mangling_separator` should live in ExportConfig or elsewhere. 
Also wondering if there is a neater way to pass `mangling_separator` down the call chain.

Tested with a `cpp_compat` config, without the new option and with. 

Not able to run tests yet due to #499 