### PR TITLE
Use a getter for accessing `Config::cpp_compat`

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -452,6 +452,8 @@ no_includes = false
 # } // extern "C"
 # #endif // __cplusplus
 #
+# If the language is not C this option won't have any effect.
+#
 # default: false
 cpp_compat = false
 

--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -265,7 +265,7 @@ impl Bindings {
         }
 
         if !self.functions.is_empty() || !self.globals.is_empty() {
-            if self.config.language == Language::C && self.config.cpp_compat {
+            if self.config.cpp_compatible_c() {
                 out.new_line_if_not_start();
                 out.write("#ifdef __cplusplus");
             }
@@ -280,13 +280,13 @@ impl Bindings {
                 }
             }
 
-            if self.config.language == Language::Cxx || self.config.cpp_compat {
+            if self.config.language == Language::Cxx || self.config.cpp_compatible_c() {
                 out.new_line();
                 out.write("extern \"C\" {");
                 out.new_line();
             }
 
-            if self.config.language == Language::C && self.config.cpp_compat {
+            if self.config.cpp_compatible_c() {
                 out.write("#endif // __cplusplus");
                 out.new_line();
             }
@@ -303,18 +303,18 @@ impl Bindings {
                 out.new_line();
             }
 
-            if self.config.language == Language::C && self.config.cpp_compat {
+            if self.config.cpp_compatible_c() {
                 out.new_line();
                 out.write("#ifdef __cplusplus");
             }
 
-            if self.config.language == Language::Cxx || self.config.cpp_compat {
+            if self.config.language == Language::Cxx || self.config.cpp_compatible_c() {
                 out.new_line();
                 out.write("} // extern \"C\"");
                 out.new_line();
             }
 
-            if self.config.language == Language::C && self.config.cpp_compat {
+            if self.config.cpp_compatible_c() {
                 out.write("#endif // __cplusplus");
                 out.new_line();
             }
@@ -341,7 +341,7 @@ impl Bindings {
     }
 
     fn all_namespaces(&self) -> Vec<&str> {
-        if self.config.language != Language::Cxx && !self.config.cpp_compat {
+        if self.config.language != Language::Cxx && !self.config.cpp_compatible_c() {
             return vec![];
         }
         let mut ret = vec![];
@@ -366,8 +366,7 @@ impl Bindings {
             namespaces.reverse();
         }
 
-        let write_ifdefs = self.config.cpp_compat && self.config.language == Language::C;
-        if write_ifdefs {
+        if self.config.cpp_compatible_c() {
             out.new_line_if_not_start();
             out.write("#ifdef __cplusplus");
         }
@@ -381,7 +380,7 @@ impl Bindings {
         }
 
         out.new_line();
-        if write_ifdefs {
+        if self.config.cpp_compatible_c() {
             out.write("#endif // __cplusplus");
             out.new_line();
         }

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -941,6 +941,10 @@ impl Default for Config {
 }
 
 impl Config {
+    pub(crate) fn cpp_compatible_c(&self) -> bool {
+        self.language == Language::C && self.cpp_compat
+    }
+
     pub fn from_file<P: AsRef<StdPath>>(file_name: P) -> Result<Config, String> {
         let config_text = fs::read_to_string(file_name.as_ref()).map_err(|_| {
             format!(

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -646,7 +646,7 @@ impl Source for Enum {
                 write!(out, " {}", enum_name);
             }
 
-            if config.cpp_compat {
+            if config.cpp_compatible_c() {
                 if let Some(prim) = size {
                     out.new_line();
                     out.write("#ifdef __cplusplus");
@@ -692,7 +692,7 @@ impl Source for Enum {
 
         if config.language == Language::C {
             if let Some(prim) = size {
-                if config.cpp_compat {
+                if config.cpp_compatible_c() {
                     out.new_line_if_not_start();
                     out.write("#ifndef __cplusplus");
                 }
@@ -700,7 +700,7 @@ impl Source for Enum {
                 out.new_line();
                 write!(out, "typedef {} {};", prim, enum_name);
 
-                if config.cpp_compat {
+                if config.cpp_compatible_c() {
                     out.new_line_if_not_start();
                     out.write("#endif // __cplusplus");
                 }


### PR DESCRIPTION
Extracted from https://github.com/eqrion/cbindgen/pull/590.

Many config options only make sense when some other options have specific values (e.g. the language is C, or something like that) and should return "false" or "empty list" otherwise, as they were not set at all.
https://github.com/eqrion/cbindgen/pull/590 is going to introduce more such getters, but a getter from `cpp_compat` makes sense regardless of Cython.
`cpp_compat` should be considered `true` only if the current language is C, otherwise it should be considered effectively `false` even if set. This PR introduces a method `Config::cpp_compatible_c` to solve this problem.

I didn't rename the original field `cpp_compat` because it's a part of the public crate interface, but ideally it would be renamed to something like `cpp_compat_raw` to prevent direct reads from it.