### PR TITLE
Fixes to support Rust 1.32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ addons:
 script:
   - export CC=gcc-8
   - export CXX=g++-8
-  - cargo fmt --all -- --check
+  - echo $TRAVIS_RUST_VERSION
+  - test "$TRAVIS_RUST_VERSION" = "nightly" && cargo fmt --all -- --check || true
   - cargo build --verbose
   - cargo build --verbose --no-default-features
   - CBINDGEN_TEST_VERIFY=1 cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 cache: cargo
 rust:
   - nightly
+  - 1.32.0
 before_script:
   - rustup component add rustfmt
 addons:

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -34,27 +34,27 @@ pub enum VariantBody {
 
 impl VariantBody {
     fn empty() -> Self {
-        Self::Empty(AnnotationSet::new())
+        VariantBody::Empty(AnnotationSet::new())
     }
 
     fn annotations(&self) -> &AnnotationSet {
         match *self {
-            Self::Empty(ref anno) => anno,
-            Self::Body { ref body, .. } => &body.annotations,
+            VariantBody::Empty(ref anno) => anno,
+            VariantBody::Body { ref body, .. } => &body.annotations,
         }
     }
 
     fn is_empty(&self) -> bool {
         match *self {
-            Self::Empty(..) => true,
-            Self::Body { .. } => false,
+            VariantBody::Empty(..) => true,
+            VariantBody::Body { .. } => false,
         }
     }
 
     fn specialize(&self, generic_values: &[Type], mappings: &[(&Path, &Type)]) -> Self {
         match *self {
-            Self::Empty(ref annos) => Self::Empty(annos.clone()),
-            Self::Body { ref name, ref body } => Self::Body {
+            VariantBody::Empty(ref annos) => VariantBody::Empty(annos.clone()),
+            VariantBody::Body { ref name, ref body } => VariantBody::Body {
                 name: name.clone(),
                 body: body.specialize(generic_values, mappings),
             },


### PR DESCRIPTION
- travis-ci: add Rust 1.32 to the build matrix
- Don't use enum variants on type aliases
