### PR TITLE
Add support for specifying line ending style

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -70,9 +70,9 @@ impl Default for LineEndingStyle {
 impl LineEndingStyle {
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::LF => &"\n",
-            Self::CR => &"\r",
-            Self::CRLF => &"\r\n",
+            Self::LF => "\n",
+            Self::CR => "\r",
+            Self::CRLF => "\r\n",
             Self::Native => {
                 #[cfg(target_os = "windows")]
                 {
@@ -801,7 +801,7 @@ pub struct Config {
     /// The amount of spaces in a tab
     pub tab_width: usize,
     /// The type of line endings to generate
-    pub line_endings: Option<LineEndingStyle>,
+    pub line_endings: LineEndingStyle,
     /// The language to output bindings for
     pub language: Language,
     /// Include preprocessor defines in C bindings to ensure C++ compatibility
@@ -858,7 +858,7 @@ impl Default for Config {
             braces: Braces::SameLine,
             line_length: 100,
             tab_width: 2,
-            line_endings: None,
+            line_endings: LineEndingStyle::default(),
             language: Language::Cxx,
             cpp_compat: false,
             style: Style::Type,

--- a/src/bindgen/writer.rs
+++ b/src/bindgen/writer.rs
@@ -138,7 +138,9 @@ impl<'a, F: Write> SourceWriter<'a, F> {
     }
 
     pub fn new_line(&mut self) {
-        write!(self.out, "{}", self.bindings.config.line_endings.unwrap_or_default().as_str()).unwrap();
+        self.out
+            .write(self.bindings.config.line_endings.as_str().as_bytes())
+            .unwrap();
         self.line_started = false;
         self.line_length = 0;
         self.line_number += 1;

--- a/src/bindgen/writer.rs
+++ b/src/bindgen/writer.rs
@@ -65,6 +65,7 @@ pub struct SourceWriter<'a, F: Write> {
     line_number: usize,
     max_line_length: usize,
 }
+
 pub type MeasureWriter<'a> = SourceWriter<'a, NullFile>;
 
 impl<'a, F: Write> SourceWriter<'a, F> {
@@ -137,7 +138,7 @@ impl<'a, F: Write> SourceWriter<'a, F> {
     }
 
     pub fn new_line(&mut self) {
-        writeln!(self.out).unwrap();
+        write!(self.out, "{}", self.bindings.config.line_endings.unwrap_or_default().as_str()).unwrap();
         self.line_started = false;
         self.line_length = 0;
         self.line_number += 1;

--- a/template.toml
+++ b/template.toml
@@ -35,7 +35,7 @@ braces = "SameLine"
 line_length = 100
 tab_width = 2
 documentation_style = "auto"
-
+line-endings = "LF" # also "CR", "CRLF", "Native"
 
 
 

--- a/tests/expectations/both/linestyle_cr.c
+++ b/tests/expectations/both/linestyle_cr.c
@@ -1,0 +1,1 @@
+#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>typedef struct Dummy {  int32_t x;  float y;} Dummy;void root(Dummy d);

--- a/tests/expectations/both/linestyle_cr.compat.c
+++ b/tests/expectations/both/linestyle_cr.compat.c
@@ -1,0 +1,1 @@
+#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>typedef struct Dummy {  int32_t x;  float y;} Dummy;#ifdef __cplusplusextern "C" {#endif // __cplusplusvoid root(Dummy d);#ifdef __cplusplus} // extern "C"#endif // __cplusplus

--- a/tests/expectations/both/linestyle_crlf.c
+++ b/tests/expectations/both/linestyle_crlf.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Dummy {
+  int32_t x;
+  float y;
+} Dummy;
+
+void root(Dummy d);

--- a/tests/expectations/both/linestyle_crlf.compat.c
+++ b/tests/expectations/both/linestyle_crlf.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Dummy {
+  int32_t x;
+  float y;
+} Dummy;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(Dummy d);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/both/linestyle_lf.c
+++ b/tests/expectations/both/linestyle_lf.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Dummy {
+  int32_t x;
+  float y;
+} Dummy;
+
+void root(Dummy d);

--- a/tests/expectations/both/linestyle_lf.compat.c
+++ b/tests/expectations/both/linestyle_lf.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Dummy {
+  int32_t x;
+  float y;
+} Dummy;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(Dummy d);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/linestyle_cr.c
+++ b/tests/expectations/linestyle_cr.c
@@ -1,0 +1,1 @@
+#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>typedef struct {  int32_t x;  float y;} Dummy;void root(Dummy d);

--- a/tests/expectations/linestyle_cr.compat.c
+++ b/tests/expectations/linestyle_cr.compat.c
@@ -1,0 +1,1 @@
+#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>typedef struct {  int32_t x;  float y;} Dummy;#ifdef __cplusplusextern "C" {#endif // __cplusplusvoid root(Dummy d);#ifdef __cplusplus} // extern "C"#endif // __cplusplus

--- a/tests/expectations/linestyle_cr.cpp
+++ b/tests/expectations/linestyle_cr.cpp
@@ -1,0 +1,1 @@
+#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>typedef struct {  int32_t x;  float y;} Dummy;void root(Dummy d);

--- a/tests/expectations/linestyle_cr.cpp
+++ b/tests/expectations/linestyle_cr.cpp
@@ -1,1 +1,1 @@
-#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>typedef struct {  int32_t x;  float y;} Dummy;void root(Dummy d);
+#include <cstdarg>#include <cstdint>#include <cstdlib>#include <new>struct Dummy {  int32_t x;  float y;};extern "C" {void root(Dummy d);} // extern "C"

--- a/tests/expectations/linestyle_crlf.c
+++ b/tests/expectations/linestyle_crlf.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  float y;
+} Dummy;
+
+void root(Dummy d);

--- a/tests/expectations/linestyle_crlf.compat.c
+++ b/tests/expectations/linestyle_crlf.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  float y;
+} Dummy;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(Dummy d);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/linestyle_crlf.cpp
+++ b/tests/expectations/linestyle_crlf.cpp
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  float y;
+} Dummy;
+
+void root(Dummy d);

--- a/tests/expectations/linestyle_crlf.cpp
+++ b/tests/expectations/linestyle_crlf.cpp
@@ -1,11 +1,15 @@
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
 
-typedef struct {
+struct Dummy {
   int32_t x;
   float y;
-} Dummy;
+};
+
+extern "C" {
 
 void root(Dummy d);
+
+} // extern "C"

--- a/tests/expectations/linestyle_lf.c
+++ b/tests/expectations/linestyle_lf.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  float y;
+} Dummy;
+
+void root(Dummy d);

--- a/tests/expectations/linestyle_lf.compat.c
+++ b/tests/expectations/linestyle_lf.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  float y;
+} Dummy;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(Dummy d);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/linestyle_lf.cpp
+++ b/tests/expectations/linestyle_lf.cpp
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  float y;
+} Dummy;
+
+void root(Dummy d);

--- a/tests/expectations/linestyle_lf.cpp
+++ b/tests/expectations/linestyle_lf.cpp
@@ -1,11 +1,15 @@
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
 
-typedef struct {
+struct Dummy {
   int32_t x;
   float y;
-} Dummy;
+};
+
+extern "C" {
 
 void root(Dummy d);
+
+} // extern "C"

--- a/tests/expectations/tag/linestyle_cr.c
+++ b/tests/expectations/tag/linestyle_cr.c
@@ -1,0 +1,1 @@
+#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>struct Dummy {  int32_t x;  float y;};void root(struct Dummy d);

--- a/tests/expectations/tag/linestyle_cr.compat.c
+++ b/tests/expectations/tag/linestyle_cr.compat.c
@@ -1,0 +1,1 @@
+#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>struct Dummy {  int32_t x;  float y;};#ifdef __cplusplusextern "C" {#endif // __cplusplusvoid root(struct Dummy d);#ifdef __cplusplus} // extern "C"#endif // __cplusplus

--- a/tests/expectations/tag/linestyle_crlf.c
+++ b/tests/expectations/tag/linestyle_crlf.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Dummy {
+  int32_t x;
+  float y;
+};
+
+void root(struct Dummy d);

--- a/tests/expectations/tag/linestyle_crlf.compat.c
+++ b/tests/expectations/tag/linestyle_crlf.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Dummy {
+  int32_t x;
+  float y;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(struct Dummy d);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/tag/linestyle_lf.c
+++ b/tests/expectations/tag/linestyle_lf.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Dummy {
+  int32_t x;
+  float y;
+};
+
+void root(struct Dummy d);

--- a/tests/expectations/tag/linestyle_lf.compat.c
+++ b/tests/expectations/tag/linestyle_lf.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Dummy {
+  int32_t x;
+  float y;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(struct Dummy d);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/rust/linestyle_cr.rs
+++ b/tests/rust/linestyle_cr.rs
@@ -1,0 +1,8 @@
+#[repr(C)]
+struct Dummy {
+    x: i32,
+    y: f32,
+}
+
+#[no_mangle]
+pub extern "C" fn root(d: Dummy) {}

--- a/tests/rust/linestyle_cr.toml
+++ b/tests/rust/linestyle_cr.toml
@@ -1,2 +1,1 @@
-language = "c"
 line_endings = "CR"

--- a/tests/rust/linestyle_cr.toml
+++ b/tests/rust/linestyle_cr.toml
@@ -1,0 +1,2 @@
+language = "c"
+line_endings = "CR"

--- a/tests/rust/linestyle_crlf.rs
+++ b/tests/rust/linestyle_crlf.rs
@@ -1,0 +1,8 @@
+#[repr(C)]
+struct Dummy {
+    x: i32,
+    y: f32,
+}
+
+#[no_mangle]
+pub extern "C" fn root(d: Dummy) {}

--- a/tests/rust/linestyle_crlf.toml
+++ b/tests/rust/linestyle_crlf.toml
@@ -1,2 +1,1 @@
-language = "c"
 line_endings = "CRLF"

--- a/tests/rust/linestyle_crlf.toml
+++ b/tests/rust/linestyle_crlf.toml
@@ -1,0 +1,2 @@
+language = "c"
+line_endings = "CRLF"

--- a/tests/rust/linestyle_lf.rs
+++ b/tests/rust/linestyle_lf.rs
@@ -1,0 +1,8 @@
+#[repr(C)]
+struct Dummy {
+    x: i32,
+    y: f32,
+}
+
+#[no_mangle]
+pub extern "C" fn root(d: Dummy) {}

--- a/tests/rust/linestyle_lf.toml
+++ b/tests/rust/linestyle_lf.toml
@@ -1,2 +1,1 @@
-language = "c"
 line_endings = "LF"

--- a/tests/rust/linestyle_lf.toml
+++ b/tests/rust/linestyle_lf.toml
@@ -1,0 +1,2 @@
+language = "c"
+line_endings = "LF"


### PR DESCRIPTION
Hello!

This is a PR to allow specification of the desired line ending style in the generated file. The background for this is working in a git repository shared between Windows and Linux users. The windows users have their git `core.autocrlf` flag setup to check out CRLF, submit LF, and Linux users only work with LF. Both the input and output files are tracked in source control to highlight inadvertent changes in the generated API. 

Since cbindgen generates with only '\n' (based on `write!`) their checked-out CRLF header file becomes LF, and they both get a meaningless whitespace-only diff as-well-as a warning from git that they have a LF file in their CRLF repository.

This changeset introduces a new configuration option that gives four options for line endings: LF, CR, CRLF, or Native. The last option will try to follow the configuration on the target_os, which in practice means CRLF on Windows and LF everywhere else. The default value will remain LF, making this opt-in and fully backwards compatible.