### PR TITLE
Pascal case primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,6 @@ name = "cbindgen"
 version = "0.14.5"
 dependencies = [
  "clap",
- "convert_case",
  "heck",
  "log",
  "proc-macro2",
@@ -71,12 +70,6 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,330 +4,335 @@
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi",
 ]
 
 [[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "c2-chacha"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 dependencies = [
- "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86",
 ]
 
 [[package]]
 name = "cbindgen"
 version = "0.14.5"
 dependencies = [
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap",
+ "convert_case",
+ "heck",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "getrandom"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 dependencies = [
- "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 
 [[package]]
 name = "libc"
 version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 
 [[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
 ]
 
 [[package]]
 name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
 dependencies = [
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 dependencies = [
- "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "c2-chacha",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core",
 ]
 
 [[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "remove_dir_all"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi",
 ]
 
 [[package]]
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 
 [[package]]
 name = "serde"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 dependencies = [
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 dependencies = [
- "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width",
 ]
 
 [[package]]
 name = "toml"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
 dependencies = [
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "wasi"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
-"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-"checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
-"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
-"checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
-"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
-"checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
-"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
-"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
-"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
-"checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
-"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
-"checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
-"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-"checksum toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
-"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
-"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ toml = "0.5"
 proc-macro2 = "1"
 quote = "1"
 heck = "0.3"
+convert_case = "0.4.0"
 
 [dependencies.syn]
 version = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ toml = "0.5"
 proc-macro2 = "1"
 quote = "1"
 heck = "0.3"
-convert_case = "0.4.0"
 
 [dependencies.syn]
 version = "1.0.3"

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -299,8 +299,10 @@ pub struct ExportConfig {
     pub item_types: Vec<ItemType>,
     /// Whether renaming overrides or extends prefixing.
     pub renaming_overrides_prefixing: bool,
-    /// Name mangling character. Defaults to `_`
-    pub mangle_separator: Option<String>,
+    /// Remove the underscores used for name mangling
+    pub remove_underscores: bool,
+    /// Whether to capitalise primitives, e.g. if mangle_separator is empty
+    pub pascal_case_primitives: bool,
 }
 
 impl ExportConfig {

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -287,6 +287,8 @@ pub struct ExportConfig {
     pub include: Vec<String>,
     /// A list of items to not include in the generated bindings
     pub exclude: Vec<String>,
+    /// The rename rule to apply to the type names
+    pub rename_types: Option<RenameRule>,
     /// Table of name conversions to apply to item names
     pub rename: HashMap<String, String>,
     /// Table of raw strings to prepend to the body of items.
@@ -301,8 +303,6 @@ pub struct ExportConfig {
     pub renaming_overrides_prefixing: bool,
     /// Remove the underscores used for name mangling
     pub remove_underscores: bool,
-    /// Whether to capitalise primitives, e.g. if mangle_separator is empty
-    pub pascal_case_primitives: bool,
 }
 
 impl ExportConfig {

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -240,7 +240,7 @@ impl EnumVariant {
                 &self.name,
                 generic_values,
                 config.export.remove_underscores,
-                config.export.pascal_case_primitives,
+                config.export.rename_types,
             ),
             self.discriminant,
             self.body.specialize(generic_values, mappings, config),
@@ -563,7 +563,7 @@ impl Item for Enum {
             &self.path,
             generic_values,
             library.get_config().export.remove_underscores,
-            library.get_config().export.pascal_case_primitives,
+            library.get_config().export.rename_types,
         );
 
         let monomorph = Enum::new(

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -239,7 +239,8 @@ impl EnumVariant {
             mangle::mangle_name(
                 &self.name,
                 generic_values,
-                config.export.mangle_separator.as_deref(),
+                config.export.remove_underscores,
+                config.export.pascal_case_primitives,
             ),
             self.discriminant,
             self.body.specialize(generic_values, mappings, config),
@@ -561,7 +562,8 @@ impl Item for Enum {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangle_separator.as_deref(),
+            library.get_config().export.remove_underscores,
+            library.get_config().export.pascal_case_primitives,
         );
 
         let monomorph = Enum::new(

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -122,7 +122,8 @@ impl Item for OpaqueItem {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangle_separator.as_deref(),
+            library.get_config().export.remove_underscores,
+            library.get_config().export.pascal_case_primitives,
         );
 
         let monomorph = OpaqueItem::new(

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -123,7 +123,7 @@ impl Item for OpaqueItem {
             &self.path,
             generic_values,
             library.get_config().export.remove_underscores,
-            library.get_config().export.pascal_case_primitives,
+            library.get_config().export.rename_types,
         );
 
         let monomorph = OpaqueItem::new(

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -181,7 +181,7 @@ impl Struct {
             &self.path,
             generic_values,
             config.export.remove_underscores,
-            config.export.pascal_case_primitives,
+            config.export.rename_types,
         );
         Struct::new(
             mangled_path,

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -180,7 +180,8 @@ impl Struct {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            config.export.mangle_separator.as_deref(),
+            config.export.remove_underscores,
+            config.export.pascal_case_primitives,
         );
         Struct::new(
             mangled_path,

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -176,7 +176,7 @@ impl Item for Typedef {
             &self.path,
             generic_values,
             library.get_config().export.remove_underscores,
-            library.get_config().export.pascal_case_primitives,
+            library.get_config().export.rename_types,
         );
 
         let monomorph = Typedef::new(

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -175,7 +175,8 @@ impl Item for Typedef {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangle_separator.as_deref(),
+            library.get_config().export.remove_underscores,
+            library.get_config().export.pascal_case_primitives,
         );
 
         let monomorph = Typedef::new(

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -238,7 +238,8 @@ impl Item for Union {
         let mangled_path = mangle::mangle_path(
             &self.path,
             generic_values,
-            library.get_config().export.mangle_separator.as_deref(),
+            library.get_config().export.remove_underscores,
+            library.get_config().export.pascal_case_primitives,
         );
 
         let monomorph = Union::new(

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -239,7 +239,7 @@ impl Item for Union {
             &self.path,
             generic_values,
             library.get_config().export.remove_underscores,
-            library.get_config().export.pascal_case_primitives,
+            library.get_config().export.rename_types,
         );
 
         let monomorph = Union::new(

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -3,17 +3,36 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::bindgen::ir::{Path, Type};
+use convert_case::{Case, Casing};
+use std::borrow::Cow;
+use std::ops::Deref;
 
-pub fn mangle_path(path: &Path, generic_values: &[Type], mangle_separator: Option<&str>) -> Path {
-    Path::new(mangle_name(path.name(), generic_values, mangle_separator))
+pub fn mangle_path(
+    path: &Path,
+    generic_values: &[Type],
+    remove_underscores: bool,
+    pascal_case_primitives: bool,
+) -> Path {
+    Path::new(mangle_name(
+        path.name(),
+        generic_values,
+        remove_underscores,
+        pascal_case_primitives,
+    ))
 }
 
-pub fn mangle_name(name: &str, generic_values: &[Type], mangle_separator: Option<&str>) -> String {
+pub fn mangle_name(
+    name: &str,
+    generic_values: &[Type],
+    remove_underscores: bool,
+    pascal_case_primitives: bool,
+) -> String {
     Mangler::new(
         name,
         generic_values,
         /* last = */ true,
-        mangle_separator,
+        remove_underscores,
+        pascal_case_primitives,
     )
     .mangle()
 }
@@ -31,7 +50,8 @@ struct Mangler<'a> {
     generic_values: &'a [Type],
     output: String,
     last: bool,
-    mangle_separator: &'a str,
+    remove_underscores: bool,
+    pascal_case_primitives: bool,
 }
 
 impl<'a> Mangler<'a> {
@@ -39,18 +59,16 @@ impl<'a> Mangler<'a> {
         input: &'a str,
         generic_values: &'a [Type],
         last: bool,
-        mangle_separator: Option<&'a str>,
+        remove_underscores: bool,
+        pascal_case_primitives: bool,
     ) -> Self {
-        let separator = match mangle_separator {
-            Some(s) => s,
-            None => "_",
-        };
         Self {
             input,
             generic_values,
             output: String::new(),
             last,
-            mangle_separator: separator,
+            remove_underscores,
+            pascal_case_primitives,
         }
     }
 
@@ -61,8 +79,8 @@ impl<'a> Mangler<'a> {
 
     fn push(&mut self, id: Separator) {
         let count = id as usize;
-        self.output
-            .extend(std::iter::repeat(self.mangle_separator).take(count));
+        let separator = if self.remove_underscores { "" } else { "_" };
+        self.output.extend(std::iter::repeat(separator).take(count));
     }
 
     fn append_mangled_type(&mut self, ty: &Type, last: bool) {
@@ -72,13 +90,18 @@ impl<'a> Mangler<'a> {
                     generic.export_name(),
                     generic.generics(),
                     last,
-                    Some(self.mangle_separator),
+                    self.remove_underscores,
+                    self.pascal_case_primitives,
                 )
                 .mangle();
                 self.output.push_str(&sub_path);
             }
             Type::Primitive(ref primitive) => {
-                self.output.push_str(primitive.to_repr_rust());
+                let mut primitive_string = Cow::Borrowed(primitive.to_repr_rust());
+                if self.pascal_case_primitives {
+                    primitive_string = Cow::Owned(primitive_string.to_case(Case::Pascal));
+                }
+                self.output.push_str(primitive_string.deref());
             }
             Type::Ptr {
                 ref ty, is_const, ..
@@ -131,6 +154,10 @@ fn generics() {
         Type::Primitive(PrimitiveType::Float)
     }
 
+    fn c_char() -> Type {
+        Type::Primitive(PrimitiveType::Char)
+    }
+
     fn path(path: &str) -> Type {
         generic_path(path, &vec![])
     }
@@ -143,7 +170,7 @@ fn generics() {
 
     // Foo<f32> => Foo_f32
     assert_eq!(
-        mangle_path(&Path::new("Foo"), &vec![float()], None),
+        mangle_path(&Path::new("Foo"), &vec![float()], false, false),
         Path::new("Foo_f32")
     );
 
@@ -152,21 +179,44 @@ fn generics() {
         mangle_path(
             &Path::new("Foo"),
             &vec![generic_path("Bar", &[float()])],
-            None
+            false,
+            false,
         ),
         Path::new("Foo_Bar_f32")
     );
 
     // Foo<Bar> => Foo_Bar
     assert_eq!(
-        mangle_path(&Path::new("Foo"), &[path("Bar")], None),
+        mangle_path(&Path::new("Foo"), &[path("Bar")], false, false),
         Path::new("Foo_Bar")
     );
 
     // Foo<Bar> => FooBar
     assert_eq!(
-        mangle_path(&Path::new("Foo"), &[path("Bar")], Some("")),
+        mangle_path(&Path::new("Foo"), &[path("Bar")], true, false),
         Path::new("FooBar")
+    );
+
+    // Foo<Bar<f32>> => FooBarF32
+    assert_eq!(
+        mangle_path(
+            &Path::new("Foo"),
+            &vec![generic_path("Bar", &[float()])],
+            true,
+            true,
+        ),
+        Path::new("FooBarF32")
+    );
+
+    // Foo<Bar<c_char>> => FooBarCChar
+    assert_eq!(
+        mangle_path(
+            &Path::new("Foo"),
+            &vec![generic_path("Bar", &[c_char()])],
+            true,
+            true,
+        ),
+        Path::new("FooBarCChar")
     );
 
     // Foo<Bar<T>> => Foo_Bar_T
@@ -174,7 +224,8 @@ fn generics() {
         mangle_path(
             &Path::new("Foo"),
             &[generic_path("Bar", &[path("T")])],
-            None
+            false,
+            false,
         ),
         Path::new("Foo_Bar_T")
     );
@@ -184,7 +235,8 @@ fn generics() {
         mangle_path(
             &Path::new("Foo"),
             &[generic_path("Bar", &[path("T")]), path("E")],
-            None,
+            false,
+            false,
         ),
         Path::new("Foo_Bar_T_____E")
     );
@@ -197,8 +249,34 @@ fn generics() {
                 generic_path("Bar", &[path("T")]),
                 generic_path("Bar", &[path("E")]),
             ],
-            None,
+            false,
+            false,
         ),
         Path::new("Foo_Bar_T_____Bar_E")
+    );
+
+    // Foo<Bar<T>, E> => FooBarTE
+    assert_eq!(
+        mangle_path(
+            &Path::new("Foo"),
+            &[generic_path("Bar", &[path("T")]), path("E")],
+            true,
+            false,
+        ),
+        Path::new("FooBarTE")
+    );
+
+    // Foo<Bar<T>, Bar<E>> => FooBarTBarE
+    assert_eq!(
+        mangle_path(
+            &Path::new("Foo"),
+            &[
+                generic_path("Bar", &[path("T")]),
+                generic_path("Bar", &[path("E")]),
+            ],
+            true,
+            false,
+        ),
+        Path::new("FooBarTBarE")
     );
 }

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -5,8 +5,6 @@
 use crate::bindgen::ir::{Path, Type};
 use crate::bindgen::rename::IdentifierType;
 use crate::bindgen::rename::RenameRule;
-#[cfg(test)]
-use crate::bindgen::rename::RenameRule::PascalCase;
 
 pub fn mangle_path(
     path: &Path,
@@ -159,6 +157,7 @@ impl<'a> Mangler<'a> {
 #[test]
 fn generics() {
     use crate::bindgen::ir::{GenericPath, PrimitiveType};
+    use crate::bindgen::rename::RenameRule::PascalCase;
 
     fn float() -> Type {
         Type::Primitive(PrimitiveType::Float)
@@ -180,7 +179,7 @@ fn generics() {
 
     // Foo<f32> => Foo_f32
     assert_eq!(
-        mangle_path(&Path::new("Foo"), &vec![float()], false, None::<RenameRule>),
+        mangle_path(&Path::new("Foo"), &vec![float()], false, None),
         Path::new("Foo_f32")
     );
 

--- a/src/bindgen/rename.rs
+++ b/src/bindgen/rename.rs
@@ -22,7 +22,7 @@ impl<'a> IdentifierType<'a> {
             IdentifierType::StructMember => "m",
             IdentifierType::EnumVariant(..) => "",
             IdentifierType::FunctionArg => "a",
-            IdentifierType::Type => "t",
+            IdentifierType::Type => "",
             IdentifierType::Enum => "",
         }
     }

--- a/src/bindgen/rename.rs
+++ b/src/bindgen/rename.rs
@@ -12,6 +12,7 @@ pub enum IdentifierType<'a> {
     StructMember,
     EnumVariant(&'a Enum),
     FunctionArg,
+    Type,
     Enum,
 }
 
@@ -21,6 +22,7 @@ impl<'a> IdentifierType<'a> {
             IdentifierType::StructMember => "m",
             IdentifierType::EnumVariant(..) => "",
             IdentifierType::FunctionArg => "a",
+            IdentifierType::Type => "t",
             IdentifierType::Enum => "",
         }
     }


### PR DESCRIPTION
This properly addresses our use case where we want to the default of e.g. `MyType______c_char` to be `MyTypeCChar`. The previous PR did not take the `c_char` type or similar into account, only capitalising the first letter for e.g. `MyTypeU32`. 