### PR TITLE
Add an option for converting usize/isize into size_t/ptrdiff_t

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -691,6 +691,10 @@ rename_args = "PascalCase"
 # default: "None"
 sort_by = "Name"
 
+# If this option is true `usize` and `isize` will be converted into `size_t` and `ptrdiff_t`
+# instead of `uintptr_t` and `intptr_t` respectively.
+usize_is_size_t = true
+
 [struct]
 # A rule to use to rename struct field names. The renaming assumes the input is
 # the Rust standard snake_case, however it acccepts all the different rename_args

--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -169,6 +169,10 @@ impl Bindings {
                 out.new_line();
                 out.write("#include <stdbool.h>");
                 out.new_line();
+                if self.config.usize_is_size_t {
+                    out.write("#include <stddef.h>");
+                    out.new_line();
+                }
                 out.write("#include <stdint.h>");
                 out.new_line();
                 out.write("#include <stdlib.h>");
@@ -176,6 +180,10 @@ impl Bindings {
             } else {
                 out.write("#include <cstdarg>");
                 out.new_line();
+                if self.config.usize_is_size_t {
+                    out.write("#include <cstddef>");
+                    out.new_line();
+                }
                 out.write("#include <cstdint>");
                 out.new_line();
                 out.write("#include <cstdlib>");

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -840,6 +840,9 @@ pub struct Config {
     pub style: Style,
     /// Default sort key for functions and constants.
     pub sort_by: SortKey,
+    /// If this option is true `usize` and `isize` will be converted into `size_t` and `ptrdiff_t`
+    /// instead of `uintptr_t` and `intptr_t` respectively.
+    pub usize_is_size_t: bool,
     /// The configuration options for parsing
     pub parse: ParseConfig,
     /// The configuration options for exporting
@@ -894,6 +897,7 @@ impl Default for Config {
             language: Language::Cxx,
             cpp_compat: false,
             style: Style::Type,
+            usize_is_size_t: false,
             sort_by: SortKey::None,
             macro_expansion: Default::default(),
             parse: ParseConfig::default(),

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -9,7 +9,7 @@ use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
     AnnotationSet, AnnotationValue, Cfg, ConditionWrite, Documentation, GenericParams, GenericPath,
-    Item, ItemContainer, Path, Repr, ReprStyle, ReprType, Struct, ToCondition, Type,
+    Item, ItemContainer, Path, Repr, ReprStyle, Struct, ToCondition, Type,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -595,18 +595,7 @@ impl Item for Enum {
 
 impl Source for Enum {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
-        let size = self.repr.ty.map(|ty| match ty {
-            ReprType::USize => "uintptr_t",
-            ReprType::U64 => "uint64_t",
-            ReprType::U32 => "uint32_t",
-            ReprType::U16 => "uint16_t",
-            ReprType::U8 => "uint8_t",
-            ReprType::ISize => "intptr_t",
-            ReprType::I64 => "int64_t",
-            ReprType::I32 => "int32_t",
-            ReprType::I16 => "int16_t",
-            ReprType::I8 => "int8_t",
-        });
+        let size = self.repr.ty.map(|ty| ty.to_primitive().to_repr_c(config));
 
         let condition = self.cfg.to_condition(config);
         condition.write_before(config, out);

--- a/src/bindgen/ir/repr.rs
+++ b/src/bindgen/ir/repr.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::bindgen::ir::ty::PrimitiveType;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ReprStyle {
     Rust,
@@ -27,6 +29,23 @@ pub enum ReprType {
     I32,
     I64,
     ISize,
+}
+
+impl ReprType {
+    pub(crate) fn to_primitive(self) -> PrimitiveType {
+        match self {
+            ReprType::U8 => PrimitiveType::UInt8,
+            ReprType::U16 => PrimitiveType::UInt16,
+            ReprType::U32 => PrimitiveType::UInt32,
+            ReprType::U64 => PrimitiveType::UInt64,
+            ReprType::USize => PrimitiveType::USize,
+            ReprType::I8 => PrimitiveType::Int8,
+            ReprType::I16 => PrimitiveType::Int16,
+            ReprType::I32 => PrimitiveType::Int32,
+            ReprType::I64 => PrimitiveType::Int64,
+            ReprType::ISize => PrimitiveType::ISize,
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::fmt;
 use std::io::Write;
 
 use crate::bindgen::cdecl;
@@ -123,7 +122,7 @@ impl PrimitiveType {
         }
     }
 
-    pub fn to_repr_c(&self) -> &'static str {
+    pub fn to_repr_c(&self, config: &Config) -> &'static str {
         match *self {
             PrimitiveType::Void => "void",
             PrimitiveType::Bool => "bool",
@@ -147,11 +146,13 @@ impl PrimitiveType {
             PrimitiveType::UInt => "unsigned int",
             PrimitiveType::ULong => "unsigned long",
             PrimitiveType::ULongLong => "unsigned long long",
+            PrimitiveType::USize if config.usize_is_size_t => "size_t",
             PrimitiveType::USize => "uintptr_t",
             PrimitiveType::UInt8 => "uint8_t",
             PrimitiveType::UInt16 => "uint16_t",
             PrimitiveType::UInt32 => "uint32_t",
             PrimitiveType::UInt64 => "uint64_t",
+            PrimitiveType::ISize if config.usize_is_size_t => "ptrdiff_t",
             PrimitiveType::ISize => "intptr_t",
             PrimitiveType::Int8 => "int8_t",
             PrimitiveType::Int16 => "int16_t",
@@ -175,12 +176,6 @@ impl PrimitiveType {
 
     fn can_cmp_eq(&self) -> bool {
         true
-    }
-}
-
-impl fmt::Display for PrimitiveType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_repr_c())
     }
 }
 

--- a/template.toml
+++ b/template.toml
@@ -44,6 +44,7 @@ line-endings = "LF" # also "CR", "CRLF", "Native"
 
 style = "both"
 sort_by = "Name" # default for `fn.sort_by` and `const.sort_by`
+usize_is_size_t = true
 
 
 

--- a/tests/expectations/size-types.c
+++ b/tests/expectations/size-types.c
@@ -1,0 +1,21 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum IE {
+  IV,
+};
+typedef ptrdiff_t IE;
+
+enum UE {
+  UV,
+};
+typedef size_t UE;
+
+typedef size_t Usize;
+
+typedef ptrdiff_t Isize;
+
+void root(Usize, Isize, UE, IE);

--- a/tests/expectations/size-types.compat.c
+++ b/tests/expectations/size-types.compat.c
@@ -1,0 +1,41 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum IE
+#ifdef __cplusplus
+  : ptrdiff_t
+#endif // __cplusplus
+ {
+  IV,
+};
+#ifndef __cplusplus
+typedef ptrdiff_t IE;
+#endif // __cplusplus
+
+enum UE
+#ifdef __cplusplus
+  : size_t
+#endif // __cplusplus
+ {
+  UV,
+};
+#ifndef __cplusplus
+typedef size_t UE;
+#endif // __cplusplus
+
+typedef size_t Usize;
+
+typedef ptrdiff_t Isize;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(Usize, Isize, UE, IE);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/size-types.cpp
+++ b/tests/expectations/size-types.cpp
@@ -1,0 +1,24 @@
+#include <cstdarg>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+enum class IE : ptrdiff_t {
+  IV,
+};
+
+enum class UE : size_t {
+  UV,
+};
+
+using Usize = size_t;
+
+using Isize = ptrdiff_t;
+
+extern "C" {
+
+void root(Usize, Isize, UE, IE);
+
+} // extern "C"

--- a/tests/rust/size-types.rs
+++ b/tests/rust/size-types.rs
@@ -1,0 +1,15 @@
+type Usize = usize;
+type Isize = isize;
+
+#[repr(usize)]
+enum UE {
+    UV,
+}
+
+#[repr(isize)]
+enum IE {
+    IV,
+}
+
+#[no_mangle]
+pub extern "C" fn root(_: Usize, _: Isize, _: UE, _: IE) {}

--- a/tests/rust/size-types.toml
+++ b/tests/rust/size-types.toml
@@ -1,0 +1,1 @@
+usize_is_size_t = true


### PR DESCRIPTION
This PR adds a new global option `usize_is_size_t` that mirrors `size_t_is_usize` in bindgen and allows to map `usize`/`isize` into the more traditional pair `size_t`/`ptrdiff_t` instead of `uintptr_t`/`intptr_t` into which they are converted currently.

(I'd personally want to see this as the default, similarly to https://github.com/rust-lang/rust-bindgen/pull/1902, but I didn't change any defaults in this PR.)

cc https://github.com/eqrion/cbindgen/issues/239