### PR TITLE
Add instructions for C language switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Then all you need to do is run it:
 cbindgen --config cbindgen.toml --crate my_rust_library --output my_header.h
 ```
 
+This produces a header file for C++.  For C, add the `--lang c` switch.
+
 See `cbindgen --help` for more options.
 
 [Read the full user docs here!](docs.md)

--- a/docs.md
+++ b/docs.md
@@ -36,6 +36,8 @@ Then all you need to do is run it:
 cbindgen --config cbindgen.toml --crate my_rust_library --output my_header.h
 ```
 
+This produces a header file for C++.  For C, add the `--lang c` switch.
+
 See `cbindgen --help` for more options.
 
 [Get a template cbindgen.toml here.](template.toml)


### PR DESCRIPTION
The default instructions produce C++ headers that are incompatible with
C.  This makes it explicit what the default command does, and the switch
needed to produce C headers.

Fixes #393.