### PR TITLE
CI: Add a minimum Rust version check?

### DIFF
--- a/.github/workflows/cbindgen.yml
+++ b/.github/workflows/cbindgen.yml
@@ -30,6 +30,16 @@ jobs:
         command: fmt
         args: -- --check
 
+    - name: Install minimum supported Rust version
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.40.0
+
+    - name: Build with minimum supported Rust version
+      run: |
+        cargo +1.40.0 build --verbose
+
   build:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
There's no clippy check forcing new features now (fbdad17dc630bd2e0cf7975c879a6738e3949074), so the minimum supported Rust version is currently enforced by dependencies (`remove_dir_all-0.5.3`) and should be relatively stable.
Should it be checked on CI to avoid bumping the version requirements accidentally?