### PR TITLE
enum: Unconditionally generate a return statement in partialeq implementations.

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -946,9 +946,13 @@ impl Source for Enum {
                     }
                 }
                 if !exhaustive {
-                    write!(out, "default: return true;");
+                    write!(out, "default: break;");
                 }
                 out.close_brace(false);
+
+                out.new_line();
+                write!(out, "return true;");
+
                 out.close_brace(false);
 
                 if config.structure.derive_neq(&self.annotations) {

--- a/tests/expectations/cfg.cpp
+++ b/tests/expectations/cfg.cpp
@@ -124,8 +124,9 @@ union C {
 #if defined(PLATFORM_UNIX)
       case Tag::C5: return c5 == other.c5;
 #endif
-      default: return true;
+      default: break;
     }
+    return true;
   }
 
   bool operator!=(const C& other) const {

--- a/tests/expectations/derive-eq.cpp
+++ b/tests/expectations/derive-eq.cpp
@@ -82,8 +82,9 @@ union Bar {
       case Tag::Bazz: return bazz == aOther.bazz;
       case Tag::FooNamed: return foo_named == aOther.foo_named;
       case Tag::FooParen: return foo_paren == aOther.foo_paren;
-      default: return true;
+      default: break;
     }
+    return true;
   }
 
   bool operator!=(const Bar& aOther) const {


### PR DESCRIPTION
This fixes: https://bugzilla.mozilla.org/show_bug.cgi?id=1628754#c7