### PR TITLE
Support constants with arbitrary types

### DIFF
--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -374,6 +374,25 @@ impl Type {
         Ok(Some(converted))
     }
 
+    pub fn walk(&self, f: &mut impl FnMut(&Self)) {
+        f(self);
+        match self {
+            Type::Array(ty, ..) | Type::Ptr { ty, .. } => ty.walk(f),
+            Type::Path(generic_path) => {
+                for ty in generic_path.generics() {
+                    ty.walk(f);
+                }
+            }
+            Type::Primitive(..) => {}
+            Type::FuncPtr(ret, args) => {
+                ret.walk(f);
+                for arg in args {
+                    arg.1.walk(f);
+                }
+            }
+        }
+    }
+
     pub fn is_primitive_or_ptr_primitive(&self) -> bool {
         match *self {
             Type::Primitive(..) => true,

--- a/tests/expectations/both/constant_user_defined_type.c
+++ b/tests/expectations/both/constant_user_defined_type.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum E {
+  V,
+} E;
+
+typedef struct S {
+  uint8_t field;
+} S;
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/expectations/both/constant_user_defined_type.compat.c
+++ b/tests/expectations/both/constant_user_defined_type.compat.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum E {
+  V,
+} E;
+
+typedef struct S {
+  uint8_t field;
+} S;
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/expectations/constant_user_defined_type.c
+++ b/tests/expectations/constant_user_defined_type.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum {
+  V,
+} E;
+
+typedef struct {
+  uint8_t field;
+} S;
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/expectations/constant_user_defined_type.compat.c
+++ b/tests/expectations/constant_user_defined_type.compat.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum {
+  V,
+} E;
+
+typedef struct {
+  uint8_t field;
+} S;
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/expectations/constant_user_defined_type.cpp
+++ b/tests/expectations/constant_user_defined_type.cpp
@@ -1,0 +1,21 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+enum E {
+  V,
+};
+
+struct S {
+  uint8_t field;
+};
+
+using A = uint8_t;
+
+static const S C1 = S{ /* .field = */ 0 };
+
+static const E C2 = V;
+
+static const A C3 = 0;

--- a/tests/expectations/tag/constant_user_defined_type.c
+++ b/tests/expectations/tag/constant_user_defined_type.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum E {
+  V,
+};
+
+struct S {
+  uint8_t field;
+};
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/expectations/tag/constant_user_defined_type.compat.c
+++ b/tests/expectations/tag/constant_user_defined_type.compat.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum E {
+  V,
+};
+
+struct S {
+  uint8_t field;
+};
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/rust/constant_user_defined_type.rs
+++ b/tests/rust/constant_user_defined_type.rs
@@ -1,0 +1,17 @@
+#[repr(C)]
+pub struct S {
+    field: u8,
+}
+
+/// cbindgen:enum-class=false
+#[repr(C)]
+pub enum E {
+    V,
+}
+use E::*;
+
+pub type A = u8;
+
+pub const C1: S = S { field: 0 };
+pub const C2: E = V;
+pub const C3: A = 0;


### PR DESCRIPTION
When converting `const` items migrate from whitelist to blacklist approach to the constant's type.
As long as we can convert the right hand side with `Literal::load` we assume that we can convert the left hand side as well, perhaps using user-defined types defined in the crate.

The one exception is `str` type.
Despite being able to convert string literals with `Literal::load`, we cannot convert `str`.
We can't even introduce an opaque type for it because it's unsized and pointers to it are fat.

Closes https://github.com/eqrion/cbindgen/issues/583