### PR TITLE
Support wider range of expressions in enum discriminants

### DIFF
--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -287,7 +287,7 @@ impl Literal {
         }
     }
 
-    fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
+    pub(crate) fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         match self {
             Literal::Expr(v) => write!(out, "{}", v),
             Literal::Path(v) => write!(out, "{}", v),

--- a/tests/expectations/enum_discriminant.c
+++ b/tests/expectations/enum_discriminant.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define FOUR 4
+
+enum E {
+  A = 1,
+  B = -1,
+  C = (1 + 2),
+  D = FOUR,
+  F = 5,
+  G = (int8_t)'6',
+  H = (int8_t)false,
+};
+typedef int8_t E;
+
+void root(const E*);

--- a/tests/expectations/enum_discriminant.compat.c
+++ b/tests/expectations/enum_discriminant.compat.c
@@ -1,0 +1,33 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define FOUR 4
+
+enum E
+#ifdef __cplusplus
+  : int8_t
+#endif // __cplusplus
+ {
+  A = 1,
+  B = -1,
+  C = (1 + 2),
+  D = FOUR,
+  F = 5,
+  G = (int8_t)'6',
+  H = (int8_t)false,
+};
+#ifndef __cplusplus
+typedef int8_t E;
+#endif // __cplusplus
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(const E*);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/enum_discriminant.cpp
+++ b/tests/expectations/enum_discriminant.cpp
@@ -1,0 +1,23 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+static const int8_t FOUR = 4;
+
+enum class E : int8_t {
+  A = 1,
+  B = -1,
+  C = (1 + 2),
+  D = FOUR,
+  F = 5,
+  G = (int8_t)'6',
+  H = (int8_t)false,
+};
+
+extern "C" {
+
+void root(const E*);
+
+} // extern "C"

--- a/tests/rust/enum_discriminant.rs
+++ b/tests/rust/enum_discriminant.rs
@@ -1,0 +1,15 @@
+pub const FOUR: i8 = 4;
+
+#[repr(i8)]
+enum E {
+    A = 1,
+    B = -1,
+    C = 1 + 2,
+    D = FOUR,
+    F = (5),
+    G = '6' as i8,
+    H = false as i8,
+}
+
+#[no_mangle]
+pub extern "C" fn root(_: &E) {}


### PR DESCRIPTION
```rust
enum E {
    V = EXPR
}
```
now supports the same set of expressions as
```
const C: Type = EXPR;
```
with paths and binary operators probably being the most important case in practice
```
enum E {
    V = CONST,
    U = CONST + 1,
}
```