### PR TITLE
Support constants with arbitrary types (take 2)

### DIFF
--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -195,12 +195,9 @@ impl Literal {
                 })
             }
 
-            // Match literals like "one", 'a', 32 etc
+            // Match literals like true, 'a', 32 etc
             syn::Expr::Lit(syn::ExprLit { ref lit, .. }) => {
                 match lit {
-                    syn::Lit::Str(ref value) => {
-                        Ok(Literal::Expr(format!("u8\"{}\"", value.value())))
-                    }
                     syn::Lit::Byte(ref value) => Ok(Literal::Expr(format!("{}", value.value()))),
                     syn::Lit::Char(ref value) => Ok(Literal::Expr(match value.value() as u32 {
                         0..=255 => format!("'{}'", value.value().escape_default()),
@@ -363,16 +360,6 @@ pub struct Constant {
     pub associated_to: Option<Path>,
 }
 
-fn can_handle(ty: &Type, expr: &syn::Expr) -> bool {
-    if ty.is_primitive_or_ptr_primitive() {
-        return true;
-    }
-    match *expr {
-        syn::Expr::Struct(_) => true,
-        _ => false,
-    }
-}
-
 impl Constant {
     pub fn load(
         path: Path,
@@ -389,10 +376,6 @@ impl Constant {
                 return Err("Cannot have a zero sized const definition.".to_owned());
             }
         };
-
-        if !can_handle(&ty, expr) {
-            return Err("Unhandled const definition".to_owned());
-        }
 
         let mut lit = Literal::load(&expr)?;
 

--- a/tests/expectations/both/constant_user_defined_type.c
+++ b/tests/expectations/both/constant_user_defined_type.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum E {
+  V,
+} E;
+
+typedef struct S {
+  uint8_t field;
+} S;
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/expectations/both/constant_user_defined_type.compat.c
+++ b/tests/expectations/both/constant_user_defined_type.compat.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum E {
+  V,
+} E;
+
+typedef struct S {
+  uint8_t field;
+} S;
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/expectations/constant_user_defined_type.c
+++ b/tests/expectations/constant_user_defined_type.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum {
+  V,
+} E;
+
+typedef struct {
+  uint8_t field;
+} S;
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/expectations/constant_user_defined_type.compat.c
+++ b/tests/expectations/constant_user_defined_type.compat.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum {
+  V,
+} E;
+
+typedef struct {
+  uint8_t field;
+} S;
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/expectations/constant_user_defined_type.cpp
+++ b/tests/expectations/constant_user_defined_type.cpp
@@ -1,0 +1,21 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+enum E {
+  V,
+};
+
+struct S {
+  uint8_t field;
+};
+
+using A = uint8_t;
+
+static const S C1 = S{ /* .field = */ 0 };
+
+static const E C2 = V;
+
+static const A C3 = 0;

--- a/tests/expectations/tag/constant_user_defined_type.c
+++ b/tests/expectations/tag/constant_user_defined_type.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum E {
+  V,
+};
+
+struct S {
+  uint8_t field;
+};
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/expectations/tag/constant_user_defined_type.compat.c
+++ b/tests/expectations/tag/constant_user_defined_type.compat.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum E {
+  V,
+};
+
+struct S {
+  uint8_t field;
+};
+
+typedef uint8_t A;
+
+#define C1 (S){ .field = 0 }
+
+#define C2 V
+
+#define C3 0

--- a/tests/rust/constant_user_defined_type.rs
+++ b/tests/rust/constant_user_defined_type.rs
@@ -1,0 +1,17 @@
+#[repr(C)]
+pub struct S {
+    field: u8,
+}
+
+/// cbindgen:enum-class=false
+#[repr(C)]
+pub enum E {
+    V,
+}
+use E::*;
+
+pub type A = u8;
+
+pub const C1: S = S { field: 0 };
+pub const C2: E = V;
+pub const C3: A = 0;


### PR DESCRIPTION
(Take 1 - https://github.com/eqrion/cbindgen/pull/588.)

When converting `const` items stop checking their types and check only values instead.
As long as we can convert the right hand side with `Literal::load` we assume that we can convert the left hand side as well, perhaps using user-defined types defined in the crate.

The one exception is `str` type.
Despite being able to convert string literals with `Literal::load`, we cannot convert `str`.
We can't even introduce an opaque type for it because it's unsized and pointers to it are fat.
So we just remove the support for string literals from `Literal::load`, processing of `const` items is the only place where it is used anyway.

Closes https://github.com/eqrion/cbindgen/issues/583