### PR TITLE
Refactor rename-rules to make more sense.

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -310,7 +310,7 @@ pub struct ExportConfig {
 #[serde(default)]
 pub struct MangleConfig {
     /// The rename rule to apply to the type names mangled.
-    pub rename_types: Option<RenameRule>,
+    pub rename_types: RenameRule,
     /// Remove the underscores used for name mangling.
     pub remove_underscores: bool,
 }
@@ -379,7 +379,7 @@ pub struct FunctionConfig {
     /// The style to layout the args
     pub args: Layout,
     /// The rename rule to apply to function args
-    pub rename_args: Option<RenameRule>,
+    pub rename_args: RenameRule,
     /// An optional macro to use when generating Swift function name attributes
     pub swift_name_macro: Option<String>,
     /// Sort key for function names
@@ -395,7 +395,7 @@ impl Default for FunctionConfig {
             postfix: None,
             must_use: None,
             args: Layout::Auto,
-            rename_args: None,
+            rename_args: RenameRule::None,
             swift_name_macro: None,
             sort_by: SortKey::Name,
             no_return: None,
@@ -426,7 +426,7 @@ impl FunctionConfig {
 #[serde(default)]
 pub struct StructConfig {
     /// The rename rule to apply to the name of struct fields
-    pub rename_fields: Option<RenameRule>,
+    pub rename_fields: RenameRule,
     /// Whether to generate a constructor for the struct (which takes
     /// arguments to initialize all the members)
     pub derive_constructor: bool,
@@ -501,7 +501,7 @@ impl StructConfig {
 #[serde(default)]
 pub struct EnumConfig {
     /// The rename rule to apply to the name of enum variants
-    pub rename_variants: Option<RenameRule>,
+    pub rename_variants: RenameRule,
     /// Whether to add a `Sentinel` value at the end of every enum
     /// This is useful in Gecko for IPC serialization
     pub add_sentinel: bool,
@@ -540,7 +540,7 @@ pub struct EnumConfig {
 impl Default for EnumConfig {
     fn default() -> EnumConfig {
         EnumConfig {
-            rename_variants: None,
+            rename_variants: RenameRule::None,
             add_sentinel: false,
             prefix_with_name: false,
             derive_helper_methods: false,

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -5,7 +5,6 @@
 use crate::bindgen::config::MangleConfig;
 use crate::bindgen::ir::{Path, Type};
 use crate::bindgen::rename::IdentifierType;
-use crate::bindgen::rename::RenameRule;
 
 pub fn mangle_path(path: &Path, generic_values: &[Type], config: &MangleConfig) -> Path {
     Path::new(mangle_name(path.name(), generic_values, config))
@@ -73,7 +72,6 @@ impl<'a> Mangler<'a> {
                     &self
                         .config
                         .rename_types
-                        .unwrap_or(RenameRule::None)
                         .apply(&sub_path, IdentifierType::Type),
                 );
             }
@@ -82,7 +80,6 @@ impl<'a> Mangler<'a> {
                     &self
                         .config
                         .rename_types
-                        .unwrap_or(RenameRule::None)
                         .apply(primitive.to_repr_rust(), IdentifierType::Type),
                 );
             }
@@ -132,7 +129,7 @@ impl<'a> Mangler<'a> {
 #[test]
 fn generics() {
     use crate::bindgen::ir::{GenericPath, PrimitiveType};
-    use crate::bindgen::rename::RenameRule::PascalCase;
+    use crate::bindgen::rename::RenameRule::{self, PascalCase};
 
     fn float() -> Type {
         Type::Primitive(PrimitiveType::Float)
@@ -181,7 +178,7 @@ fn generics() {
             &[path("Bar")],
             &MangleConfig {
                 remove_underscores: true,
-                rename_types: None,
+                rename_types: RenameRule::None,
             }
         ),
         Path::new("FooBar")
@@ -194,7 +191,7 @@ fn generics() {
             &vec![generic_path("Bar", &[float()])],
             &MangleConfig {
                 remove_underscores: true,
-                rename_types: Some(PascalCase),
+                rename_types: PascalCase,
             },
         ),
         Path::new("FooBarF32")
@@ -207,7 +204,7 @@ fn generics() {
             &vec![generic_path("Bar", &[c_char()])],
             &MangleConfig {
                 remove_underscores: true,
-                rename_types: Some(PascalCase),
+                rename_types: PascalCase,
             },
         ),
         Path::new("FooBarCChar")
@@ -253,7 +250,7 @@ fn generics() {
             &[generic_path("Bar", &[path("T")]), path("E")],
             &MangleConfig {
                 remove_underscores: true,
-                rename_types: Some(PascalCase),
+                rename_types: PascalCase,
             },
         ),
         Path::new("FooBarTE")
@@ -269,7 +266,7 @@ fn generics() {
             ],
             &MangleConfig {
                 remove_underscores: true,
-                rename_types: Some(PascalCase),
+                rename_types: PascalCase,
             },
         ),
         Path::new("FooBarTBarE")

--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -28,15 +28,6 @@ where
     }
 }
 
-pub fn find_first_some<T>(slice: &[Option<T>]) -> Option<&T> {
-    for x in slice {
-        if let Some(ref x) = *x {
-            return Some(x);
-        }
-    }
-    None
-}
-
 pub trait SynItemFnHelpers: SynAttributeHelpers {
     fn exported_name(&self) -> Option<String>;
 }

--- a/tests/expectations/annotation.cpp
+++ b/tests/expectations/annotation.cpp
@@ -11,8 +11,8 @@ enum class C : uint32_t {
 struct A {
   int32_t m0;
 
-  A(int32_t const& aM0)
-    : m0(aM0)
+  A(int32_t const& m0)
+    : m0(m0)
   {}
 
   bool operator<(const A& other) const {
@@ -52,9 +52,9 @@ union F {
   Foo_Body foo;
   Bar_Body bar;
 
-  static F Foo(const int16_t &a0) {
+  static F Foo(const int16_t &_0) {
     F result;
-    ::new (&result.foo._0) (int16_t)(a0);
+    ::new (&result.foo._0) (int16_t)(_0);
     result.tag = Tag::Foo;
     return result;
   }
@@ -63,11 +63,11 @@ union F {
     return tag == Tag::Foo;
   }
 
-  static F Bar(const uint8_t &aX,
-               const int16_t &aY) {
+  static F Bar(const uint8_t &x,
+               const int16_t &y) {
     F result;
-    ::new (&result.bar.x) (uint8_t)(aX);
-    ::new (&result.bar.y) (int16_t)(aY);
+    ::new (&result.bar.x) (uint8_t)(x);
+    ::new (&result.bar.y) (int16_t)(y);
     result.tag = Tag::Bar;
     return result;
   }
@@ -109,9 +109,9 @@ struct H {
     There_Body there;
   };
 
-  static H Hello(const int16_t &a0) {
+  static H Hello(const int16_t &_0) {
     H result;
-    ::new (&result.hello._0) (int16_t)(a0);
+    ::new (&result.hello._0) (int16_t)(_0);
     result.tag = Tag::Hello;
     return result;
   }
@@ -120,11 +120,11 @@ struct H {
     return tag == Tag::Hello;
   }
 
-  static H There(const uint8_t &aX,
-                 const int16_t &aY) {
+  static H There(const uint8_t &x,
+                 const int16_t &y) {
     H result;
-    ::new (&result.there.x) (uint8_t)(aX);
-    ::new (&result.there.y) (int16_t)(aY);
+    ::new (&result.there.x) (uint8_t)(x);
+    ::new (&result.there.y) (int16_t)(y);
     result.tag = Tag::There;
     return result;
   }

--- a/tests/expectations/array.cpp
+++ b/tests/expectations/array.cpp
@@ -17,10 +17,10 @@ struct Foo {
     A_Body a;
   };
 
-  static Foo A(const float (&a0)[20]) {
+  static Foo A(const float (&_0)[20]) {
     Foo result;
     for (int i = 0; i < 20; i++) {
-      ::new (&result.a._0[i]) (float)(a0[i]);
+      ::new (&result.a._0[i]) (float)(_0[i]);
     }
     result.tag = Tag::A;
     return result;

--- a/tests/expectations/asserted-cast.cpp
+++ b/tests/expectations/asserted-cast.cpp
@@ -31,9 +31,9 @@ struct H {
     H_Bar_Body bar;
   };
 
-  static H H_Foo(const int16_t &a0) {
+  static H H_Foo(const int16_t &_0) {
     H result;
-    ::new (&result.foo._0) (int16_t)(a0);
+    ::new (&result.foo._0) (int16_t)(_0);
     result.tag = Tag::H_Foo;
     return result;
   }
@@ -52,11 +52,11 @@ struct H {
     return foo._0;
   }
 
-  static H H_Bar(const uint8_t &aX,
-                 const int16_t &aY) {
+  static H H_Bar(const uint8_t &x,
+                 const int16_t &y) {
     H result;
-    ::new (&result.bar.x) (uint8_t)(aX);
-    ::new (&result.bar.y) (int16_t)(aY);
+    ::new (&result.bar.x) (uint8_t)(x);
+    ::new (&result.bar.y) (int16_t)(y);
     result.tag = Tag::H_Bar;
     return result;
   }
@@ -108,9 +108,9 @@ struct J {
     J_Bar_Body bar;
   };
 
-  static J J_Foo(const int16_t &a0) {
+  static J J_Foo(const int16_t &_0) {
     J result;
-    ::new (&result.foo._0) (int16_t)(a0);
+    ::new (&result.foo._0) (int16_t)(_0);
     result.tag = Tag::J_Foo;
     return result;
   }
@@ -129,11 +129,11 @@ struct J {
     return foo._0;
   }
 
-  static J J_Bar(const uint8_t &aX,
-                 const int16_t &aY) {
+  static J J_Bar(const uint8_t &x,
+                 const int16_t &y) {
     J result;
-    ::new (&result.bar.x) (uint8_t)(aX);
-    ::new (&result.bar.y) (int16_t)(aY);
+    ::new (&result.bar.x) (uint8_t)(x);
+    ::new (&result.bar.y) (int16_t)(y);
     result.tag = Tag::J_Bar;
     return result;
   }
@@ -187,9 +187,9 @@ union K {
   K_Foo_Body foo;
   K_Bar_Body bar;
 
-  static K K_Foo(const int16_t &a0) {
+  static K K_Foo(const int16_t &_0) {
     K result;
-    ::new (&result.foo._0) (int16_t)(a0);
+    ::new (&result.foo._0) (int16_t)(_0);
     result.tag = Tag::K_Foo;
     return result;
   }
@@ -208,11 +208,11 @@ union K {
     return foo._0;
   }
 
-  static K K_Bar(const uint8_t &aX,
-                 const int16_t &aY) {
+  static K K_Bar(const uint8_t &x,
+                 const int16_t &y) {
     K result;
-    ::new (&result.bar.x) (uint8_t)(aX);
-    ::new (&result.bar.y) (int16_t)(aY);
+    ::new (&result.bar.x) (uint8_t)(x);
+    ::new (&result.bar.y) (int16_t)(y);
     result.tag = Tag::K_Bar;
     return result;
   }

--- a/tests/expectations/cfg.cpp
+++ b/tests/expectations/cfg.cpp
@@ -104,9 +104,9 @@ union C {
 #endif
 
 #if defined(PLATFORM_UNIX)
-  static C C5(const int32_t &aInt) {
+  static C C5(const int32_t &int_) {
     C result;
-    ::new (&result.c5.int_) (int32_t)(aInt);
+    ::new (&result.c5.int_) (int32_t)(int_);
     result.tag = Tag::C5;
     return result;
   }

--- a/tests/expectations/destructor-and-copy-ctor.cpp
+++ b/tests/expectations/destructor-and-copy-ctor.cpp
@@ -79,9 +79,9 @@ struct Foo {
     return tag == Tag::Bar;
   }
 
-  static Foo Polygon1(const Polygon<T> &a0) {
+  static Foo Polygon1(const Polygon<T> &_0) {
     Foo result;
-    ::new (&result.polygon1._0) (Polygon<T>)(a0);
+    ::new (&result.polygon1._0) (Polygon<T>)(_0);
     result.tag = Tag::Polygon1;
     return result;
   }
@@ -90,9 +90,9 @@ struct Foo {
     return tag == Tag::Polygon1;
   }
 
-  static Foo Slice1(const OwnedSlice<T> &a0) {
+  static Foo Slice1(const OwnedSlice<T> &_0) {
     Foo result;
-    ::new (&result.slice1._0) (OwnedSlice<T>)(a0);
+    ::new (&result.slice1._0) (OwnedSlice<T>)(_0);
     result.tag = Tag::Slice1;
     return result;
   }
@@ -101,9 +101,9 @@ struct Foo {
     return tag == Tag::Slice1;
   }
 
-  static Foo Slice2(const OwnedSlice<int32_t> &a0) {
+  static Foo Slice2(const OwnedSlice<int32_t> &_0) {
     Foo result;
-    ::new (&result.slice2._0) (OwnedSlice<int32_t>)(a0);
+    ::new (&result.slice2._0) (OwnedSlice<int32_t>)(_0);
     result.tag = Tag::Slice2;
     return result;
   }
@@ -112,11 +112,11 @@ struct Foo {
     return tag == Tag::Slice2;
   }
 
-  static Foo Slice3(const FillRule &aFill,
-                    const OwnedSlice<T> &aCoords) {
+  static Foo Slice3(const FillRule &fill,
+                    const OwnedSlice<T> &coords) {
     Foo result;
-    ::new (&result.slice3.fill) (FillRule)(aFill);
-    ::new (&result.slice3.coords) (OwnedSlice<T>)(aCoords);
+    ::new (&result.slice3.fill) (FillRule)(fill);
+    ::new (&result.slice3.coords) (OwnedSlice<T>)(coords);
     result.tag = Tag::Slice3;
     return result;
   }
@@ -125,11 +125,11 @@ struct Foo {
     return tag == Tag::Slice3;
   }
 
-  static Foo Slice4(const FillRule &aFill,
-                    const OwnedSlice<int32_t> &aCoords) {
+  static Foo Slice4(const FillRule &fill,
+                    const OwnedSlice<int32_t> &coords) {
     Foo result;
-    ::new (&result.slice4.fill) (FillRule)(aFill);
-    ::new (&result.slice4.coords) (OwnedSlice<int32_t>)(aCoords);
+    ::new (&result.slice4.fill) (FillRule)(fill);
+    ::new (&result.slice4.coords) (OwnedSlice<int32_t>)(coords);
     result.tag = Tag::Slice4;
     return result;
   }
@@ -233,9 +233,9 @@ union Baz {
     return tag == Tag::Bar2;
   }
 
-  static Baz Polygon21(const Polygon<T> &a0) {
+  static Baz Polygon21(const Polygon<T> &_0) {
     Baz result;
-    ::new (&result.polygon21._0) (Polygon<T>)(a0);
+    ::new (&result.polygon21._0) (Polygon<T>)(_0);
     result.tag = Tag::Polygon21;
     return result;
   }
@@ -244,9 +244,9 @@ union Baz {
     return tag == Tag::Polygon21;
   }
 
-  static Baz Slice21(const OwnedSlice<T> &a0) {
+  static Baz Slice21(const OwnedSlice<T> &_0) {
     Baz result;
-    ::new (&result.slice21._0) (OwnedSlice<T>)(a0);
+    ::new (&result.slice21._0) (OwnedSlice<T>)(_0);
     result.tag = Tag::Slice21;
     return result;
   }
@@ -255,9 +255,9 @@ union Baz {
     return tag == Tag::Slice21;
   }
 
-  static Baz Slice22(const OwnedSlice<int32_t> &a0) {
+  static Baz Slice22(const OwnedSlice<int32_t> &_0) {
     Baz result;
-    ::new (&result.slice22._0) (OwnedSlice<int32_t>)(a0);
+    ::new (&result.slice22._0) (OwnedSlice<int32_t>)(_0);
     result.tag = Tag::Slice22;
     return result;
   }
@@ -266,11 +266,11 @@ union Baz {
     return tag == Tag::Slice22;
   }
 
-  static Baz Slice23(const FillRule &aFill,
-                     const OwnedSlice<T> &aCoords) {
+  static Baz Slice23(const FillRule &fill,
+                     const OwnedSlice<T> &coords) {
     Baz result;
-    ::new (&result.slice23.fill) (FillRule)(aFill);
-    ::new (&result.slice23.coords) (OwnedSlice<T>)(aCoords);
+    ::new (&result.slice23.fill) (FillRule)(fill);
+    ::new (&result.slice23.coords) (OwnedSlice<T>)(coords);
     result.tag = Tag::Slice23;
     return result;
   }
@@ -279,11 +279,11 @@ union Baz {
     return tag == Tag::Slice23;
   }
 
-  static Baz Slice24(const FillRule &aFill,
-                     const OwnedSlice<int32_t> &aCoords) {
+  static Baz Slice24(const FillRule &fill,
+                     const OwnedSlice<int32_t> &coords) {
     Baz result;
-    ::new (&result.slice24.fill) (FillRule)(aFill);
-    ::new (&result.slice24.coords) (OwnedSlice<int32_t>)(aCoords);
+    ::new (&result.slice24.fill) (FillRule)(fill);
+    ::new (&result.slice24.coords) (OwnedSlice<int32_t>)(coords);
     result.tag = Tag::Slice24;
     return result;
   }
@@ -363,9 +363,9 @@ union Taz {
     return tag == Tag::Bar3;
   }
 
-  static Taz Taz1(const int32_t &a0) {
+  static Taz Taz1(const int32_t &_0) {
     Taz result;
-    ::new (&result.taz1._0) (int32_t)(a0);
+    ::new (&result.taz1._0) (int32_t)(_0);
     result.tag = Tag::Taz1;
     return result;
   }
@@ -374,9 +374,9 @@ union Taz {
     return tag == Tag::Taz1;
   }
 
-  static Taz Taz3(const OwnedSlice<int32_t> &a0) {
+  static Taz Taz3(const OwnedSlice<int32_t> &_0) {
     Taz result;
-    ::new (&result.taz3._0) (OwnedSlice<int32_t>)(a0);
+    ::new (&result.taz3._0) (OwnedSlice<int32_t>)(_0);
     result.tag = Tag::Taz3;
     return result;
   }
@@ -443,9 +443,9 @@ union Tazz {
     return tag == Tag::Bar4;
   }
 
-  static Tazz Taz2(const int32_t &a0) {
+  static Tazz Taz2(const int32_t &_0) {
     Tazz result;
-    ::new (&result.taz2._0) (int32_t)(a0);
+    ::new (&result.taz2._0) (int32_t)(_0);
     result.tag = Tag::Taz2;
     return result;
   }
@@ -488,9 +488,9 @@ union Tazzz {
     return tag == Tag::Bar5;
   }
 
-  static Tazzz Taz5(const int32_t &a0) {
+  static Tazzz Taz5(const int32_t &_0) {
     Tazzz result;
-    ::new (&result.taz5._0) (int32_t)(a0);
+    ::new (&result.taz5._0) (int32_t)(_0);
     result.tag = Tag::Taz5;
     return result;
   }
@@ -544,9 +544,9 @@ union Tazzzz {
   Taz6_Body taz6;
   Taz7_Body taz7;
 
-  static Tazzzz Taz6(const int32_t &a0) {
+  static Tazzzz Taz6(const int32_t &_0) {
     Tazzzz result;
-    ::new (&result.taz6._0) (int32_t)(a0);
+    ::new (&result.taz6._0) (int32_t)(_0);
     result.tag = Tag::Taz6;
     return result;
   }
@@ -555,9 +555,9 @@ union Tazzzz {
     return tag == Tag::Taz6;
   }
 
-  static Tazzzz Taz7(const uint32_t &a0) {
+  static Tazzzz Taz7(const uint32_t &_0) {
     Tazzzz result;
-    ::new (&result.taz7._0) (uint32_t)(a0);
+    ::new (&result.taz7._0) (uint32_t)(_0);
     result.tag = Tag::Taz7;
     return result;
   }
@@ -628,9 +628,9 @@ union Qux {
   Qux1_Body qux1;
   Qux2_Body qux2;
 
-  static Qux Qux1(const int32_t &a0) {
+  static Qux Qux1(const int32_t &_0) {
     Qux result;
-    ::new (&result.qux1._0) (int32_t)(a0);
+    ::new (&result.qux1._0) (int32_t)(_0);
     result.tag = Tag::Qux1;
     return result;
   }
@@ -639,9 +639,9 @@ union Qux {
     return tag == Tag::Qux1;
   }
 
-  static Qux Qux2(const uint32_t &a0) {
+  static Qux Qux2(const uint32_t &_0) {
     Qux result;
-    ::new (&result.qux2._0) (uint32_t)(a0);
+    ::new (&result.qux2._0) (uint32_t)(_0);
     result.tag = Tag::Qux2;
     return result;
   }

--- a/tests/expectations/transform-op.cpp
+++ b/tests/expectations/transform-op.cpp
@@ -43,13 +43,13 @@ union StyleFoo {
   Bar_Body bar;
   Baz_Body baz;
 
-  static StyleFoo Foo(const int32_t &aX,
-                      const StylePoint<T> &aY,
-                      const StylePoint<float> &aZ) {
+  static StyleFoo Foo(const int32_t &x,
+                      const StylePoint<T> &y,
+                      const StylePoint<float> &z) {
     StyleFoo result;
-    ::new (&result.foo.x) (int32_t)(aX);
-    ::new (&result.foo.y) (StylePoint<T>)(aY);
-    ::new (&result.foo.z) (StylePoint<float>)(aZ);
+    ::new (&result.foo.x) (int32_t)(x);
+    ::new (&result.foo.y) (StylePoint<T>)(y);
+    ::new (&result.foo.z) (StylePoint<float>)(z);
     result.tag = Tag::Foo;
     return result;
   }
@@ -68,9 +68,9 @@ union StyleFoo {
     return foo;
   }
 
-  static StyleFoo Bar(const T &a0) {
+  static StyleFoo Bar(const T &_0) {
     StyleFoo result;
-    ::new (&result.bar._0) (T)(a0);
+    ::new (&result.bar._0) (T)(_0);
     result.tag = Tag::Bar;
     return result;
   }
@@ -89,9 +89,9 @@ union StyleFoo {
     return bar._0;
   }
 
-  static StyleFoo Baz(const StylePoint<T> &a0) {
+  static StyleFoo Baz(const StylePoint<T> &_0) {
     StyleFoo result;
-    ::new (&result.baz._0) (StylePoint<T>)(a0);
+    ::new (&result.baz._0) (StylePoint<T>)(_0);
     result.tag = Tag::Baz;
     return result;
   }
@@ -152,15 +152,15 @@ struct StyleBar {
     StyleBar3_Body bar3;
   };
 
-  static StyleBar Bar1(const int32_t &aX,
-                       const StylePoint<T> &aY,
-                       const StylePoint<float> &aZ,
-                       int32_t (*&aU)(int32_t)) {
+  static StyleBar Bar1(const int32_t &x,
+                       const StylePoint<T> &y,
+                       const StylePoint<float> &z,
+                       int32_t (*&u)(int32_t)) {
     StyleBar result;
-    ::new (&result.bar1.x) (int32_t)(aX);
-    ::new (&result.bar1.y) (StylePoint<T>)(aY);
-    ::new (&result.bar1.z) (StylePoint<float>)(aZ);
-    ::new (&result.bar1.u) (int32_t(*)(int32_t))(aU);
+    ::new (&result.bar1.x) (int32_t)(x);
+    ::new (&result.bar1.y) (StylePoint<T>)(y);
+    ::new (&result.bar1.z) (StylePoint<float>)(z);
+    ::new (&result.bar1.u) (int32_t(*)(int32_t))(u);
     result.tag = Tag::Bar1;
     return result;
   }
@@ -179,9 +179,9 @@ struct StyleBar {
     return bar1;
   }
 
-  static StyleBar Bar2(const T &a0) {
+  static StyleBar Bar2(const T &_0) {
     StyleBar result;
-    ::new (&result.bar2._0) (T)(a0);
+    ::new (&result.bar2._0) (T)(_0);
     result.tag = Tag::Bar2;
     return result;
   }
@@ -200,9 +200,9 @@ struct StyleBar {
     return bar2._0;
   }
 
-  static StyleBar Bar3(const StylePoint<T> &a0) {
+  static StyleBar Bar3(const StylePoint<T> &_0) {
     StyleBar result;
-    ::new (&result.bar3._0) (StylePoint<T>)(a0);
+    ::new (&result.bar3._0) (StylePoint<T>)(_0);
     result.tag = Tag::Bar3;
     return result;
   }
@@ -255,9 +255,9 @@ union StyleBaz {
   Baz1_Body baz1;
   Baz2_Body baz2;
 
-  static StyleBaz Baz1(const StyleBar<uint32_t> &a0) {
+  static StyleBaz Baz1(const StyleBar<uint32_t> &_0) {
     StyleBaz result;
-    ::new (&result.baz1._0) (StyleBar<uint32_t>)(a0);
+    ::new (&result.baz1._0) (StyleBar<uint32_t>)(_0);
     result.tag = Tag::Baz1;
     return result;
   }
@@ -276,9 +276,9 @@ union StyleBaz {
     return baz1._0;
   }
 
-  static StyleBaz Baz2(const StylePoint<int32_t> &a0) {
+  static StyleBaz Baz2(const StylePoint<int32_t> &_0) {
     StyleBaz result;
-    ::new (&result.baz2._0) (StylePoint<int32_t>)(a0);
+    ::new (&result.baz2._0) (StylePoint<int32_t>)(_0);
     result.tag = Tag::Baz2;
     return result;
   }
@@ -329,9 +329,9 @@ struct StyleTaz {
     StyleTaz2_Body taz2;
   };
 
-  static StyleTaz Taz1(const StyleBar<uint32_t> &a0) {
+  static StyleTaz Taz1(const StyleBar<uint32_t> &_0) {
     StyleTaz result;
-    ::new (&result.taz1._0) (StyleBar<uint32_t>)(a0);
+    ::new (&result.taz1._0) (StyleBar<uint32_t>)(_0);
     result.tag = Tag::Taz1;
     return result;
   }
@@ -350,9 +350,9 @@ struct StyleTaz {
     return taz1._0;
   }
 
-  static StyleTaz Taz2(const StyleBaz &a0) {
+  static StyleTaz Taz2(const StyleBaz &_0) {
     StyleTaz result;
-    ::new (&result.taz2._0) (StyleBaz)(a0);
+    ::new (&result.taz2._0) (StyleBaz)(_0);
     result.tag = Tag::Taz2;
     return result;
   }


### PR DESCRIPTION
Option<RenameRule> doesn't make sense anywhere because there's a
RenameRule::None itself, which is also default.

This simplifies a bit the rename rules code, and removes one weird
"default-to-gecko-case" that seems snuck by.

This is a breaking change because the `config` types are exposed
publicly, but #575 is a breaking-change as well so let's take
advantage of the opportunity.