### PR TITLE
Add support for an optional nonnull attribute

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -476,11 +476,6 @@ tab_width = 3
 # default: "auto"
 documentation_style = "doxy"
 
-# An optional string that, if present, will decorate all pointers that are
-# required to be non null. Nullability is inferred from the Rust type: `&T`,
-# `&mut T` and `NonNull<T>` are all require a valid pointer value. 
-non_null_attribute = "_Nonnull"
-
 
 
 
@@ -941,6 +936,12 @@ default_features = true
 #
 # default: []
 features = ["cbindgen"]
+
+[ptr]
+# An optional string to decorate all pointers that are
+# required to be non null. Nullability is inferred from the Rust type: `&T`,
+# `&mut T` and `NonNull<T>` all require a valid pointer value. 
+non_null_attribute = "_Nonnull"
 
 ```
 

--- a/docs.md
+++ b/docs.md
@@ -476,6 +476,10 @@ tab_width = 3
 # default: "auto"
 documentation_style = "doxy"
 
+# An optional string that, if present, will decorate all pointers that are
+# required to be non null. Nullability is inferred from the Rust type: `&T`,
+# `&mut T` and `NonNull<T>` are all require a valid pointer value. 
+non_null_attribute = "_Nonnull"
 
 
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -765,6 +765,8 @@ pub struct Config {
     pub documentation: bool,
     /// How documentation comments should be styled.
     pub documentation_style: DocumentationStyle,
+    /// Optional attribute to apply to pointers that are required to not be null
+    pub non_null_attribute: Option<String>,
 }
 
 impl Default for Config {
@@ -800,6 +802,7 @@ impl Default for Config {
             defines: HashMap::new(),
             documentation: true,
             documentation_style: DocumentationStyle::Auto,
+            non_null_attribute: None,
         }
     }
 }

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -692,6 +692,24 @@ impl ParseConfig {
     }
 }
 
+/// Settings to apply to pointers
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
+pub struct PtrConfig {
+    /// Optional attribute to apply to pointers that are required to not be null
+    pub non_null_attribute: Option<String>,
+}
+
+impl Default for PtrConfig {
+    fn default() -> Self {
+        Self {
+            non_null_attribute: None,
+        }
+    }
+}
+
 /// A collection of settings to customize the generated bindings.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -765,8 +783,9 @@ pub struct Config {
     pub documentation: bool,
     /// How documentation comments should be styled.
     pub documentation_style: DocumentationStyle,
-    /// Optional attribute to apply to pointers that are required to not be null
-    pub non_null_attribute: Option<String>,
+    /// Configuration options for pointers
+    #[serde(rename = "ptr")]
+    pub pointer: PtrConfig,
 }
 
 impl Default for Config {
@@ -802,7 +821,7 @@ impl Default for Config {
             defines: HashMap::new(),
             documentation: true,
             documentation_style: DocumentationStyle::Auto,
-            non_null_attribute: None,
+            pointer: PtrConfig::default(),
         }
     }
 }

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -494,7 +494,7 @@ impl Constant {
         debug_assert!(config.structure.associated_constants_in_body);
         debug_assert!(config.constant.allow_static_const);
 
-        if let Type::ConstPtr(..) = self.ty {
+        if let Type::ConstPtr { .. } = self.ty {
             out.write("static ");
         } else {
             out.write("static const ");
@@ -579,7 +579,7 @@ impl Constant {
                 out.write(if in_body { "inline " } else { "static " });
             }
 
-            if let Type::ConstPtr(..) = self.ty {
+            if let Type::ConstPtr { .. } = self.ty {
                 // Nothing.
             } else {
                 out.write("const ");

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -305,8 +305,14 @@ fn gen_self_type(receiver: &syn::Receiver) -> Type {
     let self_ty = Type::Path(GenericPath::self_path());
     match receiver.reference {
         Some(_) => match receiver.mutability {
-            Some(_) => Type::Ptr(Box::new(self_ty)),
-            None => Type::ConstPtr(Box::new(self_ty)),
+            Some(_) => Type::Ptr {
+                ty: Box::new(self_ty),
+                is_nullable: true,
+            },
+            None => Type::ConstPtr {
+                ty: Box::new(self_ty),
+                is_nullable: true,
+            },
         },
         None => self_ty,
     }

--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -109,7 +109,7 @@ impl Item for Static {
 impl Source for Static {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         out.write("extern ");
-        if let Type::ConstPtr(..) = self.ty {
+        if let Type::ConstPtr { .. } = self.ty {
         } else if !self.mutable {
             out.write("const ");
         }

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -58,11 +58,11 @@ impl<'a> Mangler<'a> {
             Type::Primitive(ref primitive) => {
                 self.output.push_str(primitive.to_repr_rust());
             }
-            Type::Ptr(ref ty) | Type::MutRef(ref ty) | Type::NonNullPtr(ref ty) => {
+            Type::Ptr { ref ty, .. } | Type::MutRef(ref ty) => {
                 self.push(Separator::BeginMutPtr);
                 self.append_mangled_type(&**ty, last);
             }
-            Type::ConstPtr(ref ty) | Type::Ref(ref ty) | Type::ConstNonNullPtr(ref ty) => {
+            Type::ConstPtr { ref ty, .. } | Type::Ref(ref ty) => {
                 self.push(Separator::BeginConstPtr);
                 self.append_mangled_type(&**ty, last);
             }

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -58,11 +58,11 @@ impl<'a> Mangler<'a> {
             Type::Primitive(ref primitive) => {
                 self.output.push_str(primitive.to_repr_rust());
             }
-            Type::Ptr(ref ty) | Type::MutRef(ref ty) => {
+            Type::Ptr(ref ty) | Type::MutRef(ref ty) | Type::NonNullPtr(ref ty) => {
                 self.push(Separator::BeginMutPtr);
                 self.append_mangled_type(&**ty, last);
             }
-            Type::ConstPtr(ref ty) | Type::Ref(ref ty) => {
+            Type::ConstPtr(ref ty) | Type::Ref(ref ty) | Type::ConstNonNullPtr(ref ty) => {
                 self.push(Separator::BeginConstPtr);
                 self.append_mangled_type(&**ty, last);
             }

--- a/tests/expectations/both/nonnull_attribute.c
+++ b/tests/expectations/both/nonnull_attribute.c
@@ -13,40 +13,40 @@
 typedef struct Opaque Opaque;
 
 typedef struct Pointers_u64 {
-  float * CBINDGEN_NONNULL a;
-  uint64_t * CBINDGEN_NONNULL b;
-  Opaque * CBINDGEN_NONNULL c;
-  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
-  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
-  Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  float *CBINDGEN_NONNULL a;
+  uint64_t *CBINDGEN_NONNULL b;
+  Opaque *CBINDGEN_NONNULL c;
+  uint64_t *CBINDGEN_NONNULL *CBINDGEN_NONNULL d;
+  float *CBINDGEN_NONNULL *CBINDGEN_NONNULL e;
+  Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL f;
   uint64_t *g;
   int32_t *h;
-  int32_t * CBINDGEN_NONNULL *i;
+  int32_t *CBINDGEN_NONNULL *i;
   const uint64_t *j;
   uint64_t *k;
 } Pointers_u64;
 
 typedef struct References {
-  const Opaque * CBINDGEN_NONNULL a;
-  Opaque * CBINDGEN_NONNULL b;
+  const Opaque *CBINDGEN_NONNULL a;
+  Opaque *CBINDGEN_NONNULL b;
   const Opaque *c;
   Opaque *d;
 } References;
 
-void mut_ref_arg(const Pointers_u64 * CBINDGEN_NONNULL arg);
+void mut_ref_arg(Pointers_u64 *CBINDGEN_NONNULL arg);
 
-void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+void mutltiple_args(int32_t *CBINDGEN_NONNULL arg,
                     Pointers_u64 *foo,
-                    Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+                    Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL d);
 
 void nullable_const_ptr(const Pointers_u64 *arg);
 
 void nullable_mut_ptr(Pointers_u64 *arg);
 
-void optional_mut_ref_arg(const Pointers_u64 *arg);
+void optional_mut_ref_arg(Pointers_u64 *arg);
 
-void optional_ref_arg(Pointers_u64 *arg);
+void optional_ref_arg(const Pointers_u64 *arg);
 
-void ref_arg(Pointers_u64 * CBINDGEN_NONNULL arg);
+void ref_arg(const Pointers_u64 *CBINDGEN_NONNULL arg);
 
 void value_arg(References arg);

--- a/tests/expectations/both/nonnull_attribute.c
+++ b/tests/expectations/both/nonnull_attribute.c
@@ -1,0 +1,52 @@
+#ifdef __clang__
+#define CBINDGEN_NONNULL _Nonnull
+#else
+#define CBINDGEN_NONNULL
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct Pointers_u64 {
+  float * CBINDGEN_NONNULL a;
+  uint64_t * CBINDGEN_NONNULL b;
+  Opaque * CBINDGEN_NONNULL c;
+  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
+  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
+  Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  uint64_t *g;
+  int32_t *h;
+  int32_t * CBINDGEN_NONNULL *i;
+  const uint64_t *j;
+  uint64_t *k;
+} Pointers_u64;
+
+typedef struct References {
+  const Opaque * CBINDGEN_NONNULL a;
+  Opaque * CBINDGEN_NONNULL b;
+  const Opaque *c;
+  Opaque *d;
+} References;
+
+void mut_ref_arg(const Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+                    Pointers_u64 *foo,
+                    Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+
+void nullable_const_ptr(const Pointers_u64 *arg);
+
+void nullable_mut_ptr(Pointers_u64 *arg);
+
+void optional_mut_ref_arg(const Pointers_u64 *arg);
+
+void optional_ref_arg(Pointers_u64 *arg);
+
+void ref_arg(Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void value_arg(References arg);

--- a/tests/expectations/both/nonnull_attribute.compat.c
+++ b/tests/expectations/both/nonnull_attribute.compat.c
@@ -1,0 +1,60 @@
+#ifdef __clang__
+#define CBINDGEN_NONNULL _Nonnull
+#else
+#define CBINDGEN_NONNULL
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct Pointers_u64 {
+  float * CBINDGEN_NONNULL a;
+  uint64_t * CBINDGEN_NONNULL b;
+  Opaque * CBINDGEN_NONNULL c;
+  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
+  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
+  Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  uint64_t *g;
+  int32_t *h;
+  int32_t * CBINDGEN_NONNULL *i;
+  const uint64_t *j;
+  uint64_t *k;
+} Pointers_u64;
+
+typedef struct References {
+  const Opaque * CBINDGEN_NONNULL a;
+  Opaque * CBINDGEN_NONNULL b;
+  const Opaque *c;
+  Opaque *d;
+} References;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void mut_ref_arg(const Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+                    Pointers_u64 *foo,
+                    Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+
+void nullable_const_ptr(const Pointers_u64 *arg);
+
+void nullable_mut_ptr(Pointers_u64 *arg);
+
+void optional_mut_ref_arg(const Pointers_u64 *arg);
+
+void optional_ref_arg(Pointers_u64 *arg);
+
+void ref_arg(Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void value_arg(References arg);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/both/nonnull_attribute.compat.c
+++ b/tests/expectations/both/nonnull_attribute.compat.c
@@ -13,22 +13,22 @@
 typedef struct Opaque Opaque;
 
 typedef struct Pointers_u64 {
-  float * CBINDGEN_NONNULL a;
-  uint64_t * CBINDGEN_NONNULL b;
-  Opaque * CBINDGEN_NONNULL c;
-  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
-  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
-  Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  float *CBINDGEN_NONNULL a;
+  uint64_t *CBINDGEN_NONNULL b;
+  Opaque *CBINDGEN_NONNULL c;
+  uint64_t *CBINDGEN_NONNULL *CBINDGEN_NONNULL d;
+  float *CBINDGEN_NONNULL *CBINDGEN_NONNULL e;
+  Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL f;
   uint64_t *g;
   int32_t *h;
-  int32_t * CBINDGEN_NONNULL *i;
+  int32_t *CBINDGEN_NONNULL *i;
   const uint64_t *j;
   uint64_t *k;
 } Pointers_u64;
 
 typedef struct References {
-  const Opaque * CBINDGEN_NONNULL a;
-  Opaque * CBINDGEN_NONNULL b;
+  const Opaque *CBINDGEN_NONNULL a;
+  Opaque *CBINDGEN_NONNULL b;
   const Opaque *c;
   Opaque *d;
 } References;
@@ -37,21 +37,21 @@ typedef struct References {
 extern "C" {
 #endif // __cplusplus
 
-void mut_ref_arg(const Pointers_u64 * CBINDGEN_NONNULL arg);
+void mut_ref_arg(Pointers_u64 *CBINDGEN_NONNULL arg);
 
-void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+void mutltiple_args(int32_t *CBINDGEN_NONNULL arg,
                     Pointers_u64 *foo,
-                    Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+                    Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL d);
 
 void nullable_const_ptr(const Pointers_u64 *arg);
 
 void nullable_mut_ptr(Pointers_u64 *arg);
 
-void optional_mut_ref_arg(const Pointers_u64 *arg);
+void optional_mut_ref_arg(Pointers_u64 *arg);
 
-void optional_ref_arg(Pointers_u64 *arg);
+void optional_ref_arg(const Pointers_u64 *arg);
 
-void ref_arg(Pointers_u64 * CBINDGEN_NONNULL arg);
+void ref_arg(const Pointers_u64 *CBINDGEN_NONNULL arg);
 
 void value_arg(References arg);
 

--- a/tests/expectations/nonnull_attribute.c
+++ b/tests/expectations/nonnull_attribute.c
@@ -1,0 +1,52 @@
+#ifdef __clang__
+#define CBINDGEN_NONNULL _Nonnull
+#else
+#define CBINDGEN_NONNULL
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct {
+  float * CBINDGEN_NONNULL a;
+  uint64_t * CBINDGEN_NONNULL b;
+  Opaque * CBINDGEN_NONNULL c;
+  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
+  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
+  Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  uint64_t *g;
+  int32_t *h;
+  int32_t * CBINDGEN_NONNULL *i;
+  const uint64_t *j;
+  uint64_t *k;
+} Pointers_u64;
+
+typedef struct {
+  const Opaque * CBINDGEN_NONNULL a;
+  Opaque * CBINDGEN_NONNULL b;
+  const Opaque *c;
+  Opaque *d;
+} References;
+
+void mut_ref_arg(const Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+                    Pointers_u64 *foo,
+                    Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+
+void nullable_const_ptr(const Pointers_u64 *arg);
+
+void nullable_mut_ptr(Pointers_u64 *arg);
+
+void optional_mut_ref_arg(const Pointers_u64 *arg);
+
+void optional_ref_arg(Pointers_u64 *arg);
+
+void ref_arg(Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void value_arg(References arg);

--- a/tests/expectations/nonnull_attribute.c
+++ b/tests/expectations/nonnull_attribute.c
@@ -13,40 +13,40 @@
 typedef struct Opaque Opaque;
 
 typedef struct {
-  float * CBINDGEN_NONNULL a;
-  uint64_t * CBINDGEN_NONNULL b;
-  Opaque * CBINDGEN_NONNULL c;
-  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
-  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
-  Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  float *CBINDGEN_NONNULL a;
+  uint64_t *CBINDGEN_NONNULL b;
+  Opaque *CBINDGEN_NONNULL c;
+  uint64_t *CBINDGEN_NONNULL *CBINDGEN_NONNULL d;
+  float *CBINDGEN_NONNULL *CBINDGEN_NONNULL e;
+  Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL f;
   uint64_t *g;
   int32_t *h;
-  int32_t * CBINDGEN_NONNULL *i;
+  int32_t *CBINDGEN_NONNULL *i;
   const uint64_t *j;
   uint64_t *k;
 } Pointers_u64;
 
 typedef struct {
-  const Opaque * CBINDGEN_NONNULL a;
-  Opaque * CBINDGEN_NONNULL b;
+  const Opaque *CBINDGEN_NONNULL a;
+  Opaque *CBINDGEN_NONNULL b;
   const Opaque *c;
   Opaque *d;
 } References;
 
-void mut_ref_arg(const Pointers_u64 * CBINDGEN_NONNULL arg);
+void mut_ref_arg(Pointers_u64 *CBINDGEN_NONNULL arg);
 
-void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+void mutltiple_args(int32_t *CBINDGEN_NONNULL arg,
                     Pointers_u64 *foo,
-                    Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+                    Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL d);
 
 void nullable_const_ptr(const Pointers_u64 *arg);
 
 void nullable_mut_ptr(Pointers_u64 *arg);
 
-void optional_mut_ref_arg(const Pointers_u64 *arg);
+void optional_mut_ref_arg(Pointers_u64 *arg);
 
-void optional_ref_arg(Pointers_u64 *arg);
+void optional_ref_arg(const Pointers_u64 *arg);
 
-void ref_arg(Pointers_u64 * CBINDGEN_NONNULL arg);
+void ref_arg(const Pointers_u64 *CBINDGEN_NONNULL arg);
 
 void value_arg(References arg);

--- a/tests/expectations/nonnull_attribute.compat.c
+++ b/tests/expectations/nonnull_attribute.compat.c
@@ -1,0 +1,60 @@
+#ifdef __clang__
+#define CBINDGEN_NONNULL _Nonnull
+#else
+#define CBINDGEN_NONNULL
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque Opaque;
+
+typedef struct {
+  float * CBINDGEN_NONNULL a;
+  uint64_t * CBINDGEN_NONNULL b;
+  Opaque * CBINDGEN_NONNULL c;
+  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
+  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
+  Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  uint64_t *g;
+  int32_t *h;
+  int32_t * CBINDGEN_NONNULL *i;
+  const uint64_t *j;
+  uint64_t *k;
+} Pointers_u64;
+
+typedef struct {
+  const Opaque * CBINDGEN_NONNULL a;
+  Opaque * CBINDGEN_NONNULL b;
+  const Opaque *c;
+  Opaque *d;
+} References;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void mut_ref_arg(const Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+                    Pointers_u64 *foo,
+                    Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+
+void nullable_const_ptr(const Pointers_u64 *arg);
+
+void nullable_mut_ptr(Pointers_u64 *arg);
+
+void optional_mut_ref_arg(const Pointers_u64 *arg);
+
+void optional_ref_arg(Pointers_u64 *arg);
+
+void ref_arg(Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void value_arg(References arg);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/nonnull_attribute.compat.c
+++ b/tests/expectations/nonnull_attribute.compat.c
@@ -13,22 +13,22 @@
 typedef struct Opaque Opaque;
 
 typedef struct {
-  float * CBINDGEN_NONNULL a;
-  uint64_t * CBINDGEN_NONNULL b;
-  Opaque * CBINDGEN_NONNULL c;
-  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
-  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
-  Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  float *CBINDGEN_NONNULL a;
+  uint64_t *CBINDGEN_NONNULL b;
+  Opaque *CBINDGEN_NONNULL c;
+  uint64_t *CBINDGEN_NONNULL *CBINDGEN_NONNULL d;
+  float *CBINDGEN_NONNULL *CBINDGEN_NONNULL e;
+  Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL f;
   uint64_t *g;
   int32_t *h;
-  int32_t * CBINDGEN_NONNULL *i;
+  int32_t *CBINDGEN_NONNULL *i;
   const uint64_t *j;
   uint64_t *k;
 } Pointers_u64;
 
 typedef struct {
-  const Opaque * CBINDGEN_NONNULL a;
-  Opaque * CBINDGEN_NONNULL b;
+  const Opaque *CBINDGEN_NONNULL a;
+  Opaque *CBINDGEN_NONNULL b;
   const Opaque *c;
   Opaque *d;
 } References;
@@ -37,21 +37,21 @@ typedef struct {
 extern "C" {
 #endif // __cplusplus
 
-void mut_ref_arg(const Pointers_u64 * CBINDGEN_NONNULL arg);
+void mut_ref_arg(Pointers_u64 *CBINDGEN_NONNULL arg);
 
-void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+void mutltiple_args(int32_t *CBINDGEN_NONNULL arg,
                     Pointers_u64 *foo,
-                    Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+                    Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL d);
 
 void nullable_const_ptr(const Pointers_u64 *arg);
 
 void nullable_mut_ptr(Pointers_u64 *arg);
 
-void optional_mut_ref_arg(const Pointers_u64 *arg);
+void optional_mut_ref_arg(Pointers_u64 *arg);
 
-void optional_ref_arg(Pointers_u64 *arg);
+void optional_ref_arg(const Pointers_u64 *arg);
 
-void ref_arg(Pointers_u64 * CBINDGEN_NONNULL arg);
+void ref_arg(const Pointers_u64 *CBINDGEN_NONNULL arg);
 
 void value_arg(References arg);
 

--- a/tests/expectations/nonnull_attribute.cpp
+++ b/tests/expectations/nonnull_attribute.cpp
@@ -14,43 +14,43 @@ struct Opaque;
 
 template<typename T>
 struct Pointers {
-  float * CBINDGEN_NONNULL a;
-  T * CBINDGEN_NONNULL b;
-  Opaque * CBINDGEN_NONNULL c;
-  T * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
-  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
-  Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  float *CBINDGEN_NONNULL a;
+  T *CBINDGEN_NONNULL b;
+  Opaque *CBINDGEN_NONNULL c;
+  T *CBINDGEN_NONNULL *CBINDGEN_NONNULL d;
+  float *CBINDGEN_NONNULL *CBINDGEN_NONNULL e;
+  Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL f;
   T *g;
   int32_t *h;
-  int32_t * CBINDGEN_NONNULL *i;
+  int32_t *CBINDGEN_NONNULL *i;
   const T *j;
   T *k;
 };
 
 struct References {
-  const Opaque * CBINDGEN_NONNULL a;
-  Opaque * CBINDGEN_NONNULL b;
+  const Opaque *CBINDGEN_NONNULL a;
+  Opaque *CBINDGEN_NONNULL b;
   const Opaque *c;
   Opaque *d;
 };
 
 extern "C" {
 
-void mut_ref_arg(const Pointers<uint64_t> * CBINDGEN_NONNULL arg);
+void mut_ref_arg(Pointers<uint64_t> *CBINDGEN_NONNULL arg);
 
-void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+void mutltiple_args(int32_t *CBINDGEN_NONNULL arg,
                     Pointers<uint64_t> *foo,
-                    Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+                    Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL d);
 
 void nullable_const_ptr(const Pointers<uint64_t> *arg);
 
 void nullable_mut_ptr(Pointers<uint64_t> *arg);
 
-void optional_mut_ref_arg(const Pointers<uint64_t> *arg);
+void optional_mut_ref_arg(Pointers<uint64_t> *arg);
 
-void optional_ref_arg(Pointers<uint64_t> *arg);
+void optional_ref_arg(const Pointers<uint64_t> *arg);
 
-void ref_arg(Pointers<uint64_t> * CBINDGEN_NONNULL arg);
+void ref_arg(const Pointers<uint64_t> *CBINDGEN_NONNULL arg);
 
 void value_arg(References arg);
 

--- a/tests/expectations/nonnull_attribute.cpp
+++ b/tests/expectations/nonnull_attribute.cpp
@@ -1,0 +1,57 @@
+#ifdef __clang__
+#define CBINDGEN_NONNULL _Nonnull
+#else
+#define CBINDGEN_NONNULL
+#endif
+
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+
+struct Opaque;
+
+template<typename T>
+struct Pointers {
+  float * CBINDGEN_NONNULL a;
+  T * CBINDGEN_NONNULL b;
+  Opaque * CBINDGEN_NONNULL c;
+  T * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
+  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
+  Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  T *g;
+  int32_t *h;
+  int32_t * CBINDGEN_NONNULL *i;
+  const T *j;
+  T *k;
+};
+
+struct References {
+  const Opaque * CBINDGEN_NONNULL a;
+  Opaque * CBINDGEN_NONNULL b;
+  const Opaque *c;
+  Opaque *d;
+};
+
+extern "C" {
+
+void mut_ref_arg(const Pointers<uint64_t> * CBINDGEN_NONNULL arg);
+
+void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+                    Pointers<uint64_t> *foo,
+                    Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+
+void nullable_const_ptr(const Pointers<uint64_t> *arg);
+
+void nullable_mut_ptr(Pointers<uint64_t> *arg);
+
+void optional_mut_ref_arg(const Pointers<uint64_t> *arg);
+
+void optional_ref_arg(Pointers<uint64_t> *arg);
+
+void ref_arg(Pointers<uint64_t> * CBINDGEN_NONNULL arg);
+
+void value_arg(References arg);
+
+} // extern "C"

--- a/tests/expectations/tag/nonnull_attribute.c
+++ b/tests/expectations/tag/nonnull_attribute.c
@@ -13,40 +13,40 @@
 struct Opaque;
 
 struct Pointers_u64 {
-  float * CBINDGEN_NONNULL a;
-  uint64_t * CBINDGEN_NONNULL b;
-  struct Opaque * CBINDGEN_NONNULL c;
-  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
-  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
-  struct Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  float *CBINDGEN_NONNULL a;
+  uint64_t *CBINDGEN_NONNULL b;
+  struct Opaque *CBINDGEN_NONNULL c;
+  uint64_t *CBINDGEN_NONNULL *CBINDGEN_NONNULL d;
+  float *CBINDGEN_NONNULL *CBINDGEN_NONNULL e;
+  struct Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL f;
   uint64_t *g;
   int32_t *h;
-  int32_t * CBINDGEN_NONNULL *i;
+  int32_t *CBINDGEN_NONNULL *i;
   const uint64_t *j;
   uint64_t *k;
 };
 
 struct References {
-  const struct Opaque * CBINDGEN_NONNULL a;
-  struct Opaque * CBINDGEN_NONNULL b;
+  const struct Opaque *CBINDGEN_NONNULL a;
+  struct Opaque *CBINDGEN_NONNULL b;
   const struct Opaque *c;
   struct Opaque *d;
 };
 
-void mut_ref_arg(const struct Pointers_u64 * CBINDGEN_NONNULL arg);
+void mut_ref_arg(struct Pointers_u64 *CBINDGEN_NONNULL arg);
 
-void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+void mutltiple_args(int32_t *CBINDGEN_NONNULL arg,
                     struct Pointers_u64 *foo,
-                    struct Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+                    struct Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL d);
 
 void nullable_const_ptr(const struct Pointers_u64 *arg);
 
 void nullable_mut_ptr(struct Pointers_u64 *arg);
 
-void optional_mut_ref_arg(const struct Pointers_u64 *arg);
+void optional_mut_ref_arg(struct Pointers_u64 *arg);
 
-void optional_ref_arg(struct Pointers_u64 *arg);
+void optional_ref_arg(const struct Pointers_u64 *arg);
 
-void ref_arg(struct Pointers_u64 * CBINDGEN_NONNULL arg);
+void ref_arg(const struct Pointers_u64 *CBINDGEN_NONNULL arg);
 
 void value_arg(struct References arg);

--- a/tests/expectations/tag/nonnull_attribute.c
+++ b/tests/expectations/tag/nonnull_attribute.c
@@ -1,0 +1,52 @@
+#ifdef __clang__
+#define CBINDGEN_NONNULL _Nonnull
+#else
+#define CBINDGEN_NONNULL
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Opaque;
+
+struct Pointers_u64 {
+  float * CBINDGEN_NONNULL a;
+  uint64_t * CBINDGEN_NONNULL b;
+  struct Opaque * CBINDGEN_NONNULL c;
+  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
+  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
+  struct Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  uint64_t *g;
+  int32_t *h;
+  int32_t * CBINDGEN_NONNULL *i;
+  const uint64_t *j;
+  uint64_t *k;
+};
+
+struct References {
+  const struct Opaque * CBINDGEN_NONNULL a;
+  struct Opaque * CBINDGEN_NONNULL b;
+  const struct Opaque *c;
+  struct Opaque *d;
+};
+
+void mut_ref_arg(const struct Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+                    struct Pointers_u64 *foo,
+                    struct Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+
+void nullable_const_ptr(const struct Pointers_u64 *arg);
+
+void nullable_mut_ptr(struct Pointers_u64 *arg);
+
+void optional_mut_ref_arg(const struct Pointers_u64 *arg);
+
+void optional_ref_arg(struct Pointers_u64 *arg);
+
+void ref_arg(struct Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void value_arg(struct References arg);

--- a/tests/expectations/tag/nonnull_attribute.compat.c
+++ b/tests/expectations/tag/nonnull_attribute.compat.c
@@ -1,0 +1,60 @@
+#ifdef __clang__
+#define CBINDGEN_NONNULL _Nonnull
+#else
+#define CBINDGEN_NONNULL
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Opaque;
+
+struct Pointers_u64 {
+  float * CBINDGEN_NONNULL a;
+  uint64_t * CBINDGEN_NONNULL b;
+  struct Opaque * CBINDGEN_NONNULL c;
+  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
+  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
+  struct Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  uint64_t *g;
+  int32_t *h;
+  int32_t * CBINDGEN_NONNULL *i;
+  const uint64_t *j;
+  uint64_t *k;
+};
+
+struct References {
+  const struct Opaque * CBINDGEN_NONNULL a;
+  struct Opaque * CBINDGEN_NONNULL b;
+  const struct Opaque *c;
+  struct Opaque *d;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void mut_ref_arg(const struct Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+                    struct Pointers_u64 *foo,
+                    struct Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+
+void nullable_const_ptr(const struct Pointers_u64 *arg);
+
+void nullable_mut_ptr(struct Pointers_u64 *arg);
+
+void optional_mut_ref_arg(const struct Pointers_u64 *arg);
+
+void optional_ref_arg(struct Pointers_u64 *arg);
+
+void ref_arg(struct Pointers_u64 * CBINDGEN_NONNULL arg);
+
+void value_arg(struct References arg);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/tag/nonnull_attribute.compat.c
+++ b/tests/expectations/tag/nonnull_attribute.compat.c
@@ -13,22 +13,22 @@
 struct Opaque;
 
 struct Pointers_u64 {
-  float * CBINDGEN_NONNULL a;
-  uint64_t * CBINDGEN_NONNULL b;
-  struct Opaque * CBINDGEN_NONNULL c;
-  uint64_t * CBINDGEN_NONNULL * CBINDGEN_NONNULL d;
-  float * CBINDGEN_NONNULL * CBINDGEN_NONNULL e;
-  struct Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL f;
+  float *CBINDGEN_NONNULL a;
+  uint64_t *CBINDGEN_NONNULL b;
+  struct Opaque *CBINDGEN_NONNULL c;
+  uint64_t *CBINDGEN_NONNULL *CBINDGEN_NONNULL d;
+  float *CBINDGEN_NONNULL *CBINDGEN_NONNULL e;
+  struct Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL f;
   uint64_t *g;
   int32_t *h;
-  int32_t * CBINDGEN_NONNULL *i;
+  int32_t *CBINDGEN_NONNULL *i;
   const uint64_t *j;
   uint64_t *k;
 };
 
 struct References {
-  const struct Opaque * CBINDGEN_NONNULL a;
-  struct Opaque * CBINDGEN_NONNULL b;
+  const struct Opaque *CBINDGEN_NONNULL a;
+  struct Opaque *CBINDGEN_NONNULL b;
   const struct Opaque *c;
   struct Opaque *d;
 };
@@ -37,21 +37,21 @@ struct References {
 extern "C" {
 #endif // __cplusplus
 
-void mut_ref_arg(const struct Pointers_u64 * CBINDGEN_NONNULL arg);
+void mut_ref_arg(struct Pointers_u64 *CBINDGEN_NONNULL arg);
 
-void mutltiple_args(int32_t * CBINDGEN_NONNULL arg,
+void mutltiple_args(int32_t *CBINDGEN_NONNULL arg,
                     struct Pointers_u64 *foo,
-                    struct Opaque * CBINDGEN_NONNULL * CBINDGEN_NONNULL d);
+                    struct Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL d);
 
 void nullable_const_ptr(const struct Pointers_u64 *arg);
 
 void nullable_mut_ptr(struct Pointers_u64 *arg);
 
-void optional_mut_ref_arg(const struct Pointers_u64 *arg);
+void optional_mut_ref_arg(struct Pointers_u64 *arg);
 
-void optional_ref_arg(struct Pointers_u64 *arg);
+void optional_ref_arg(const struct Pointers_u64 *arg);
 
-void ref_arg(struct Pointers_u64 * CBINDGEN_NONNULL arg);
+void ref_arg(const struct Pointers_u64 *CBINDGEN_NONNULL arg);
 
 void value_arg(struct References arg);
 

--- a/tests/rust/nonnull_attribute.rs
+++ b/tests/rust/nonnull_attribute.rs
@@ -1,0 +1,55 @@
+use std::ptr::NonNull;
+
+struct Opaque;
+
+#[repr(C)]
+pub struct Pointers<T> {
+    a: NonNull<f32>,
+    b: NonNull<T>,
+    c: NonNull<Opaque>,
+    d: NonNull<NonNull<T>>,
+    e: NonNull<NonNull<f32>>,
+    f: NonNull<NonNull<Opaque>>,
+    g: Option<NonNull<T>>,
+    h: Option<NonNull<i32>>,
+    i: Option<NonNull<NonNull<i32>>>,
+    j: *const T,
+    k: *mut T,
+}
+
+#[repr(C)]
+pub struct References<'a> {
+    a: &'a Opaque,
+    b: &'a mut Opaque,
+    c: Option<&'a Opaque>,
+    d: Option<&'a mut Opaque>,
+}
+
+#[no_mangle]
+pub extern "C" fn value_arg(arg: References<'static>) {}
+
+#[no_mangle]
+pub extern "C" fn mutltiple_args(
+    arg: NonNull<i32>,
+    foo: *mut Pointers<u64>,
+    d: NonNull<NonNull<Opaque>>,
+) {
+}
+
+#[no_mangle]
+pub extern "C" fn mut_ref_arg(arg: &Pointers<u64>) {}
+
+#[no_mangle]
+pub extern "C" fn ref_arg(arg: &mut Pointers<u64>) {}
+
+#[no_mangle]
+pub extern "C" fn optional_mut_ref_arg(arg: Option<&Pointers<u64>>) {}
+
+#[no_mangle]
+pub extern "C" fn optional_ref_arg(arg: Option<&mut Pointers<u64>>) {}
+
+#[no_mangle]
+pub extern "C" fn nullable_const_ptr(arg: *const Pointers<u64>) {}
+
+#[no_mangle]
+pub extern "C" fn nullable_mut_ptr(arg: *mut Pointers<u64>) {}

--- a/tests/rust/nonnull_attribute.rs
+++ b/tests/rust/nonnull_attribute.rs
@@ -37,16 +37,16 @@ pub extern "C" fn mutltiple_args(
 }
 
 #[no_mangle]
-pub extern "C" fn mut_ref_arg(arg: &Pointers<u64>) {}
+pub extern "C" fn ref_arg(arg: &Pointers<u64>) {}
 
 #[no_mangle]
-pub extern "C" fn ref_arg(arg: &mut Pointers<u64>) {}
+pub extern "C" fn mut_ref_arg(arg: &mut Pointers<u64>) {}
 
 #[no_mangle]
-pub extern "C" fn optional_mut_ref_arg(arg: Option<&Pointers<u64>>) {}
+pub extern "C" fn optional_ref_arg(arg: Option<&Pointers<u64>>) {}
 
 #[no_mangle]
-pub extern "C" fn optional_ref_arg(arg: Option<&mut Pointers<u64>>) {}
+pub extern "C" fn optional_mut_ref_arg(arg: Option<&mut Pointers<u64>>) {}
 
 #[no_mangle]
 pub extern "C" fn nullable_const_ptr(arg: *const Pointers<u64>) {}

--- a/tests/rust/nonnull_attribute.toml
+++ b/tests/rust/nonnull_attribute.toml
@@ -6,4 +6,5 @@ header = """
 #endif
 """
 
+[ptr]
 non_null_attribute = "CBINDGEN_NONNULL"

--- a/tests/rust/nonnull_attribute.toml
+++ b/tests/rust/nonnull_attribute.toml
@@ -1,0 +1,9 @@
+header = """
+#ifdef __clang__
+#define CBINDGEN_NONNULL _Nonnull
+#else
+#define CBINDGEN_NONNULL
+#endif
+"""
+
+non_null_attribute = "CBINDGEN_NONNULL"


### PR DESCRIPTION
This allows clang and swiftc users to use `_Nonnull`

Tested with `CC=clang CXX=clang++ cargo test` as well as `cargo test`