### PR TITLE
function: Add support for wildcards in arguments.

### DIFF
--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -63,7 +63,7 @@ impl CDecl {
         let args = f
             .args
             .iter()
-            .map(|&(ref arg_name, ref arg_ty)| (arg_name.clone(), CDecl::from_type(arg_ty)))
+            .map(|arg| (arg.name.clone(), CDecl::from_type(&arg.ty)))
             .collect();
         self.declarators
             .push(CDeclarator::Func(args, layout_vertical));

--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -63,7 +63,7 @@ impl CDecl {
         let args = f
             .args
             .iter()
-            .map(|&(ref arg_name, ref arg_ty)| (Some(arg_name.clone()), CDecl::from_type(arg_ty)))
+            .map(|&(ref arg_name, ref arg_ty)| (arg_name.clone(), CDecl::from_type(arg_ty)))
             .collect();
         self.declarators
             .push(CDeclarator::Func(args, layout_vertical));

--- a/tests/expectations/both/function_args.c
+++ b/tests/expectations/both/function_args.c
@@ -6,3 +6,5 @@
 void pointer_test(const uint64_t *a);
 
 void print_from_rust(void);
+
+void unnamed(const uint64_t*);

--- a/tests/expectations/both/function_args.compat.c
+++ b/tests/expectations/both/function_args.compat.c
@@ -11,6 +11,8 @@ void pointer_test(const uint64_t *a);
 
 void print_from_rust(void);
 
+void unnamed(const uint64_t*);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/both/swift_name.c
+++ b/tests/expectations/both/swift_name.c
@@ -53,3 +53,5 @@ void free_function_should_exist_ref_mut(SelfTypeTestStruct *test_struct) CF_SWIF
 void free_function_should_not_exist_box(Box_SelfTypeTestStruct boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
 
 void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());
+
+void unnamed_argument(SelfTypeTestStruct*);

--- a/tests/expectations/both/swift_name.compat.c
+++ b/tests/expectations/both/swift_name.compat.c
@@ -58,6 +58,8 @@ void free_function_should_not_exist_box(Box_SelfTypeTestStruct boxed) CF_SWIFT_N
 
 void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());
 
+void unnamed_argument(SelfTypeTestStruct*);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/function_args.c
+++ b/tests/expectations/function_args.c
@@ -6,3 +6,5 @@
 void pointer_test(const uint64_t *a);
 
 void print_from_rust(void);
+
+void unnamed(const uint64_t*);

--- a/tests/expectations/function_args.compat.c
+++ b/tests/expectations/function_args.compat.c
@@ -11,6 +11,8 @@ void pointer_test(const uint64_t *a);
 
 void print_from_rust(void);
 
+void unnamed(const uint64_t*);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/function_args.cpp
+++ b/tests/expectations/function_args.cpp
@@ -9,4 +9,6 @@ void pointer_test(const uint64_t *a);
 
 void print_from_rust();
 
+void unnamed(const uint64_t*);
+
 } // extern "C"

--- a/tests/expectations/swift_name.c
+++ b/tests/expectations/swift_name.c
@@ -53,3 +53,5 @@ void free_function_should_exist_ref_mut(SelfTypeTestStruct *test_struct) CF_SWIF
 void free_function_should_not_exist_box(Box_SelfTypeTestStruct boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
 
 void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());
+
+void unnamed_argument(SelfTypeTestStruct*);

--- a/tests/expectations/swift_name.compat.c
+++ b/tests/expectations/swift_name.compat.c
@@ -58,6 +58,8 @@ void free_function_should_not_exist_box(Box_SelfTypeTestStruct boxed) CF_SWIFT_N
 
 void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());
 
+void unnamed_argument(SelfTypeTestStruct*);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/swift_name.cpp
+++ b/tests/expectations/swift_name.cpp
@@ -57,4 +57,6 @@ void free_function_should_not_exist_box(Box<SelfTypeTestStruct> boxed) CF_SWIFT_
 
 void rust_print_hello_world() CF_SWIFT_NAME(rust_print_hello_world());
 
+void unnamed_argument(SelfTypeTestStruct*);
+
 } // extern "C"

--- a/tests/expectations/tag/function_args.c
+++ b/tests/expectations/tag/function_args.c
@@ -6,3 +6,5 @@
 void pointer_test(const uint64_t *a);
 
 void print_from_rust(void);
+
+void unnamed(const uint64_t*);

--- a/tests/expectations/tag/function_args.compat.c
+++ b/tests/expectations/tag/function_args.compat.c
@@ -11,6 +11,8 @@ void pointer_test(const uint64_t *a);
 
 void print_from_rust(void);
 
+void unnamed(const uint64_t*);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/tag/swift_name.c
+++ b/tests/expectations/tag/swift_name.c
@@ -53,3 +53,5 @@ void free_function_should_exist_ref_mut(struct SelfTypeTestStruct *test_struct) 
 void free_function_should_not_exist_box(struct Box_SelfTypeTestStruct boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
 
 void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());
+
+void unnamed_argument(struct SelfTypeTestStruct*);

--- a/tests/expectations/tag/swift_name.compat.c
+++ b/tests/expectations/tag/swift_name.compat.c
@@ -58,6 +58,8 @@ void free_function_should_not_exist_box(struct Box_SelfTypeTestStruct boxed) CF_
 
 void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());
 
+void unnamed_argument(struct SelfTypeTestStruct*);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/rust/function_args.rs
+++ b/tests/rust/function_args.rs
@@ -9,11 +9,14 @@ pub unsafe extern fn array_test(a: [u64; 3]) {
 }
 
 #[no_mangle]
+pub unsafe extern fn unnamed(_: *const u64) {
+}
+
+#[no_mangle]
 pub unsafe extern fn pointer_test(a: *const u64) {
     let a = std::slice::from_raw_parts(a, 3);
     array_print(a);
 }
-
 
 #[no_mangle]
 pub unsafe extern fn print_from_rust() {

--- a/tests/rust/swift_name.rs
+++ b/tests/rust/swift_name.rs
@@ -86,6 +86,11 @@ pub extern fn free_function_should_exist_ref_mut(test_struct: &mut SelfTypeTestS
 }
 
 #[no_mangle]
+pub extern fn unnamed_argument(_: &mut SelfTypeTestStruct) {
+  println!("unnamed_argument");
+}
+
+#[no_mangle]
 #[allow(unused_variables)]
 pub extern fn free_function_should_not_exist_box(boxed: Box<SelfTypeTestStruct>) {
   println!("free_function_should_not_exist_box");


### PR DESCRIPTION
We don't support unnamed arguments, and we give a terrible error
("Parameter has an unsupported type.") when you use them.

They're very simple to implement so we should just do it.