### PR TITLE
feat(ir) Add ability to ignore specific struct fields

### DIFF
--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -229,6 +229,7 @@ impl_syn_item_helper!(syn::ItemMod);
 impl_syn_item_helper!(syn::ItemForeignMod);
 impl_syn_item_helper!(syn::ItemType);
 impl_syn_item_helper!(syn::ItemStruct);
+impl_syn_item_helper!(syn::Field);
 impl_syn_item_helper!(syn::ItemEnum);
 impl_syn_item_helper!(syn::ItemUnion);
 impl_syn_item_helper!(syn::ItemTrait);

--- a/tests/expectations/both/ignore.c
+++ b/tests/expectations/both/ignore.c
@@ -3,4 +3,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-void no_ignore_root(void);
+typedef struct OneFieldIgnored {
+  int32_t x;
+  int32_t z;
+} OneFieldIgnored;
+
+typedef struct AllFieldsIgnored {
+
+} AllFieldsIgnored;
+
+void no_ignore_root(OneFieldIgnored one, AllFieldsIgnored all);

--- a/tests/expectations/both/ignore.compat.c
+++ b/tests/expectations/both/ignore.compat.c
@@ -3,11 +3,20 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+typedef struct OneFieldIgnored {
+  int32_t x;
+  int32_t z;
+} OneFieldIgnored;
+
+typedef struct AllFieldsIgnored {
+
+} AllFieldsIgnored;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void no_ignore_root(void);
+void no_ignore_root(OneFieldIgnored one, AllFieldsIgnored all);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/ignore.c
+++ b/tests/expectations/ignore.c
@@ -3,4 +3,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-void no_ignore_root(void);
+typedef struct {
+  int32_t x;
+  int32_t z;
+} OneFieldIgnored;
+
+typedef struct {
+
+} AllFieldsIgnored;
+
+void no_ignore_root(OneFieldIgnored one, AllFieldsIgnored all);

--- a/tests/expectations/ignore.compat.c
+++ b/tests/expectations/ignore.compat.c
@@ -3,11 +3,20 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+typedef struct {
+  int32_t x;
+  int32_t z;
+} OneFieldIgnored;
+
+typedef struct {
+
+} AllFieldsIgnored;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void no_ignore_root(void);
+void no_ignore_root(OneFieldIgnored one, AllFieldsIgnored all);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/ignore.cpp
+++ b/tests/expectations/ignore.cpp
@@ -3,8 +3,17 @@
 #include <cstdlib>
 #include <new>
 
+struct OneFieldIgnored {
+  int32_t x;
+  int32_t z;
+};
+
+struct AllFieldsIgnored {
+
+};
+
 extern "C" {
 
-void no_ignore_root();
+void no_ignore_root(OneFieldIgnored one, AllFieldsIgnored all);
 
 } // extern "C"

--- a/tests/expectations/tag/ignore.c
+++ b/tests/expectations/tag/ignore.c
@@ -3,4 +3,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-void no_ignore_root(void);
+struct OneFieldIgnored {
+  int32_t x;
+  int32_t z;
+};
+
+struct AllFieldsIgnored {
+
+};
+
+void no_ignore_root(struct OneFieldIgnored one, struct AllFieldsIgnored all);

--- a/tests/expectations/tag/ignore.compat.c
+++ b/tests/expectations/tag/ignore.compat.c
@@ -3,11 +3,20 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+struct OneFieldIgnored {
+  int32_t x;
+  int32_t z;
+};
+
+struct AllFieldsIgnored {
+
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void no_ignore_root(void);
+void no_ignore_root(struct OneFieldIgnored one, struct AllFieldsIgnored all);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/rust/ignore.rs
+++ b/tests/rust/ignore.rs
@@ -8,5 +8,19 @@ pub extern "C" fn root() {}
 #[no_mangle]
 pub extern "C" fn another_root() {}
 
+#[repr(C)]
+pub struct OneFieldIgnored {
+    x: i32,
+    /// cbindgen:ignore
+    y: i64,
+    z: i32,
+}
+
+#[repr(C)]
+pub struct AllFieldsIgnored {
+    /// cbindgen:ignore
+    inner: i32,
+}
+
 #[no_mangle]
-pub extern "C" fn no_ignore_root() {}
+pub extern "C" fn no_ignore_root(one: OneFieldIgnored, all: AllFieldsIgnored) {}


### PR DESCRIPTION
With this PR, it is now possible to add `/// cbindgen:ignore` on specific struct fields to ignore them.

Thus:

```rust
pub struct OneFieldIgnored {
    x: i32,
    /// cbindgen:ignore
    y: i64,
    z: i32,
}
```

is bound to:

```c
typedef struct {
    int32_t x;
    int32_t z;
} OneFieldIgnored;
```

It is useful for a project I'm working on, but it can also be helpful for issue like https://github.com/eqrion/cbindgen/issues/149.

Thoughts?