### PR TITLE
fix: resolve path types for 'both' style

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -202,6 +202,12 @@ impl Style {
     }
 }
 
+impl Default for Style {
+    fn default() -> Self {
+        Style::Both
+    }
+}
+
 impl FromStr for Style {
     type Err = String;
 
@@ -921,7 +927,7 @@ impl Default for Config {
             line_endings: LineEndingStyle::default(),
             language: Language::Cxx,
             cpp_compat: false,
-            style: Style::Type,
+            style: Style::default(),
             usize_is_size_t: false,
             sort_by: SortKey::None,
             macro_expansion: Default::default(),

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -308,7 +308,7 @@ impl Library {
     }
 
     fn resolve_declaration_types(&mut self) {
-        if self.config.style.generate_typedef() {
+        if !self.config.style.generate_tag() {
             return;
         }
 

--- a/tests/expectations/alias.both.c
+++ b/tests/expectations/alias.both.c
@@ -17,18 +17,18 @@ typedef struct Dep {
 typedef struct Foo_i32 {
   int32_t a;
   int32_t b;
-  Dep c;
+  struct Dep c;
 } Foo_i32;
 
-typedef Foo_i32 IntFoo;
+typedef struct Foo_i32 IntFoo;
 
 typedef struct Foo_f64 {
   double a;
   double b;
-  Dep c;
+  struct Dep c;
 } Foo_f64;
 
-typedef Foo_f64 DoubleFoo;
+typedef struct Foo_f64 DoubleFoo;
 
 typedef int32_t Unit;
 

--- a/tests/expectations/alias.both.compat.c
+++ b/tests/expectations/alias.both.compat.c
@@ -23,18 +23,18 @@ typedef struct Dep {
 typedef struct Foo_i32 {
   int32_t a;
   int32_t b;
-  Dep c;
+  struct Dep c;
 } Foo_i32;
 
-typedef Foo_i32 IntFoo;
+typedef struct Foo_i32 IntFoo;
 
 typedef struct Foo_f64 {
   double a;
   double b;
-  Dep c;
+  struct Dep c;
 } Foo_f64;
 
-typedef Foo_f64 DoubleFoo;
+typedef struct Foo_f64 DoubleFoo;
 
 typedef int32_t Unit;
 

--- a/tests/expectations/annotation.both.c
+++ b/tests/expectations/annotation.both.c
@@ -66,4 +66,4 @@ typedef struct H {
   };
 } H;
 
-void root(A x, B y, C z, F f, H h);
+void root(struct A x, struct B y, C z, union F f, struct H h);

--- a/tests/expectations/annotation.both.compat.c
+++ b/tests/expectations/annotation.both.compat.c
@@ -88,7 +88,7 @@ typedef struct H {
 extern "C" {
 #endif // __cplusplus
 
-void root(A x, B y, C z, F f, H h);
+void root(struct A x, struct B y, C z, union F f, struct H h);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/array.both.c
+++ b/tests/expectations/array.both.c
@@ -18,4 +18,4 @@ typedef struct Foo {
   };
 } Foo;
 
-void root(Foo a);
+void root(struct Foo a);

--- a/tests/expectations/array.both.compat.c
+++ b/tests/expectations/array.both.compat.c
@@ -22,7 +22,7 @@ typedef struct Foo {
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo a);
+void root(struct Foo a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/asserted_cast.both.c
+++ b/tests/expectations/asserted_cast.both.c
@@ -81,4 +81,4 @@ typedef union K {
   K_Bar_Body bar;
 } K;
 
-void foo(H h, I i, J j, K k);
+void foo(struct H h, struct I i, struct J j, union K k);

--- a/tests/expectations/asserted_cast.both.compat.c
+++ b/tests/expectations/asserted_cast.both.compat.c
@@ -103,7 +103,7 @@ typedef union K {
 extern "C" {
 #endif // __cplusplus
 
-void foo(H h, I i, J j, K k);
+void foo(struct H h, struct I i, struct J j, union K k);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/assoc_constant.both.c
+++ b/tests/expectations/assoc_constant.both.c
@@ -9,4 +9,4 @@ typedef struct Foo {
 #define Foo_GA 10
 #define Foo_ZO 3.14
 
-void root(Foo x);
+void root(struct Foo x);

--- a/tests/expectations/assoc_constant.both.compat.c
+++ b/tests/expectations/assoc_constant.both.compat.c
@@ -13,7 +13,7 @@ typedef struct Foo {
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo x);
+void root(struct Foo x);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/associated_in_body.both.c
+++ b/tests/expectations/associated_in_body.both.c
@@ -32,4 +32,4 @@ typedef struct StyleAlignFlags {
  */
 #define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
 
-void root(StyleAlignFlags flags);
+void root(struct StyleAlignFlags flags);

--- a/tests/expectations/associated_in_body.both.compat.c
+++ b/tests/expectations/associated_in_body.both.compat.c
@@ -36,7 +36,7 @@ typedef struct StyleAlignFlags {
 extern "C" {
 #endif // __cplusplus
 
-void root(StyleAlignFlags flags);
+void root(struct StyleAlignFlags flags);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/bitfield.both.c
+++ b/tests/expectations/bitfield.both.c
@@ -8,4 +8,4 @@ typedef struct HasBitfields {
   uint64_t bar: 56;
 } HasBitfields;
 
-void root(const HasBitfields*);
+void root(const struct HasBitfields*);

--- a/tests/expectations/bitfield.both.compat.c
+++ b/tests/expectations/bitfield.both.compat.c
@@ -12,7 +12,7 @@ typedef struct HasBitfields {
 extern "C" {
 #endif // __cplusplus
 
-void root(const HasBitfields*);
+void root(const struct HasBitfields*);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/bitflags.both.c
+++ b/tests/expectations/bitflags.both.c
@@ -40,4 +40,4 @@ typedef struct DebugFlags {
  */
 #define DebugFlags_BIGGEST_ALLOWED (DebugFlags){ .bits = (uint32_t)(1 << 31) }
 
-void root(AlignFlags flags, DebugFlags bigger_flags);
+void root(struct AlignFlags flags, struct DebugFlags bigger_flags);

--- a/tests/expectations/bitflags.both.compat.c
+++ b/tests/expectations/bitflags.both.compat.c
@@ -44,7 +44,7 @@ typedef struct DebugFlags {
 extern "C" {
 #endif // __cplusplus
 
-void root(AlignFlags flags, DebugFlags bigger_flags);
+void root(struct AlignFlags flags, struct DebugFlags bigger_flags);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/body.both.c
+++ b/tests/expectations/body.both.c
@@ -91,11 +91,11 @@ typedef union MyUnion_Prepended {
   uint32_t u;
 } MyUnion_Prepended;
 
-void root(MyFancyStruct s,
-          MyFancyEnum e,
-          MyCLikeEnum c,
-          MyUnion u,
-          MyFancyStruct_Prepended sp,
-          MyFancyEnum_Prepended ep,
-          MyCLikeEnum_Prepended cp,
-          MyUnion_Prepended up);
+void root(struct MyFancyStruct s,
+          struct MyFancyEnum e,
+          enum MyCLikeEnum c,
+          union MyUnion u,
+          struct MyFancyStruct_Prepended sp,
+          struct MyFancyEnum_Prepended ep,
+          enum MyCLikeEnum_Prepended cp,
+          union MyUnion_Prepended up);

--- a/tests/expectations/body.both.compat.c
+++ b/tests/expectations/body.both.compat.c
@@ -95,14 +95,14 @@ typedef union MyUnion_Prepended {
 extern "C" {
 #endif // __cplusplus
 
-void root(MyFancyStruct s,
-          MyFancyEnum e,
-          MyCLikeEnum c,
-          MyUnion u,
-          MyFancyStruct_Prepended sp,
-          MyFancyEnum_Prepended ep,
-          MyCLikeEnum_Prepended cp,
-          MyUnion_Prepended up);
+void root(struct MyFancyStruct s,
+          struct MyFancyEnum e,
+          enum MyCLikeEnum c,
+          union MyUnion u,
+          struct MyFancyStruct_Prepended sp,
+          struct MyFancyEnum_Prepended ep,
+          enum MyCLikeEnum_Prepended cp,
+          union MyUnion_Prepended up);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/box.both.c
+++ b/tests/expectations/box.both.c
@@ -11,13 +11,13 @@ using Box = T*;
 
 typedef struct NotReprC_Box_i32 NotReprC_Box_i32;
 
-typedef NotReprC_Box_i32 Foo;
+typedef struct NotReprC_Box_i32 Foo;
 
 typedef struct MyStruct {
   int32_t *number;
 } MyStruct;
 
-void root(const Foo *a, const MyStruct *with_box);
+void root(const Foo *a, const struct MyStruct *with_box);
 
 void drop_box(int32_t *x);
 

--- a/tests/expectations/box.both.compat.c
+++ b/tests/expectations/box.both.compat.c
@@ -11,7 +11,7 @@ using Box = T*;
 
 typedef struct NotReprC_Box_i32 NotReprC_Box_i32;
 
-typedef NotReprC_Box_i32 Foo;
+typedef struct NotReprC_Box_i32 Foo;
 
 typedef struct MyStruct {
   int32_t *number;
@@ -21,7 +21,7 @@ typedef struct MyStruct {
 extern "C" {
 #endif // __cplusplus
 
-void root(const Foo *a, const MyStruct *with_box);
+void root(const Foo *a, const struct MyStruct *with_box);
 
 void drop_box(int32_t *x);
 

--- a/tests/expectations/cell.both.c
+++ b/tests/expectations/cell.both.c
@@ -5,10 +5,10 @@
 
 typedef struct NotReprC_RefCell_i32 NotReprC_RefCell_i32;
 
-typedef NotReprC_RefCell_i32 Foo;
+typedef struct NotReprC_RefCell_i32 Foo;
 
 typedef struct MyStruct {
   int32_t number;
 } MyStruct;
 
-void root(const Foo *a, const MyStruct *with_cell);
+void root(const Foo *a, const struct MyStruct *with_cell);

--- a/tests/expectations/cell.both.compat.c
+++ b/tests/expectations/cell.both.compat.c
@@ -5,7 +5,7 @@
 
 typedef struct NotReprC_RefCell_i32 NotReprC_RefCell_i32;
 
-typedef NotReprC_RefCell_i32 Foo;
+typedef struct NotReprC_RefCell_i32 Foo;
 
 typedef struct MyStruct {
   int32_t number;
@@ -15,7 +15,7 @@ typedef struct MyStruct {
 extern "C" {
 #endif // __cplusplus
 
-void root(const Foo *a, const MyStruct *with_cell);
+void root(const Foo *a, const struct MyStruct *with_cell);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/cfg.both.c
+++ b/tests/expectations/cfg.both.c
@@ -64,9 +64,9 @@ typedef struct BarHandle {
 #endif
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
-void root(FooHandle a, C c);
+void root(struct FooHandle a, union C c);
 #endif
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
-void root(BarHandle a, C c);
+void root(struct BarHandle a, union C c);
 #endif

--- a/tests/expectations/cfg.both.compat.c
+++ b/tests/expectations/cfg.both.compat.c
@@ -86,11 +86,11 @@ extern "C" {
 #endif // __cplusplus
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
-void root(FooHandle a, C c);
+void root(struct FooHandle a, union C c);
 #endif
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
-void root(BarHandle a, C c);
+void root(struct BarHandle a, union C c);
 #endif
 
 #ifdef __cplusplus

--- a/tests/expectations/cfg_2.both.c
+++ b/tests/expectations/cfg_2.both.c
@@ -19,18 +19,18 @@ typedef struct Foo {
 
 #if defined(NOT_DEFINED)
 typedef struct Bar {
-  Foo y;
+  struct Foo y;
 } Bar;
 #endif
 
 #if defined(DEFINED)
 typedef struct Bar {
-  Foo z;
+  struct Foo z;
 } Bar;
 #endif
 
 typedef struct Root {
-  Bar w;
+  struct Bar w;
 } Root;
 
-void root(Root a);
+void root(struct Root a);

--- a/tests/expectations/cfg_2.both.compat.c
+++ b/tests/expectations/cfg_2.both.compat.c
@@ -19,25 +19,25 @@ typedef struct Foo {
 
 #if defined(NOT_DEFINED)
 typedef struct Bar {
-  Foo y;
+  struct Foo y;
 } Bar;
 #endif
 
 #if defined(DEFINED)
 typedef struct Bar {
-  Foo z;
+  struct Foo z;
 } Bar;
 #endif
 
 typedef struct Root {
-  Bar w;
+  struct Bar w;
 } Root;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(Root a);
+void root(struct Root a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/char.both.c
+++ b/tests/expectations/char.both.c
@@ -7,4 +7,4 @@ typedef struct Foo {
   uint32_t a;
 } Foo;
 
-void root(Foo a);
+void root(struct Foo a);

--- a/tests/expectations/char.both.compat.c
+++ b/tests/expectations/char.both.compat.c
@@ -11,7 +11,7 @@ typedef struct Foo {
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo a);
+void root(struct Foo a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/constant.both.c
+++ b/tests/expectations/constant.both.c
@@ -50,4 +50,4 @@ typedef struct Foo {
   int32_t x[FOO];
 } Foo;
 
-void root(Foo x);
+void root(struct Foo x);

--- a/tests/expectations/constant.both.compat.c
+++ b/tests/expectations/constant.both.compat.c
@@ -54,7 +54,7 @@ typedef struct Foo {
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo x);
+void root(struct Foo x);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/dep_v2.both.c
+++ b/tests/expectations/dep_v2.both.c
@@ -8,4 +8,4 @@ typedef struct dep_struct {
   double y;
 } dep_struct;
 
-uint32_t get_x(const dep_struct *dep_struct);
+uint32_t get_x(const struct dep_struct *dep_struct);

--- a/tests/expectations/dep_v2.both.compat.c
+++ b/tests/expectations/dep_v2.both.compat.c
@@ -12,7 +12,7 @@ typedef struct dep_struct {
 extern "C" {
 #endif // __cplusplus
 
-uint32_t get_x(const dep_struct *dep_struct);
+uint32_t get_x(const struct dep_struct *dep_struct);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/derive_eq.both.c
+++ b/tests/expectations/derive_eq.both.c
@@ -18,7 +18,7 @@ typedef uint8_t Bar_Tag;
 
 typedef struct Bazz_Body {
   Bar_Tag tag;
-  Foo named;
+  struct Foo named;
 } Bazz_Body;
 
 typedef struct FooNamed_Body {
@@ -30,7 +30,7 @@ typedef struct FooNamed_Body {
 typedef struct FooParen_Body {
   Bar_Tag tag;
   int32_t _0;
-  Foo _1;
+  struct Foo _1;
 } FooParen_Body;
 
 typedef union Bar {
@@ -40,4 +40,4 @@ typedef union Bar {
   FooParen_Body foo_paren;
 } Bar;
 
-Foo root(Bar aBar);
+struct Foo root(union Bar aBar);

--- a/tests/expectations/derive_eq.both.compat.c
+++ b/tests/expectations/derive_eq.both.compat.c
@@ -24,7 +24,7 @@ typedef uint8_t Bar_Tag;
 
 typedef struct Bazz_Body {
   Bar_Tag tag;
-  Foo named;
+  struct Foo named;
 } Bazz_Body;
 
 typedef struct FooNamed_Body {
@@ -36,7 +36,7 @@ typedef struct FooNamed_Body {
 typedef struct FooParen_Body {
   Bar_Tag tag;
   int32_t _0;
-  Foo _1;
+  struct Foo _1;
 } FooParen_Body;
 
 typedef union Bar {
@@ -50,7 +50,7 @@ typedef union Bar {
 extern "C" {
 #endif // __cplusplus
 
-Foo root(Bar aBar);
+struct Foo root(union Bar aBar);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/derive_ostream.both.c
+++ b/tests/expectations/derive_ostream.both.c
@@ -21,7 +21,7 @@ typedef struct B {
 typedef struct D {
   uint8_t List;
   uintptr_t Of;
-  B Things;
+  struct B Things;
 } D;
 
 enum F_Tag {
@@ -90,4 +90,4 @@ typedef struct I {
   };
 } I;
 
-void root(A a, B b, C c, D d, F f, H h, I i);
+void root(struct A a, struct B b, C c, struct D d, union F f, struct H h, struct I i);

--- a/tests/expectations/derive_ostream.both.compat.c
+++ b/tests/expectations/derive_ostream.both.compat.c
@@ -27,7 +27,7 @@ typedef struct B {
 typedef struct D {
   uint8_t List;
   uintptr_t Of;
-  B Things;
+  struct B Things;
 } D;
 
 enum F_Tag
@@ -118,7 +118,7 @@ typedef struct I {
 extern "C" {
 #endif // __cplusplus
 
-void root(A a, B b, C c, D d, F f, H h, I i);
+void root(struct A a, struct B b, C c, struct D d, union F f, struct H h, struct I i);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/destructor_and_copy_ctor.both.c
+++ b/tests/expectations/destructor_and_copy_ctor.both.c
@@ -24,7 +24,7 @@ typedef struct OwnedSlice_u32 {
 
 typedef struct Polygon_u32 {
   FillRule fill;
-  OwnedSlice_u32 coordinates;
+  struct OwnedSlice_u32 coordinates;
 } Polygon_u32;
 
 /**
@@ -47,25 +47,25 @@ enum Foo_u32_Tag {
 typedef uint8_t Foo_u32_Tag;
 
 typedef struct Polygon1_Body_u32 {
-  Polygon_u32 _0;
+  struct Polygon_u32 _0;
 } Polygon1_Body_u32;
 
 typedef struct Slice1_Body_u32 {
-  OwnedSlice_u32 _0;
+  struct OwnedSlice_u32 _0;
 } Slice1_Body_u32;
 
 typedef struct Slice2_Body_u32 {
-  OwnedSlice_i32 _0;
+  struct OwnedSlice_i32 _0;
 } Slice2_Body_u32;
 
 typedef struct Slice3_Body_u32 {
   FillRule fill;
-  OwnedSlice_u32 coords;
+  struct OwnedSlice_u32 coords;
 } Slice3_Body_u32;
 
 typedef struct Slice4_Body_u32 {
   FillRule fill;
-  OwnedSlice_i32 coords;
+  struct OwnedSlice_i32 coords;
 } Slice4_Body_u32;
 
 typedef struct Foo_u32 {
@@ -81,7 +81,7 @@ typedef struct Foo_u32 {
 
 typedef struct Polygon_i32 {
   FillRule fill;
-  OwnedSlice_i32 coordinates;
+  struct OwnedSlice_i32 coordinates;
 } Polygon_i32;
 
 enum Baz_i32_Tag {
@@ -96,29 +96,29 @@ typedef uint8_t Baz_i32_Tag;
 
 typedef struct Polygon21_Body_i32 {
   Baz_i32_Tag tag;
-  Polygon_i32 _0;
+  struct Polygon_i32 _0;
 } Polygon21_Body_i32;
 
 typedef struct Slice21_Body_i32 {
   Baz_i32_Tag tag;
-  OwnedSlice_i32 _0;
+  struct OwnedSlice_i32 _0;
 } Slice21_Body_i32;
 
 typedef struct Slice22_Body_i32 {
   Baz_i32_Tag tag;
-  OwnedSlice_i32 _0;
+  struct OwnedSlice_i32 _0;
 } Slice22_Body_i32;
 
 typedef struct Slice23_Body_i32 {
   Baz_i32_Tag tag;
   FillRule fill;
-  OwnedSlice_i32 coords;
+  struct OwnedSlice_i32 coords;
 } Slice23_Body_i32;
 
 typedef struct Slice24_Body_i32 {
   Baz_i32_Tag tag;
   FillRule fill;
-  OwnedSlice_i32 coords;
+  struct OwnedSlice_i32 coords;
 } Slice24_Body_i32;
 
 typedef union Baz_i32 {
@@ -144,7 +144,7 @@ typedef struct Taz1_Body {
 
 typedef struct Taz3_Body {
   Taz_Tag tag;
-  OwnedSlice_i32 _0;
+  struct OwnedSlice_i32 _0;
 } Taz3_Body;
 
 typedef union Taz {
@@ -229,10 +229,10 @@ typedef union Qux {
   Qux2_Body qux2;
 } Qux;
 
-void root(const Foo_u32 *a,
-          const Baz_i32 *b,
-          const Taz *c,
-          Tazz d,
-          const Tazzz *e,
-          const Tazzzz *f,
-          const Qux *g);
+void root(const struct Foo_u32 *a,
+          const union Baz_i32 *b,
+          const union Taz *c,
+          union Tazz d,
+          const union Tazzz *e,
+          const union Tazzzz *f,
+          const union Qux *g);

--- a/tests/expectations/destructor_and_copy_ctor.both.compat.c
+++ b/tests/expectations/destructor_and_copy_ctor.both.compat.c
@@ -30,7 +30,7 @@ typedef struct OwnedSlice_u32 {
 
 typedef struct Polygon_u32 {
   FillRule fill;
-  OwnedSlice_u32 coordinates;
+  struct OwnedSlice_u32 coordinates;
 } Polygon_u32;
 
 /**
@@ -59,25 +59,25 @@ typedef uint8_t Foo_u32_Tag;
 #endif // __cplusplus
 
 typedef struct Polygon1_Body_u32 {
-  Polygon_u32 _0;
+  struct Polygon_u32 _0;
 } Polygon1_Body_u32;
 
 typedef struct Slice1_Body_u32 {
-  OwnedSlice_u32 _0;
+  struct OwnedSlice_u32 _0;
 } Slice1_Body_u32;
 
 typedef struct Slice2_Body_u32 {
-  OwnedSlice_i32 _0;
+  struct OwnedSlice_i32 _0;
 } Slice2_Body_u32;
 
 typedef struct Slice3_Body_u32 {
   FillRule fill;
-  OwnedSlice_u32 coords;
+  struct OwnedSlice_u32 coords;
 } Slice3_Body_u32;
 
 typedef struct Slice4_Body_u32 {
   FillRule fill;
-  OwnedSlice_i32 coords;
+  struct OwnedSlice_i32 coords;
 } Slice4_Body_u32;
 
 typedef struct Foo_u32 {
@@ -93,7 +93,7 @@ typedef struct Foo_u32 {
 
 typedef struct Polygon_i32 {
   FillRule fill;
-  OwnedSlice_i32 coordinates;
+  struct OwnedSlice_i32 coordinates;
 } Polygon_i32;
 
 enum Baz_i32_Tag
@@ -114,29 +114,29 @@ typedef uint8_t Baz_i32_Tag;
 
 typedef struct Polygon21_Body_i32 {
   Baz_i32_Tag tag;
-  Polygon_i32 _0;
+  struct Polygon_i32 _0;
 } Polygon21_Body_i32;
 
 typedef struct Slice21_Body_i32 {
   Baz_i32_Tag tag;
-  OwnedSlice_i32 _0;
+  struct OwnedSlice_i32 _0;
 } Slice21_Body_i32;
 
 typedef struct Slice22_Body_i32 {
   Baz_i32_Tag tag;
-  OwnedSlice_i32 _0;
+  struct OwnedSlice_i32 _0;
 } Slice22_Body_i32;
 
 typedef struct Slice23_Body_i32 {
   Baz_i32_Tag tag;
   FillRule fill;
-  OwnedSlice_i32 coords;
+  struct OwnedSlice_i32 coords;
 } Slice23_Body_i32;
 
 typedef struct Slice24_Body_i32 {
   Baz_i32_Tag tag;
   FillRule fill;
-  OwnedSlice_i32 coords;
+  struct OwnedSlice_i32 coords;
 } Slice24_Body_i32;
 
 typedef union Baz_i32 {
@@ -168,7 +168,7 @@ typedef struct Taz1_Body {
 
 typedef struct Taz3_Body {
   Taz_Tag tag;
-  OwnedSlice_i32 _0;
+  struct OwnedSlice_i32 _0;
 } Taz3_Body;
 
 typedef union Taz {
@@ -281,13 +281,13 @@ typedef union Qux {
 extern "C" {
 #endif // __cplusplus
 
-void root(const Foo_u32 *a,
-          const Baz_i32 *b,
-          const Taz *c,
-          Tazz d,
-          const Tazzz *e,
-          const Tazzzz *f,
-          const Qux *g);
+void root(const struct Foo_u32 *a,
+          const union Baz_i32 *b,
+          const union Taz *c,
+          union Tazz d,
+          const union Tazzz *e,
+          const union Tazzzz *f,
+          const union Qux *g);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/display_list.both.c
+++ b/tests/expectations/display_list.both.c
@@ -26,14 +26,14 @@ typedef uint8_t DisplayItem_Tag;
 
 typedef struct Fill_Body {
   DisplayItem_Tag tag;
-  Rect _0;
-  Color _1;
+  struct Rect _0;
+  struct Color _1;
 } Fill_Body;
 
 typedef struct Image_Body {
   DisplayItem_Tag tag;
   uint32_t id;
-  Rect bounds;
+  struct Rect bounds;
 } Image_Body;
 
 typedef union DisplayItem {
@@ -42,4 +42,4 @@ typedef union DisplayItem {
   Image_Body image;
 } DisplayItem;
 
-bool push_item(DisplayItem item);
+bool push_item(union DisplayItem item);

--- a/tests/expectations/display_list.both.compat.c
+++ b/tests/expectations/display_list.both.compat.c
@@ -32,14 +32,14 @@ typedef uint8_t DisplayItem_Tag;
 
 typedef struct Fill_Body {
   DisplayItem_Tag tag;
-  Rect _0;
-  Color _1;
+  struct Rect _0;
+  struct Color _1;
 } Fill_Body;
 
 typedef struct Image_Body {
   DisplayItem_Tag tag;
   uint32_t id;
-  Rect bounds;
+  struct Rect bounds;
 } Image_Body;
 
 typedef union DisplayItem {
@@ -52,7 +52,7 @@ typedef union DisplayItem {
 extern "C" {
 #endif // __cplusplus
 
-bool push_item(DisplayItem item);
+bool push_item(union DisplayItem item);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/enum.both.c
+++ b/tests/expectations/enum.both.c
@@ -181,23 +181,23 @@ typedef struct P {
   };
 } P;
 
-void root(Opaque *opaque,
+void root(struct Opaque *opaque,
           A a,
           B b,
           C c,
           D d,
           E e,
           F f,
-          G g,
-          H h,
-          I i,
-          J j,
-          K k,
-          L l,
+          union G g,
+          struct H h,
+          struct I i,
+          struct J j,
+          struct K k,
+          enum L l,
           M m,
-          N n,
+          enum N n,
           O o,
-          P p);
+          struct P p);
 
 #include <stddef.h>
 #include "testing-helpers.h"

--- a/tests/expectations/enum.both.compat.c
+++ b/tests/expectations/enum.both.compat.c
@@ -251,23 +251,23 @@ typedef struct P {
 extern "C" {
 #endif // __cplusplus
 
-void root(Opaque *opaque,
+void root(struct Opaque *opaque,
           A a,
           B b,
           C c,
           D d,
           E e,
           F f,
-          G g,
-          H h,
-          I i,
-          J j,
-          K k,
-          L l,
+          union G g,
+          struct H h,
+          struct I i,
+          struct J j,
+          struct K k,
+          enum L l,
           M m,
-          N n,
+          enum N n,
           O o,
-          P p);
+          struct P p);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/enum_self.both.c
+++ b/tests/expectations/enum_self.both.c
@@ -16,12 +16,12 @@ typedef uint8_t Bar_Tag;
 
 typedef struct Min_Body {
   Bar_Tag tag;
-  Foo_Bar _0;
+  struct Foo_Bar _0;
 } Min_Body;
 
 typedef struct Max_Body {
   Bar_Tag tag;
-  Foo_Bar _0;
+  struct Foo_Bar _0;
 } Max_Body;
 
 typedef union Bar {
@@ -30,4 +30,4 @@ typedef union Bar {
   Max_Body max;
 } Bar;
 
-void root(Bar b);
+void root(union Bar b);

--- a/tests/expectations/enum_self.both.compat.c
+++ b/tests/expectations/enum_self.both.compat.c
@@ -22,12 +22,12 @@ typedef uint8_t Bar_Tag;
 
 typedef struct Min_Body {
   Bar_Tag tag;
-  Foo_Bar _0;
+  struct Foo_Bar _0;
 } Min_Body;
 
 typedef struct Max_Body {
   Bar_Tag tag;
-  Foo_Bar _0;
+  struct Foo_Bar _0;
 } Max_Body;
 
 typedef union Bar {
@@ -40,7 +40,7 @@ typedef union Bar {
 extern "C" {
 #endif // __cplusplus
 
-void root(Bar b);
+void root(union Bar b);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/euclid.both.c
+++ b/tests/expectations/euclid.both.c
@@ -11,9 +11,9 @@ typedef struct TypedLength_f32__LayoutUnit {
   float _0;
 } TypedLength_f32__LayoutUnit;
 
-typedef TypedLength_f32__UnknownUnit Length_f32;
+typedef struct TypedLength_f32__UnknownUnit Length_f32;
 
-typedef TypedLength_f32__LayoutUnit LayoutLength;
+typedef struct TypedLength_f32__LayoutUnit LayoutLength;
 
 typedef struct TypedSideOffsets2D_f32__UnknownUnit {
   float top;
@@ -29,9 +29,9 @@ typedef struct TypedSideOffsets2D_f32__LayoutUnit {
   float left;
 } TypedSideOffsets2D_f32__LayoutUnit;
 
-typedef TypedSideOffsets2D_f32__UnknownUnit SideOffsets2D_f32;
+typedef struct TypedSideOffsets2D_f32__UnknownUnit SideOffsets2D_f32;
 
-typedef TypedSideOffsets2D_f32__LayoutUnit LayoutSideOffsets2D;
+typedef struct TypedSideOffsets2D_f32__LayoutUnit LayoutSideOffsets2D;
 
 typedef struct TypedSize2D_f32__UnknownUnit {
   float width;
@@ -43,9 +43,9 @@ typedef struct TypedSize2D_f32__LayoutUnit {
   float height;
 } TypedSize2D_f32__LayoutUnit;
 
-typedef TypedSize2D_f32__UnknownUnit Size2D_f32;
+typedef struct TypedSize2D_f32__UnknownUnit Size2D_f32;
 
-typedef TypedSize2D_f32__LayoutUnit LayoutSize2D;
+typedef struct TypedSize2D_f32__LayoutUnit LayoutSize2D;
 
 typedef struct TypedPoint2D_f32__UnknownUnit {
   float x;
@@ -57,23 +57,23 @@ typedef struct TypedPoint2D_f32__LayoutUnit {
   float y;
 } TypedPoint2D_f32__LayoutUnit;
 
-typedef TypedPoint2D_f32__UnknownUnit Point2D_f32;
+typedef struct TypedPoint2D_f32__UnknownUnit Point2D_f32;
 
-typedef TypedPoint2D_f32__LayoutUnit LayoutPoint2D;
+typedef struct TypedPoint2D_f32__LayoutUnit LayoutPoint2D;
 
 typedef struct TypedRect_f32__UnknownUnit {
-  TypedPoint2D_f32__UnknownUnit origin;
-  TypedSize2D_f32__UnknownUnit size;
+  struct TypedPoint2D_f32__UnknownUnit origin;
+  struct TypedSize2D_f32__UnknownUnit size;
 } TypedRect_f32__UnknownUnit;
 
 typedef struct TypedRect_f32__LayoutUnit {
-  TypedPoint2D_f32__LayoutUnit origin;
-  TypedSize2D_f32__LayoutUnit size;
+  struct TypedPoint2D_f32__LayoutUnit origin;
+  struct TypedSize2D_f32__LayoutUnit size;
 } TypedRect_f32__LayoutUnit;
 
-typedef TypedRect_f32__UnknownUnit Rect_f32;
+typedef struct TypedRect_f32__UnknownUnit Rect_f32;
 
-typedef TypedRect_f32__LayoutUnit LayoutRect;
+typedef struct TypedRect_f32__LayoutUnit LayoutRect;
 
 typedef struct TypedTransform2D_f32__UnknownUnit__LayoutUnit {
   float m11;
@@ -93,25 +93,25 @@ typedef struct TypedTransform2D_f32__LayoutUnit__UnknownUnit {
   float m32;
 } TypedTransform2D_f32__LayoutUnit__UnknownUnit;
 
-void root(TypedLength_f32__UnknownUnit length_a,
-          TypedLength_f32__LayoutUnit length_b,
+void root(struct TypedLength_f32__UnknownUnit length_a,
+          struct TypedLength_f32__LayoutUnit length_b,
           Length_f32 length_c,
           LayoutLength length_d,
-          TypedSideOffsets2D_f32__UnknownUnit side_offsets_a,
-          TypedSideOffsets2D_f32__LayoutUnit side_offsets_b,
+          struct TypedSideOffsets2D_f32__UnknownUnit side_offsets_a,
+          struct TypedSideOffsets2D_f32__LayoutUnit side_offsets_b,
           SideOffsets2D_f32 side_offsets_c,
           LayoutSideOffsets2D side_offsets_d,
-          TypedSize2D_f32__UnknownUnit size_a,
-          TypedSize2D_f32__LayoutUnit size_b,
+          struct TypedSize2D_f32__UnknownUnit size_a,
+          struct TypedSize2D_f32__LayoutUnit size_b,
           Size2D_f32 size_c,
           LayoutSize2D size_d,
-          TypedPoint2D_f32__UnknownUnit point_a,
-          TypedPoint2D_f32__LayoutUnit point_b,
+          struct TypedPoint2D_f32__UnknownUnit point_a,
+          struct TypedPoint2D_f32__LayoutUnit point_b,
           Point2D_f32 point_c,
           LayoutPoint2D point_d,
-          TypedRect_f32__UnknownUnit rect_a,
-          TypedRect_f32__LayoutUnit rect_b,
+          struct TypedRect_f32__UnknownUnit rect_a,
+          struct TypedRect_f32__LayoutUnit rect_b,
           Rect_f32 rect_c,
           LayoutRect rect_d,
-          TypedTransform2D_f32__UnknownUnit__LayoutUnit transform_a,
-          TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);
+          struct TypedTransform2D_f32__UnknownUnit__LayoutUnit transform_a,
+          struct TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);

--- a/tests/expectations/euclid.both.compat.c
+++ b/tests/expectations/euclid.both.compat.c
@@ -11,9 +11,9 @@ typedef struct TypedLength_f32__LayoutUnit {
   float _0;
 } TypedLength_f32__LayoutUnit;
 
-typedef TypedLength_f32__UnknownUnit Length_f32;
+typedef struct TypedLength_f32__UnknownUnit Length_f32;
 
-typedef TypedLength_f32__LayoutUnit LayoutLength;
+typedef struct TypedLength_f32__LayoutUnit LayoutLength;
 
 typedef struct TypedSideOffsets2D_f32__UnknownUnit {
   float top;
@@ -29,9 +29,9 @@ typedef struct TypedSideOffsets2D_f32__LayoutUnit {
   float left;
 } TypedSideOffsets2D_f32__LayoutUnit;
 
-typedef TypedSideOffsets2D_f32__UnknownUnit SideOffsets2D_f32;
+typedef struct TypedSideOffsets2D_f32__UnknownUnit SideOffsets2D_f32;
 
-typedef TypedSideOffsets2D_f32__LayoutUnit LayoutSideOffsets2D;
+typedef struct TypedSideOffsets2D_f32__LayoutUnit LayoutSideOffsets2D;
 
 typedef struct TypedSize2D_f32__UnknownUnit {
   float width;
@@ -43,9 +43,9 @@ typedef struct TypedSize2D_f32__LayoutUnit {
   float height;
 } TypedSize2D_f32__LayoutUnit;
 
-typedef TypedSize2D_f32__UnknownUnit Size2D_f32;
+typedef struct TypedSize2D_f32__UnknownUnit Size2D_f32;
 
-typedef TypedSize2D_f32__LayoutUnit LayoutSize2D;
+typedef struct TypedSize2D_f32__LayoutUnit LayoutSize2D;
 
 typedef struct TypedPoint2D_f32__UnknownUnit {
   float x;
@@ -57,23 +57,23 @@ typedef struct TypedPoint2D_f32__LayoutUnit {
   float y;
 } TypedPoint2D_f32__LayoutUnit;
 
-typedef TypedPoint2D_f32__UnknownUnit Point2D_f32;
+typedef struct TypedPoint2D_f32__UnknownUnit Point2D_f32;
 
-typedef TypedPoint2D_f32__LayoutUnit LayoutPoint2D;
+typedef struct TypedPoint2D_f32__LayoutUnit LayoutPoint2D;
 
 typedef struct TypedRect_f32__UnknownUnit {
-  TypedPoint2D_f32__UnknownUnit origin;
-  TypedSize2D_f32__UnknownUnit size;
+  struct TypedPoint2D_f32__UnknownUnit origin;
+  struct TypedSize2D_f32__UnknownUnit size;
 } TypedRect_f32__UnknownUnit;
 
 typedef struct TypedRect_f32__LayoutUnit {
-  TypedPoint2D_f32__LayoutUnit origin;
-  TypedSize2D_f32__LayoutUnit size;
+  struct TypedPoint2D_f32__LayoutUnit origin;
+  struct TypedSize2D_f32__LayoutUnit size;
 } TypedRect_f32__LayoutUnit;
 
-typedef TypedRect_f32__UnknownUnit Rect_f32;
+typedef struct TypedRect_f32__UnknownUnit Rect_f32;
 
-typedef TypedRect_f32__LayoutUnit LayoutRect;
+typedef struct TypedRect_f32__LayoutUnit LayoutRect;
 
 typedef struct TypedTransform2D_f32__UnknownUnit__LayoutUnit {
   float m11;
@@ -97,28 +97,28 @@ typedef struct TypedTransform2D_f32__LayoutUnit__UnknownUnit {
 extern "C" {
 #endif // __cplusplus
 
-void root(TypedLength_f32__UnknownUnit length_a,
-          TypedLength_f32__LayoutUnit length_b,
+void root(struct TypedLength_f32__UnknownUnit length_a,
+          struct TypedLength_f32__LayoutUnit length_b,
           Length_f32 length_c,
           LayoutLength length_d,
-          TypedSideOffsets2D_f32__UnknownUnit side_offsets_a,
-          TypedSideOffsets2D_f32__LayoutUnit side_offsets_b,
+          struct TypedSideOffsets2D_f32__UnknownUnit side_offsets_a,
+          struct TypedSideOffsets2D_f32__LayoutUnit side_offsets_b,
           SideOffsets2D_f32 side_offsets_c,
           LayoutSideOffsets2D side_offsets_d,
-          TypedSize2D_f32__UnknownUnit size_a,
-          TypedSize2D_f32__LayoutUnit size_b,
+          struct TypedSize2D_f32__UnknownUnit size_a,
+          struct TypedSize2D_f32__LayoutUnit size_b,
           Size2D_f32 size_c,
           LayoutSize2D size_d,
-          TypedPoint2D_f32__UnknownUnit point_a,
-          TypedPoint2D_f32__LayoutUnit point_b,
+          struct TypedPoint2D_f32__UnknownUnit point_a,
+          struct TypedPoint2D_f32__LayoutUnit point_b,
           Point2D_f32 point_c,
           LayoutPoint2D point_d,
-          TypedRect_f32__UnknownUnit rect_a,
-          TypedRect_f32__LayoutUnit rect_b,
+          struct TypedRect_f32__UnknownUnit rect_a,
+          struct TypedRect_f32__LayoutUnit rect_b,
           Rect_f32 rect_c,
           LayoutRect rect_d,
-          TypedTransform2D_f32__UnknownUnit__LayoutUnit transform_a,
-          TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);
+          struct TypedTransform2D_f32__UnknownUnit__LayoutUnit transform_a,
+          struct TypedTransform2D_f32__LayoutUnit__UnknownUnit transform_b);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/exclude_generic_monomorph.both.c
+++ b/tests/expectations/exclude_generic_monomorph.both.c
@@ -12,4 +12,4 @@ typedef struct Bar {
   Option_Foo foo;
 } Bar;
 
-void root(Bar f);
+void root(struct Bar f);

--- a/tests/expectations/exclude_generic_monomorph.both.compat.c
+++ b/tests/expectations/exclude_generic_monomorph.both.compat.c
@@ -16,7 +16,7 @@ typedef struct Bar {
 extern "C" {
 #endif // __cplusplus
 
-void root(Bar f);
+void root(struct Bar f);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/exclude_generic_monomorph.cpp
+++ b/tests/expectations/exclude_generic_monomorph.cpp
@@ -8,7 +8,7 @@ typedef uint64_t Option_Foo;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct {
+typedef struct Bar {
   Option_Foo foo;
 } Bar;
 

--- a/tests/expectations/exclude_generic_monomorph.cpp
+++ b/tests/expectations/exclude_generic_monomorph.cpp
@@ -12,4 +12,4 @@ typedef struct Bar {
   Option_Foo foo;
 } Bar;
 
-void root(Bar f);
+void root(struct Bar f);

--- a/tests/expectations/expand.both.c
+++ b/tests/expectations/expand.both.c
@@ -7,4 +7,4 @@ typedef struct Foo {
 
 } Foo;
 
-void root(Foo a);
+void root(struct Foo a);

--- a/tests/expectations/expand.both.compat.c
+++ b/tests/expectations/expand.both.compat.c
@@ -11,7 +11,7 @@ typedef struct Foo {
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo a);
+void root(struct Foo a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/expand_default_features.both.c
+++ b/tests/expectations/expand_default_features.both.c
@@ -9,4 +9,4 @@ typedef struct Foo {
 
 void extra_debug_fn(void);
 
-void root(Foo a);
+void root(struct Foo a);

--- a/tests/expectations/expand_default_features.both.compat.c
+++ b/tests/expectations/expand_default_features.both.compat.c
@@ -13,7 +13,7 @@ extern "C" {
 
 void extra_debug_fn(void);
 
-void root(Foo a);
+void root(struct Foo a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/expand_dep.both.c
+++ b/tests/expectations/expand_dep.both.c
@@ -8,4 +8,4 @@ typedef struct dep_struct {
   double y;
 } dep_struct;
 
-uint32_t get_x(const dep_struct *dep_struct);
+uint32_t get_x(const struct dep_struct *dep_struct);

--- a/tests/expectations/expand_dep.both.compat.c
+++ b/tests/expectations/expand_dep.both.compat.c
@@ -12,7 +12,7 @@ typedef struct dep_struct {
 extern "C" {
 #endif // __cplusplus
 
-uint32_t get_x(const dep_struct *dep_struct);
+uint32_t get_x(const struct dep_struct *dep_struct);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/expand_dep_v2.both.c
+++ b/tests/expectations/expand_dep_v2.both.c
@@ -8,4 +8,4 @@ typedef struct dep_struct {
   double y;
 } dep_struct;
 
-uint32_t get_x(const dep_struct *dep_struct);
+uint32_t get_x(const struct dep_struct *dep_struct);

--- a/tests/expectations/expand_dep_v2.both.compat.c
+++ b/tests/expectations/expand_dep_v2.both.compat.c
@@ -12,7 +12,7 @@ typedef struct dep_struct {
 extern "C" {
 #endif // __cplusplus
 
-uint32_t get_x(const dep_struct *dep_struct);
+uint32_t get_x(const struct dep_struct *dep_struct);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/expand_features.both.c
+++ b/tests/expectations/expand_features.both.c
@@ -11,4 +11,4 @@ void extra_debug_fn(void);
 
 void cbindgen(void);
 
-void root(Foo a);
+void root(struct Foo a);

--- a/tests/expectations/expand_features.both.compat.c
+++ b/tests/expectations/expand_features.both.compat.c
@@ -15,7 +15,7 @@ void extra_debug_fn(void);
 
 void cbindgen(void);
 
-void root(Foo a);
+void root(struct Foo a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/expand_no_default_features.both.c
+++ b/tests/expectations/expand_no_default_features.both.c
@@ -7,4 +7,4 @@ typedef struct Foo {
 
 } Foo;
 
-void root(Foo a);
+void root(struct Foo a);

--- a/tests/expectations/expand_no_default_features.both.compat.c
+++ b/tests/expectations/expand_no_default_features.both.compat.c
@@ -11,7 +11,7 @@ typedef struct Foo {
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo a);
+void root(struct Foo a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/extern.both.c
+++ b/tests/expectations/extern.both.c
@@ -10,4 +10,4 @@ typedef struct Normal {
 
 extern int32_t foo(void);
 
-extern void bar(Normal a);
+extern void bar(struct Normal a);

--- a/tests/expectations/extern.both.compat.c
+++ b/tests/expectations/extern.both.compat.c
@@ -14,7 +14,7 @@ extern "C" {
 
 extern int32_t foo(void);
 
-extern void bar(Normal a);
+extern void bar(struct Normal a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/external_workspace_child.both.c
+++ b/tests/expectations/external_workspace_child.both.c
@@ -7,4 +7,4 @@ typedef struct ExtType {
   uint32_t data;
 } ExtType;
 
-void consume_ext(ExtType _ext);
+void consume_ext(struct ExtType _ext);

--- a/tests/expectations/external_workspace_child.both.compat.c
+++ b/tests/expectations/external_workspace_child.both.compat.c
@@ -11,7 +11,7 @@ typedef struct ExtType {
 extern "C" {
 #endif // __cplusplus
 
-void consume_ext(ExtType _ext);
+void consume_ext(struct ExtType _ext);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/fns.both.c
+++ b/tests/expectations/fns.both.c
@@ -11,6 +11,6 @@ typedef struct Fns {
   int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
 } Fns;
 
-void root(Fns _fns);
+void root(struct Fns _fns);
 
 void no_return(void);

--- a/tests/expectations/fns.both.compat.c
+++ b/tests/expectations/fns.both.compat.c
@@ -15,7 +15,7 @@ typedef struct Fns {
 extern "C" {
 #endif // __cplusplus
 
-void root(Fns _fns);
+void root(struct Fns _fns);
 
 void no_return(void);
 

--- a/tests/expectations/forward_declaration.both.c
+++ b/tests/expectations/forward_declaration.both.c
@@ -1,0 +1,40 @@
+#if defined(CBINDGEN_STYLE_TYPE)
+/* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct StructInfo {
+  const struct TypeInfo *const *fields;
+  uintptr_t num_fields;
+} StructInfo;
+
+typedef enum TypeData_Tag {
+  Primitive,
+  Struct,
+} TypeData_Tag;
+
+typedef struct Struct_Body {
+  struct StructInfo _0;
+} Struct_Body;
+
+typedef struct TypeData {
+  TypeData_Tag tag;
+  union {
+    Struct_Body struct_;
+  };
+} TypeData;
+
+typedef struct TypeInfo {
+  struct TypeData data;
+} TypeInfo;
+
+void root(struct TypeInfo x);
+
+#if defined(CBINDGEN_STYLE_TYPE)
+*/
+#endif

--- a/tests/expectations/forward_declaration.both.compat.c
+++ b/tests/expectations/forward_declaration.both.compat.c
@@ -1,0 +1,48 @@
+#if defined(CBINDGEN_STYLE_TYPE)
+/* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct StructInfo {
+  const struct TypeInfo *const *fields;
+  uintptr_t num_fields;
+} StructInfo;
+
+typedef enum TypeData_Tag {
+  Primitive,
+  Struct,
+} TypeData_Tag;
+
+typedef struct Struct_Body {
+  struct StructInfo _0;
+} Struct_Body;
+
+typedef struct TypeData {
+  TypeData_Tag tag;
+  union {
+    Struct_Body struct_;
+  };
+} TypeData;
+
+typedef struct TypeInfo {
+  struct TypeData data;
+} TypeInfo;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(struct TypeInfo x);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#if defined(CBINDGEN_STYLE_TYPE)
+*/
+#endif

--- a/tests/expectations/forward_declaration.c
+++ b/tests/expectations/forward_declaration.c
@@ -1,0 +1,40 @@
+#if defined(CBINDGEN_STYLE_TYPE)
+/* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  const TypeInfo *const *fields;
+  uintptr_t num_fields;
+} StructInfo;
+
+typedef enum {
+  Primitive,
+  Struct,
+} TypeData_Tag;
+
+typedef struct {
+  StructInfo _0;
+} Struct_Body;
+
+typedef struct {
+  TypeData_Tag tag;
+  union {
+    Struct_Body struct_;
+  };
+} TypeData;
+
+typedef struct {
+  TypeData data;
+} TypeInfo;
+
+void root(TypeInfo x);
+
+#if defined(CBINDGEN_STYLE_TYPE)
+*/
+#endif

--- a/tests/expectations/forward_declaration.compat.c
+++ b/tests/expectations/forward_declaration.compat.c
@@ -1,0 +1,48 @@
+#if defined(CBINDGEN_STYLE_TYPE)
+/* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  const TypeInfo *const *fields;
+  uintptr_t num_fields;
+} StructInfo;
+
+typedef enum {
+  Primitive,
+  Struct,
+} TypeData_Tag;
+
+typedef struct {
+  StructInfo _0;
+} Struct_Body;
+
+typedef struct {
+  TypeData_Tag tag;
+  union {
+    Struct_Body struct_;
+  };
+} TypeData;
+
+typedef struct {
+  TypeData data;
+} TypeInfo;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(TypeInfo x);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#if defined(CBINDGEN_STYLE_TYPE)
+*/
+#endif

--- a/tests/expectations/forward_declaration.cpp
+++ b/tests/expectations/forward_declaration.cpp
@@ -1,0 +1,45 @@
+#if defined(CBINDGEN_STYLE_TYPE)
+/* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
+#endif
+
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+struct StructInfo {
+  const TypeInfo *const *fields;
+  uintptr_t num_fields;
+};
+
+struct TypeData {
+  enum class Tag {
+    Primitive,
+    Struct,
+  };
+
+  struct Struct_Body {
+    StructInfo _0;
+  };
+
+  Tag tag;
+  union {
+    Struct_Body struct_;
+  };
+};
+
+struct TypeInfo {
+  TypeData data;
+};
+
+extern "C" {
+
+void root(TypeInfo x);
+
+} // extern "C"
+
+#if defined(CBINDGEN_STYLE_TYPE)
+*/
+#endif

--- a/tests/expectations/forward_declaration.tag.c
+++ b/tests/expectations/forward_declaration.tag.c
@@ -1,0 +1,40 @@
+#if defined(CBINDGEN_STYLE_TYPE)
+/* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct StructInfo {
+  const struct TypeInfo *const *fields;
+  uintptr_t num_fields;
+};
+
+enum TypeData_Tag {
+  Primitive,
+  Struct,
+};
+
+struct Struct_Body {
+  struct StructInfo _0;
+};
+
+struct TypeData {
+  enum TypeData_Tag tag;
+  union {
+    struct Struct_Body struct_;
+  };
+};
+
+struct TypeInfo {
+  struct TypeData data;
+};
+
+void root(struct TypeInfo x);
+
+#if defined(CBINDGEN_STYLE_TYPE)
+*/
+#endif

--- a/tests/expectations/forward_declaration.tag.compat.c
+++ b/tests/expectations/forward_declaration.tag.compat.c
@@ -1,0 +1,48 @@
+#if defined(CBINDGEN_STYLE_TYPE)
+/* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct StructInfo {
+  const struct TypeInfo *const *fields;
+  uintptr_t num_fields;
+};
+
+enum TypeData_Tag {
+  Primitive,
+  Struct,
+};
+
+struct Struct_Body {
+  struct StructInfo _0;
+};
+
+struct TypeData {
+  enum TypeData_Tag tag;
+  union {
+    struct Struct_Body struct_;
+  };
+};
+
+struct TypeInfo {
+  struct TypeData data;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(struct TypeInfo x);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#if defined(CBINDGEN_STYLE_TYPE)
+*/
+#endif

--- a/tests/expectations/generic_pointer.both.c
+++ b/tests/expectations/generic_pointer.both.c
@@ -7,6 +7,6 @@ typedef struct Foo_____u8 {
   uint8_t *a;
 } Foo_____u8;
 
-typedef Foo_____u8 Boo;
+typedef struct Foo_____u8 Boo;
 
 void root(Boo x);

--- a/tests/expectations/generic_pointer.both.compat.c
+++ b/tests/expectations/generic_pointer.both.compat.c
@@ -7,7 +7,7 @@ typedef struct Foo_____u8 {
   uint8_t *a;
 } Foo_____u8;
 
-typedef Foo_____u8 Boo;
+typedef struct Foo_____u8 Boo;
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/include_item.both.compat.c
+++ b/tests/expectations/include_item.both.compat.c
@@ -9,5 +9,5 @@ typedef struct A {
 } A;
 
 typedef struct B {
-  A data;
+  struct A data;
 } B;

--- a/tests/expectations/inner_mod.both.c
+++ b/tests/expectations/inner_mod.both.c
@@ -7,4 +7,4 @@ typedef struct Foo {
   float x;
 } Foo;
 
-void root(Foo a);
+void root(struct Foo a);

--- a/tests/expectations/inner_mod.both.compat.c
+++ b/tests/expectations/inner_mod.both.compat.c
@@ -11,7 +11,7 @@ typedef struct Foo {
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo a);
+void root(struct Foo a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/lifetime_arg.both.c
+++ b/tests/expectations/lifetime_arg.both.c
@@ -23,4 +23,4 @@ typedef struct E {
   };
 } E;
 
-void root(A _a, E _e);
+void root(struct A _a, struct E _e);

--- a/tests/expectations/lifetime_arg.both.compat.c
+++ b/tests/expectations/lifetime_arg.both.compat.c
@@ -27,7 +27,7 @@ typedef struct E {
 extern "C" {
 #endif // __cplusplus
 
-void root(A _a, E _e);
+void root(struct A _a, struct E _e);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/linestyle_cr.both.c
+++ b/tests/expectations/linestyle_cr.both.c
@@ -1,1 +1,1 @@
-#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>typedef struct Dummy {  int32_t x;  float y;} Dummy;void root(Dummy d);
+#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>typedef struct Dummy {  int32_t x;  float y;} Dummy;void root(struct Dummy d);

--- a/tests/expectations/linestyle_cr.both.compat.c
+++ b/tests/expectations/linestyle_cr.both.compat.c
@@ -1,1 +1,1 @@
-#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>typedef struct Dummy {  int32_t x;  float y;} Dummy;#ifdef __cplusplusextern "C" {#endif // __cplusplusvoid root(Dummy d);#ifdef __cplusplus} // extern "C"#endif // __cplusplus
+#include <stdarg.h>#include <stdbool.h>#include <stdint.h>#include <stdlib.h>typedef struct Dummy {  int32_t x;  float y;} Dummy;#ifdef __cplusplusextern "C" {#endif // __cplusplusvoid root(struct Dummy d);#ifdef __cplusplus} // extern "C"#endif // __cplusplus

--- a/tests/expectations/linestyle_crlf.both.c
+++ b/tests/expectations/linestyle_crlf.both.c
@@ -8,4 +8,4 @@ typedef struct Dummy {
   float y;
 } Dummy;
 
-void root(Dummy d);
+void root(struct Dummy d);

--- a/tests/expectations/linestyle_crlf.both.compat.c
+++ b/tests/expectations/linestyle_crlf.both.compat.c
@@ -12,7 +12,7 @@ typedef struct Dummy {
 extern "C" {
 #endif // __cplusplus
 
-void root(Dummy d);
+void root(struct Dummy d);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/linestyle_lf.both.c
+++ b/tests/expectations/linestyle_lf.both.c
@@ -8,4 +8,4 @@ typedef struct Dummy {
   float y;
 } Dummy;
 
-void root(Dummy d);
+void root(struct Dummy d);

--- a/tests/expectations/linestyle_lf.both.compat.c
+++ b/tests/expectations/linestyle_lf.both.compat.c
@@ -12,7 +12,7 @@ typedef struct Dummy {
 extern "C" {
 #endif // __cplusplus
 
-void root(Dummy d);
+void root(struct Dummy d);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/mangle.both.c
+++ b/tests/expectations/mangle.both.c
@@ -7,6 +7,6 @@ typedef struct FooU8 {
   uint8_t a;
 } FooU8;
 
-typedef FooU8 Boo;
+typedef struct FooU8 Boo;
 
 void root(Boo x);

--- a/tests/expectations/mangle.both.compat.c
+++ b/tests/expectations/mangle.both.compat.c
@@ -7,7 +7,7 @@ typedef struct FooU8 {
   uint8_t a;
 } FooU8;
 
-typedef FooU8 Boo;
+typedef struct FooU8 Boo;
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/manuallydrop.both.c
+++ b/tests/expectations/manuallydrop.both.c
@@ -11,7 +11,7 @@ using ManuallyDrop = T;
 
 typedef struct NotReprC_ManuallyDrop_Point NotReprC_ManuallyDrop_Point;
 
-typedef NotReprC_ManuallyDrop_Point Foo;
+typedef struct NotReprC_ManuallyDrop_Point Foo;
 
 typedef struct Point {
   int32_t x;
@@ -19,9 +19,9 @@ typedef struct Point {
 } Point;
 
 typedef struct MyStruct {
-  Point point;
+  struct Point point;
 } MyStruct;
 
-void root(const Foo *a, const MyStruct *with_manual_drop);
+void root(const Foo *a, const struct MyStruct *with_manual_drop);
 
-void take(Point with_manual_drop);
+void take(struct Point with_manual_drop);

--- a/tests/expectations/manuallydrop.both.compat.c
+++ b/tests/expectations/manuallydrop.both.compat.c
@@ -11,7 +11,7 @@ using ManuallyDrop = T;
 
 typedef struct NotReprC_ManuallyDrop_Point NotReprC_ManuallyDrop_Point;
 
-typedef NotReprC_ManuallyDrop_Point Foo;
+typedef struct NotReprC_ManuallyDrop_Point Foo;
 
 typedef struct Point {
   int32_t x;
@@ -19,16 +19,16 @@ typedef struct Point {
 } Point;
 
 typedef struct MyStruct {
-  Point point;
+  struct Point point;
 } MyStruct;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(const Foo *a, const MyStruct *with_manual_drop);
+void root(const Foo *a, const struct MyStruct *with_manual_drop);
 
-void take(Point with_manual_drop);
+void take(struct Point with_manual_drop);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/maybeuninit.both.c
+++ b/tests/expectations/maybeuninit.both.c
@@ -11,10 +11,10 @@ using MaybeUninit = T;
 
 typedef struct NotReprC_MaybeUninit______i32 NotReprC_MaybeUninit______i32;
 
-typedef NotReprC_MaybeUninit______i32 Foo;
+typedef struct NotReprC_MaybeUninit______i32 Foo;
 
 typedef struct MyStruct {
   const int32_t *number;
 } MyStruct;
 
-void root(const Foo *a, const MyStruct *with_maybe_uninit);
+void root(const Foo *a, const struct MyStruct *with_maybe_uninit);

--- a/tests/expectations/maybeuninit.both.compat.c
+++ b/tests/expectations/maybeuninit.both.compat.c
@@ -11,7 +11,7 @@ using MaybeUninit = T;
 
 typedef struct NotReprC_MaybeUninit______i32 NotReprC_MaybeUninit______i32;
 
-typedef NotReprC_MaybeUninit______i32 Foo;
+typedef struct NotReprC_MaybeUninit______i32 Foo;
 
 typedef struct MyStruct {
   const int32_t *number;
@@ -21,7 +21,7 @@ typedef struct MyStruct {
 extern "C" {
 #endif // __cplusplus
 
-void root(const Foo *a, const MyStruct *with_maybe_uninit);
+void root(const Foo *a, const struct MyStruct *with_maybe_uninit);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/mod_2015.both.c
+++ b/tests/expectations/mod_2015.both.c
@@ -9,4 +9,4 @@ typedef struct ExportMe {
   uint64_t val;
 } ExportMe;
 
-void export_me(ExportMe *val);
+void export_me(struct ExportMe *val);

--- a/tests/expectations/mod_2015.both.compat.c
+++ b/tests/expectations/mod_2015.both.compat.c
@@ -13,7 +13,7 @@ typedef struct ExportMe {
 extern "C" {
 #endif // __cplusplus
 
-void export_me(ExportMe *val);
+void export_me(struct ExportMe *val);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/mod_2018.both.c
+++ b/tests/expectations/mod_2018.both.c
@@ -9,4 +9,4 @@ typedef struct ExportMe {
   uint64_t val;
 } ExportMe;
 
-void export_me(ExportMe *val);
+void export_me(struct ExportMe *val);

--- a/tests/expectations/mod_2018.both.compat.c
+++ b/tests/expectations/mod_2018.both.compat.c
@@ -13,7 +13,7 @@ typedef struct ExportMe {
 extern "C" {
 #endif // __cplusplus
 
-void export_me(ExportMe *val);
+void export_me(struct ExportMe *val);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/mod_attr.both.c
+++ b/tests/expectations/mod_attr.both.c
@@ -24,9 +24,9 @@ typedef struct Bar {
 #endif
 
 #if defined(FOO)
-void foo(const Foo *foo);
+void foo(const struct Foo *foo);
 #endif
 
 #if defined(BAR)
-void bar(const Bar *bar);
+void bar(const struct Bar *bar);
 #endif

--- a/tests/expectations/mod_attr.both.compat.c
+++ b/tests/expectations/mod_attr.both.compat.c
@@ -28,11 +28,11 @@ extern "C" {
 #endif // __cplusplus
 
 #if defined(FOO)
-void foo(const Foo *foo);
+void foo(const struct Foo *foo);
 #endif
 
 #if defined(BAR)
-void bar(const Bar *bar);
+void bar(const struct Bar *bar);
 #endif
 
 #ifdef __cplusplus

--- a/tests/expectations/mod_path.both.c
+++ b/tests/expectations/mod_path.both.c
@@ -9,4 +9,4 @@ typedef struct ExportMe {
   uint64_t val;
 } ExportMe;
 
-void export_me(ExportMe *val);
+void export_me(struct ExportMe *val);

--- a/tests/expectations/mod_path.both.compat.c
+++ b/tests/expectations/mod_path.both.compat.c
@@ -13,7 +13,7 @@ typedef struct ExportMe {
 extern "C" {
 #endif // __cplusplus
 
-void export_me(ExportMe *val);
+void export_me(struct ExportMe *val);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/monomorph_1.both.c
+++ b/tests/expectations/monomorph_1.both.c
@@ -18,11 +18,11 @@ typedef struct Foo_f32 {
 } Foo_f32;
 
 typedef struct Foo_Bar_f32 {
-  const Bar_f32 *data;
+  const struct Bar_f32 *data;
 } Foo_Bar_f32;
 
 typedef struct Tuple_Foo_f32_____f32 {
-  const Foo_f32 *a;
+  const struct Foo_f32 *a;
   const float *b;
 } Tuple_Foo_f32_____f32;
 
@@ -31,13 +31,13 @@ typedef struct Tuple_f32__f32 {
   const float *b;
 } Tuple_f32__f32;
 
-typedef Tuple_f32__f32 Indirection_f32;
+typedef struct Tuple_f32__f32 Indirection_f32;
 
-void root(Foo_i32 a,
-          Foo_f32 b,
-          Bar_f32 c,
-          Foo_Bar_f32 d,
-          Bar_Foo_f32 e,
-          Bar_Bar_f32 f,
-          Tuple_Foo_f32_____f32 g,
+void root(struct Foo_i32 a,
+          struct Foo_f32 b,
+          struct Bar_f32 c,
+          struct Foo_Bar_f32 d,
+          struct Bar_Foo_f32 e,
+          struct Bar_Bar_f32 f,
+          struct Tuple_Foo_f32_____f32 g,
           Indirection_f32 h);

--- a/tests/expectations/monomorph_1.both.compat.c
+++ b/tests/expectations/monomorph_1.both.compat.c
@@ -18,11 +18,11 @@ typedef struct Foo_f32 {
 } Foo_f32;
 
 typedef struct Foo_Bar_f32 {
-  const Bar_f32 *data;
+  const struct Bar_f32 *data;
 } Foo_Bar_f32;
 
 typedef struct Tuple_Foo_f32_____f32 {
-  const Foo_f32 *a;
+  const struct Foo_f32 *a;
   const float *b;
 } Tuple_Foo_f32_____f32;
 
@@ -31,19 +31,19 @@ typedef struct Tuple_f32__f32 {
   const float *b;
 } Tuple_f32__f32;
 
-typedef Tuple_f32__f32 Indirection_f32;
+typedef struct Tuple_f32__f32 Indirection_f32;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo_i32 a,
-          Foo_f32 b,
-          Bar_f32 c,
-          Foo_Bar_f32 d,
-          Bar_Foo_f32 e,
-          Bar_Bar_f32 f,
-          Tuple_Foo_f32_____f32 g,
+void root(struct Foo_i32 a,
+          struct Foo_f32 b,
+          struct Bar_f32 c,
+          struct Foo_Bar_f32 d,
+          struct Bar_Foo_f32 e,
+          struct Bar_Bar_f32 f,
+          struct Tuple_Foo_f32_____f32 g,
           Indirection_f32 h);
 
 #ifdef __cplusplus

--- a/tests/expectations/monomorph_2.both.c
+++ b/tests/expectations/monomorph_2.both.c
@@ -8,15 +8,15 @@ typedef struct A A;
 typedef struct B B;
 
 typedef struct List_A {
-  A *members;
+  struct A *members;
   uintptr_t count;
 } List_A;
 
 typedef struct List_B {
-  B *members;
+  struct B *members;
   uintptr_t count;
 } List_B;
 
-void foo(List_A a);
+void foo(struct List_A a);
 
-void bar(List_B b);
+void bar(struct List_B b);

--- a/tests/expectations/monomorph_2.both.compat.c
+++ b/tests/expectations/monomorph_2.both.compat.c
@@ -8,12 +8,12 @@ typedef struct A A;
 typedef struct B B;
 
 typedef struct List_A {
-  A *members;
+  struct A *members;
   uintptr_t count;
 } List_A;
 
 typedef struct List_B {
-  B *members;
+  struct B *members;
   uintptr_t count;
 } List_B;
 
@@ -21,9 +21,9 @@ typedef struct List_B {
 extern "C" {
 #endif // __cplusplus
 
-void foo(List_A a);
+void foo(struct List_A a);
 
-void bar(List_B b);
+void bar(struct List_B b);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/monomorph_3.both.c
+++ b/tests/expectations/monomorph_3.both.c
@@ -18,11 +18,11 @@ typedef union Foo_f32 {
 } Foo_f32;
 
 typedef union Foo_Bar_f32 {
-  const Bar_f32 *data;
+  const struct Bar_f32 *data;
 } Foo_Bar_f32;
 
 typedef union Tuple_Foo_f32_____f32 {
-  const Foo_f32 *a;
+  const union Foo_f32 *a;
   const float *b;
 } Tuple_Foo_f32_____f32;
 
@@ -31,13 +31,13 @@ typedef union Tuple_f32__f32 {
   const float *b;
 } Tuple_f32__f32;
 
-typedef Tuple_f32__f32 Indirection_f32;
+typedef union Tuple_f32__f32 Indirection_f32;
 
-void root(Foo_i32 a,
-          Foo_f32 b,
-          Bar_f32 c,
-          Foo_Bar_f32 d,
-          Bar_Foo_f32 e,
-          Bar_Bar_f32 f,
-          Tuple_Foo_f32_____f32 g,
+void root(union Foo_i32 a,
+          union Foo_f32 b,
+          struct Bar_f32 c,
+          union Foo_Bar_f32 d,
+          struct Bar_Foo_f32 e,
+          struct Bar_Bar_f32 f,
+          union Tuple_Foo_f32_____f32 g,
           Indirection_f32 h);

--- a/tests/expectations/monomorph_3.both.compat.c
+++ b/tests/expectations/monomorph_3.both.compat.c
@@ -18,11 +18,11 @@ typedef union Foo_f32 {
 } Foo_f32;
 
 typedef union Foo_Bar_f32 {
-  const Bar_f32 *data;
+  const struct Bar_f32 *data;
 } Foo_Bar_f32;
 
 typedef union Tuple_Foo_f32_____f32 {
-  const Foo_f32 *a;
+  const union Foo_f32 *a;
   const float *b;
 } Tuple_Foo_f32_____f32;
 
@@ -31,19 +31,19 @@ typedef union Tuple_f32__f32 {
   const float *b;
 } Tuple_f32__f32;
 
-typedef Tuple_f32__f32 Indirection_f32;
+typedef union Tuple_f32__f32 Indirection_f32;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo_i32 a,
-          Foo_f32 b,
-          Bar_f32 c,
-          Foo_Bar_f32 d,
-          Bar_Foo_f32 e,
-          Bar_Bar_f32 f,
-          Tuple_Foo_f32_____f32 g,
+void root(union Foo_i32 a,
+          union Foo_f32 b,
+          struct Bar_f32 c,
+          union Foo_Bar_f32 d,
+          struct Bar_Foo_f32 e,
+          struct Bar_Bar_f32 f,
+          union Tuple_Foo_f32_____f32 g,
           Indirection_f32 h);
 
 #ifdef __cplusplus

--- a/tests/expectations/must_use.both.c
+++ b/tests/expectations/must_use.both.c
@@ -29,4 +29,4 @@ typedef struct MUST_USE_STRUCT OwnedPtr_i32 {
   int32_t *ptr;
 } OwnedPtr_i32;
 
-MUST_USE_FUNC MaybeOwnedPtr_i32 maybe_consume(OwnedPtr_i32 input);
+MUST_USE_FUNC struct MaybeOwnedPtr_i32 maybe_consume(struct OwnedPtr_i32 input);

--- a/tests/expectations/must_use.both.compat.c
+++ b/tests/expectations/must_use.both.compat.c
@@ -39,7 +39,7 @@ typedef struct MUST_USE_STRUCT OwnedPtr_i32 {
 extern "C" {
 #endif // __cplusplus
 
-MUST_USE_FUNC MaybeOwnedPtr_i32 maybe_consume(OwnedPtr_i32 input);
+MUST_USE_FUNC struct MaybeOwnedPtr_i32 maybe_consume(struct OwnedPtr_i32 input);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/namespace_constant.both.c
+++ b/tests/expectations/namespace_constant.both.c
@@ -11,4 +11,4 @@ typedef struct Foo {
   int32_t x[FOO];
 } Foo;
 
-void root(Foo x);
+void root(struct Foo x);

--- a/tests/expectations/namespace_constant.both.compat.c
+++ b/tests/expectations/namespace_constant.both.compat.c
@@ -19,7 +19,7 @@ typedef struct Foo {
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo x);
+void root(struct Foo x);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/namespaces_constant.both.c
+++ b/tests/expectations/namespaces_constant.both.c
@@ -11,4 +11,4 @@ typedef struct Foo {
   int32_t x[FOO];
 } Foo;
 
-void root(Foo x);
+void root(struct Foo x);

--- a/tests/expectations/namespaces_constant.both.compat.c
+++ b/tests/expectations/namespaces_constant.both.compat.c
@@ -20,7 +20,7 @@ typedef struct Foo {
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo x);
+void root(struct Foo x);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/nonnull.both.c
+++ b/tests/expectations/nonnull.both.c
@@ -8,13 +8,13 @@ typedef struct Opaque Opaque;
 typedef struct Foo_u64 {
   float *a;
   uint64_t *b;
-  Opaque *c;
+  struct Opaque *c;
   uint64_t **d;
   float **e;
-  Opaque **f;
+  struct Opaque **f;
   uint64_t *g;
   int32_t *h;
   int32_t **i;
 } Foo_u64;
 
-void root(int32_t *arg, Foo_u64 *foo, Opaque **d);
+void root(int32_t *arg, struct Foo_u64 *foo, struct Opaque **d);

--- a/tests/expectations/nonnull.both.compat.c
+++ b/tests/expectations/nonnull.both.compat.c
@@ -8,10 +8,10 @@ typedef struct Opaque Opaque;
 typedef struct Foo_u64 {
   float *a;
   uint64_t *b;
-  Opaque *c;
+  struct Opaque *c;
   uint64_t **d;
   float **e;
-  Opaque **f;
+  struct Opaque **f;
   uint64_t *g;
   int32_t *h;
   int32_t **i;
@@ -21,7 +21,7 @@ typedef struct Foo_u64 {
 extern "C" {
 #endif // __cplusplus
 
-void root(int32_t *arg, Foo_u64 *foo, Opaque **d);
+void root(int32_t *arg, struct Foo_u64 *foo, struct Opaque **d);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/nonnull_attribute.both.c
+++ b/tests/expectations/nonnull_attribute.both.c
@@ -13,19 +13,19 @@
 typedef struct Opaque Opaque;
 
 typedef struct References {
-  const Opaque *CBINDGEN_NONNULL a;
-  Opaque *CBINDGEN_NONNULL b;
-  const Opaque *c;
-  Opaque *d;
+  const struct Opaque *CBINDGEN_NONNULL a;
+  struct Opaque *CBINDGEN_NONNULL b;
+  const struct Opaque *c;
+  struct Opaque *d;
 } References;
 
 typedef struct Pointers_u64 {
   float *CBINDGEN_NONNULL a;
   uint64_t *CBINDGEN_NONNULL b;
-  Opaque *CBINDGEN_NONNULL c;
+  struct Opaque *CBINDGEN_NONNULL c;
   uint64_t *CBINDGEN_NONNULL *CBINDGEN_NONNULL d;
   float *CBINDGEN_NONNULL *CBINDGEN_NONNULL e;
-  Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL f;
+  struct Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL f;
   uint64_t *g;
   int32_t *h;
   int32_t *CBINDGEN_NONNULL *i;
@@ -33,20 +33,20 @@ typedef struct Pointers_u64 {
   uint64_t *k;
 } Pointers_u64;
 
-void value_arg(References arg);
+void value_arg(struct References arg);
 
 void mutltiple_args(int32_t *CBINDGEN_NONNULL arg,
-                    Pointers_u64 *foo,
-                    Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL d);
+                    struct Pointers_u64 *foo,
+                    struct Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL d);
 
-void ref_arg(const Pointers_u64 *CBINDGEN_NONNULL arg);
+void ref_arg(const struct Pointers_u64 *CBINDGEN_NONNULL arg);
 
-void mut_ref_arg(Pointers_u64 *CBINDGEN_NONNULL arg);
+void mut_ref_arg(struct Pointers_u64 *CBINDGEN_NONNULL arg);
 
-void optional_ref_arg(const Pointers_u64 *arg);
+void optional_ref_arg(const struct Pointers_u64 *arg);
 
-void optional_mut_ref_arg(Pointers_u64 *arg);
+void optional_mut_ref_arg(struct Pointers_u64 *arg);
 
-void nullable_const_ptr(const Pointers_u64 *arg);
+void nullable_const_ptr(const struct Pointers_u64 *arg);
 
-void nullable_mut_ptr(Pointers_u64 *arg);
+void nullable_mut_ptr(struct Pointers_u64 *arg);

--- a/tests/expectations/nonnull_attribute.both.compat.c
+++ b/tests/expectations/nonnull_attribute.both.compat.c
@@ -13,19 +13,19 @@
 typedef struct Opaque Opaque;
 
 typedef struct References {
-  const Opaque *CBINDGEN_NONNULL a;
-  Opaque *CBINDGEN_NONNULL b;
-  const Opaque *c;
-  Opaque *d;
+  const struct Opaque *CBINDGEN_NONNULL a;
+  struct Opaque *CBINDGEN_NONNULL b;
+  const struct Opaque *c;
+  struct Opaque *d;
 } References;
 
 typedef struct Pointers_u64 {
   float *CBINDGEN_NONNULL a;
   uint64_t *CBINDGEN_NONNULL b;
-  Opaque *CBINDGEN_NONNULL c;
+  struct Opaque *CBINDGEN_NONNULL c;
   uint64_t *CBINDGEN_NONNULL *CBINDGEN_NONNULL d;
   float *CBINDGEN_NONNULL *CBINDGEN_NONNULL e;
-  Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL f;
+  struct Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL f;
   uint64_t *g;
   int32_t *h;
   int32_t *CBINDGEN_NONNULL *i;
@@ -37,23 +37,23 @@ typedef struct Pointers_u64 {
 extern "C" {
 #endif // __cplusplus
 
-void value_arg(References arg);
+void value_arg(struct References arg);
 
 void mutltiple_args(int32_t *CBINDGEN_NONNULL arg,
-                    Pointers_u64 *foo,
-                    Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL d);
+                    struct Pointers_u64 *foo,
+                    struct Opaque *CBINDGEN_NONNULL *CBINDGEN_NONNULL d);
 
-void ref_arg(const Pointers_u64 *CBINDGEN_NONNULL arg);
+void ref_arg(const struct Pointers_u64 *CBINDGEN_NONNULL arg);
 
-void mut_ref_arg(Pointers_u64 *CBINDGEN_NONNULL arg);
+void mut_ref_arg(struct Pointers_u64 *CBINDGEN_NONNULL arg);
 
-void optional_ref_arg(const Pointers_u64 *arg);
+void optional_ref_arg(const struct Pointers_u64 *arg);
 
-void optional_mut_ref_arg(Pointers_u64 *arg);
+void optional_mut_ref_arg(struct Pointers_u64 *arg);
 
-void nullable_const_ptr(const Pointers_u64 *arg);
+void nullable_const_ptr(const struct Pointers_u64 *arg);
 
-void nullable_mut_ptr(Pointers_u64 *arg);
+void nullable_mut_ptr(struct Pointers_u64 *arg);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/opaque.both.c
+++ b/tests/expectations/opaque.both.c
@@ -1,0 +1,28 @@
+#ifdef __cplusplus
+// These could be added as opaque types I guess.
+template <typename T>
+struct BuildHasherDefault;
+
+struct DefaultHasher;
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct HashMap_i32__i32__BuildHasherDefault_DefaultHasher HashMap_i32__i32__BuildHasherDefault_DefaultHasher;
+
+typedef struct Result_Foo Result_Foo;
+
+/**
+ * Fast hash map used internally.
+ */
+typedef struct HashMap_i32__i32__BuildHasherDefault_DefaultHasher FastHashMap_i32__i32;
+
+typedef FastHashMap_i32__i32 Foo;
+
+typedef struct Result_Foo Bar;
+
+void root(const Foo *a, const Bar *b);

--- a/tests/expectations/opaque.both.compat.c
+++ b/tests/expectations/opaque.both.compat.c
@@ -1,0 +1,36 @@
+#ifdef __cplusplus
+// These could be added as opaque types I guess.
+template <typename T>
+struct BuildHasherDefault;
+
+struct DefaultHasher;
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct HashMap_i32__i32__BuildHasherDefault_DefaultHasher HashMap_i32__i32__BuildHasherDefault_DefaultHasher;
+
+typedef struct Result_Foo Result_Foo;
+
+/**
+ * Fast hash map used internally.
+ */
+typedef struct HashMap_i32__i32__BuildHasherDefault_DefaultHasher FastHashMap_i32__i32;
+
+typedef FastHashMap_i32__i32 Foo;
+
+typedef struct Result_Foo Bar;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(const Foo *a, const Bar *b);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/prefix.both.c
+++ b/tests/expectations/prefix.both.c
@@ -30,4 +30,4 @@ typedef union PREFIX_AbsoluteFontWeight {
   PREFIX_Weight_Body weight;
 } PREFIX_AbsoluteFontWeight;
 
-void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, union PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/prefix.both.compat.c
+++ b/tests/expectations/prefix.both.compat.c
@@ -40,7 +40,7 @@ typedef union PREFIX_AbsoluteFontWeight {
 extern "C" {
 #endif // __cplusplus
 
-void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);
+void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, union PREFIX_AbsoluteFontWeight z);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/prefixed_struct_literal.both.c
+++ b/tests/expectations/prefixed_struct_literal.both.c
@@ -11,4 +11,4 @@ typedef struct PREFIXFoo {
 
 #define PREFIXBAR (PREFIXFoo){ .a = 42, .b = 1337 }
 
-void root(PREFIXFoo x);
+void root(struct PREFIXFoo x);

--- a/tests/expectations/prefixed_struct_literal.both.compat.c
+++ b/tests/expectations/prefixed_struct_literal.both.compat.c
@@ -15,7 +15,7 @@ typedef struct PREFIXFoo {
 extern "C" {
 #endif // __cplusplus
 
-void root(PREFIXFoo x);
+void root(struct PREFIXFoo x);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/prefixed_struct_literal_deep.both.c
+++ b/tests/expectations/prefixed_struct_literal_deep.both.c
@@ -10,9 +10,9 @@ typedef struct PREFIXBar {
 typedef struct PREFIXFoo {
   int32_t a;
   uint32_t b;
-  PREFIXBar bar;
+  struct PREFIXBar bar;
 } PREFIXFoo;
 
 #define PREFIXVAL (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } }
 
-void root(PREFIXFoo x);
+void root(struct PREFIXFoo x);

--- a/tests/expectations/prefixed_struct_literal_deep.both.compat.c
+++ b/tests/expectations/prefixed_struct_literal_deep.both.compat.c
@@ -10,7 +10,7 @@ typedef struct PREFIXBar {
 typedef struct PREFIXFoo {
   int32_t a;
   uint32_t b;
-  PREFIXBar bar;
+  struct PREFIXBar bar;
 } PREFIXFoo;
 
 #define PREFIXVAL (PREFIXFoo){ .a = 42, .b = 1337, .bar = (PREFIXBar){ .a = 323 } }
@@ -19,7 +19,7 @@ typedef struct PREFIXFoo {
 extern "C" {
 #endif // __cplusplus
 
-void root(PREFIXFoo x);
+void root(struct PREFIXFoo x);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/rename.both.c
+++ b/tests/expectations/rename.both.c
@@ -25,10 +25,10 @@ typedef union C_D {
   float y;
 } C_D;
 
-typedef C_A C_F;
+typedef struct C_A C_F;
 
 #define C_I (intptr_t)(C_F*)10
 
 extern const int32_t G;
 
-void root(const C_A *a, C_AwesomeB b, C_C c, C_D d, C_E e, C_F f);
+void root(const struct C_A *a, struct C_AwesomeB b, struct C_C c, union C_D d, C_E e, C_F f);

--- a/tests/expectations/rename.both.compat.c
+++ b/tests/expectations/rename.both.compat.c
@@ -31,7 +31,7 @@ typedef union C_D {
   float y;
 } C_D;
 
-typedef C_A C_F;
+typedef struct C_A C_F;
 
 #define C_I (intptr_t)(C_F*)10
 
@@ -41,7 +41,7 @@ extern "C" {
 
 extern const int32_t G;
 
-void root(const C_A *a, C_AwesomeB b, C_C c, C_D d, C_E e, C_F f);
+void root(const struct C_A *a, struct C_AwesomeB b, struct C_C c, union C_D d, C_E e, C_F f);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/rename_crate.both.c
+++ b/tests/expectations/rename_crate.both.c
@@ -19,7 +19,7 @@ typedef struct NoExternTy {
 
 #if !defined(DEFINE_FREEBSD)
 typedef struct ContainsNoExternTy {
-  NoExternTy field;
+  struct NoExternTy field;
 } ContainsNoExternTy;
 #endif
 
@@ -29,8 +29,8 @@ typedef struct ContainsNoExternTy {
 } ContainsNoExternTy;
 #endif
 
-void root(Foo a);
+void root(struct Foo a);
 
-void renamed_func(RenamedTy a);
+void renamed_func(struct RenamedTy a);
 
-void no_extern_func(ContainsNoExternTy a);
+void no_extern_func(struct ContainsNoExternTy a);

--- a/tests/expectations/rename_crate.both.compat.c
+++ b/tests/expectations/rename_crate.both.compat.c
@@ -19,7 +19,7 @@ typedef struct NoExternTy {
 
 #if !defined(DEFINE_FREEBSD)
 typedef struct ContainsNoExternTy {
-  NoExternTy field;
+  struct NoExternTy field;
 } ContainsNoExternTy;
 #endif
 
@@ -33,11 +33,11 @@ typedef struct ContainsNoExternTy {
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo a);
+void root(struct Foo a);
 
-void renamed_func(RenamedTy a);
+void renamed_func(struct RenamedTy a);
 
-void no_extern_func(ContainsNoExternTy a);
+void no_extern_func(struct ContainsNoExternTy a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/renaming_overrides_prefixing.both.c
+++ b/tests/expectations/renaming_overrides_prefixing.both.c
@@ -10,4 +10,4 @@ typedef struct B {
   float y;
 } B;
 
-void root(const StyleA *a, B b);
+void root(const struct StyleA *a, struct B b);

--- a/tests/expectations/renaming_overrides_prefixing.both.compat.c
+++ b/tests/expectations/renaming_overrides_prefixing.both.compat.c
@@ -14,7 +14,7 @@ typedef struct B {
 extern "C" {
 #endif // __cplusplus
 
-void root(const StyleA *a, B b);
+void root(const struct StyleA *a, struct B b);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/reserved.both.c
+++ b/tests/expectations/reserved.both.c
@@ -74,4 +74,10 @@ typedef struct F {
   };
 } F;
 
-void root(A a, B b, C c, E e, F f, int32_t namespace_, float float_);
+void root(struct A a,
+          struct B b,
+          struct C c,
+          struct E e,
+          struct F f,
+          int32_t namespace_,
+          float float_);

--- a/tests/expectations/reserved.both.compat.c
+++ b/tests/expectations/reserved.both.compat.c
@@ -96,7 +96,13 @@ typedef struct F {
 extern "C" {
 #endif // __cplusplus
 
-void root(A a, B b, C c, E e, F f, int32_t namespace_, float float_);
+void root(struct A a,
+          struct B b,
+          struct C c,
+          struct E e,
+          struct F f,
+          int32_t namespace_,
+          float float_);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/sentinel.both.c
+++ b/tests/expectations/sentinel.both.c
@@ -52,4 +52,4 @@ typedef union C {
   C_C2_Body c2;
 } C;
 
-void root(A a, B b, C c);
+void root(A a, B b, union C c);

--- a/tests/expectations/sentinel.both.compat.c
+++ b/tests/expectations/sentinel.both.compat.c
@@ -74,7 +74,7 @@ typedef union C {
 extern "C" {
 #endif // __cplusplus
 
-void root(A a, B b, C c);
+void root(A a, B b, union C c);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/simplify_option_ptr.both.c
+++ b/tests/expectations/simplify_option_ptr.both.c
@@ -6,15 +6,15 @@
 typedef struct Opaque Opaque;
 
 typedef struct Foo {
-  const Opaque *x;
-  Opaque *y;
+  const struct Opaque *x;
+  struct Opaque *y;
   void (*z)(void);
 } Foo;
 
 typedef union Bar {
-  const Opaque *x;
-  Opaque *y;
+  const struct Opaque *x;
+  struct Opaque *y;
   void (*z)(void);
 } Bar;
 
-void root(const Opaque *a, Opaque *b, Foo c, Bar d);
+void root(const struct Opaque *a, struct Opaque *b, struct Foo c, union Bar d);

--- a/tests/expectations/simplify_option_ptr.both.compat.c
+++ b/tests/expectations/simplify_option_ptr.both.compat.c
@@ -6,14 +6,14 @@
 typedef struct Opaque Opaque;
 
 typedef struct Foo {
-  const Opaque *x;
-  Opaque *y;
+  const struct Opaque *x;
+  struct Opaque *y;
   void (*z)(void);
 } Foo;
 
 typedef union Bar {
-  const Opaque *x;
-  Opaque *y;
+  const struct Opaque *x;
+  struct Opaque *y;
   void (*z)(void);
 } Bar;
 
@@ -21,7 +21,7 @@ typedef union Bar {
 extern "C" {
 #endif // __cplusplus
 
-void root(const Opaque *a, Opaque *b, Foo c, Bar d);
+void root(const struct Opaque *a, struct Opaque *b, struct Foo c, union Bar d);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/static.both.c
+++ b/tests/expectations/static.both.c
@@ -11,8 +11,8 @@ typedef struct Foo {
 
 extern const int32_t NUMBER;
 
-extern Foo FOO;
+extern struct Foo FOO;
 
-extern const Bar BAR;
+extern const struct Bar BAR;
 
 void root(void);

--- a/tests/expectations/static.both.compat.c
+++ b/tests/expectations/static.both.compat.c
@@ -15,9 +15,9 @@ extern "C" {
 
 extern const int32_t NUMBER;
 
-extern Foo FOO;
+extern struct Foo FOO;
 
-extern const Bar BAR;
+extern const struct Bar BAR;
 
 void root(void);
 

--- a/tests/expectations/std_lib.both.c
+++ b/tests/expectations/std_lib.both.c
@@ -1,0 +1,14 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Option_i32 Option_i32;
+
+typedef struct Result_i32__String Result_i32__String;
+
+typedef struct Vec_String Vec_String;
+
+void root(const struct Vec_String *a,
+          const struct Option_i32 *b,
+          const struct Result_i32__String *c);

--- a/tests/expectations/std_lib.both.compat.c
+++ b/tests/expectations/std_lib.both.compat.c
@@ -1,0 +1,22 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Option_i32 Option_i32;
+
+typedef struct Result_i32__String Result_i32__String;
+
+typedef struct Vec_String Vec_String;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(const struct Vec_String *a,
+          const struct Option_i32 *b,
+          const struct Result_i32__String *c);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/struct.both.c
+++ b/tests/expectations/struct.both.c
@@ -25,4 +25,8 @@ typedef struct TupleNamed {
   float y;
 } TupleNamed;
 
-void root(Opaque *a, Normal b, NormalWithZST c, TupleRenamed d, TupleNamed e);
+void root(struct Opaque *a,
+          struct Normal b,
+          struct NormalWithZST c,
+          struct TupleRenamed d,
+          struct TupleNamed e);

--- a/tests/expectations/struct.both.compat.c
+++ b/tests/expectations/struct.both.compat.c
@@ -29,7 +29,11 @@ typedef struct TupleNamed {
 extern "C" {
 #endif // __cplusplus
 
-void root(Opaque *a, Normal b, NormalWithZST c, TupleRenamed d, TupleNamed e);
+void root(struct Opaque *a,
+          struct Normal b,
+          struct NormalWithZST c,
+          struct TupleRenamed d,
+          struct TupleNamed e);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/struct_literal.both.c
+++ b/tests/expectations/struct_literal.both.c
@@ -18,4 +18,4 @@ typedef struct Foo {
 
 
 
-void root(Foo x, Bar bar);
+void root(struct Foo x, struct Bar bar);

--- a/tests/expectations/struct_literal.both.compat.c
+++ b/tests/expectations/struct_literal.both.compat.c
@@ -22,7 +22,7 @@ typedef struct Foo {
 extern "C" {
 #endif // __cplusplus
 
-void root(Foo x, Bar bar);
+void root(struct Foo x, struct Bar bar);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/struct_literal_order.both.c
+++ b/tests/expectations/struct_literal_order.both.c
@@ -21,4 +21,4 @@ typedef struct BAC {
 #define BAC_bac (BAC){ .b = 1, .a = 2.0, .c = 3 }
 #define BAC_cba (BAC){ .b = 1, .a = 2.0, .c = 3 }
 
-void root(ABC a1, BAC a2);
+void root(struct ABC a1, struct BAC a2);

--- a/tests/expectations/struct_literal_order.both.compat.c
+++ b/tests/expectations/struct_literal_order.both.compat.c
@@ -25,7 +25,7 @@ typedef struct BAC {
 extern "C" {
 #endif // __cplusplus
 
-void root(ABC a1, BAC a2);
+void root(struct ABC a1, struct BAC a2);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/struct_self.both.c
+++ b/tests/expectations/struct_self.both.c
@@ -9,7 +9,7 @@ typedef struct Foo_Bar {
 
 typedef struct Bar {
   int32_t something;
-  Foo_Bar subexpressions;
+  struct Foo_Bar subexpressions;
 } Bar;
 
-void root(Bar b);
+void root(struct Bar b);

--- a/tests/expectations/struct_self.both.compat.c
+++ b/tests/expectations/struct_self.both.compat.c
@@ -9,14 +9,14 @@ typedef struct Foo_Bar {
 
 typedef struct Bar {
   int32_t something;
-  Foo_Bar subexpressions;
+  struct Foo_Bar subexpressions;
 } Bar;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(Bar b);
+void root(struct Bar b);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/swift_name.both.c
+++ b/tests/expectations/swift_name.both.c
@@ -12,44 +12,44 @@ typedef struct SelfTypeTestStruct {
 } SelfTypeTestStruct;
 
 typedef struct PointerToOpaque {
-  Opaque *ptr;
+  struct Opaque *ptr;
 } PointerToOpaque;
 
 void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());
 
-void SelfTypeTestStruct_should_exist_ref(const SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref(self:));
+void SelfTypeTestStruct_should_exist_ref(const struct SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref(self:));
 
-void SelfTypeTestStruct_should_exist_ref_mut(SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref_mut(self:));
+void SelfTypeTestStruct_should_exist_ref_mut(struct SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref_mut(self:));
 
-void SelfTypeTestStruct_should_not_exist_box(SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_box(self:));
+void SelfTypeTestStruct_should_not_exist_box(struct SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_box(self:));
 
-SelfTypeTestStruct *SelfTypeTestStruct_should_not_exist_return_box(void) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_return_box());
+struct SelfTypeTestStruct *SelfTypeTestStruct_should_not_exist_return_box(void) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_return_box());
 
-void SelfTypeTestStruct_should_exist_annotated_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_self(self:));
+void SelfTypeTestStruct_should_exist_annotated_self(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_self(self:));
 
-void SelfTypeTestStruct_should_exist_annotated_mut_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_self(self:));
+void SelfTypeTestStruct_should_exist_annotated_mut_self(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_self(self:));
 
-void SelfTypeTestStruct_should_exist_annotated_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_by_name(self:));
+void SelfTypeTestStruct_should_exist_annotated_by_name(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_by_name(self:));
 
-void SelfTypeTestStruct_should_exist_annotated_mut_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_by_name(self:));
+void SelfTypeTestStruct_should_exist_annotated_mut_by_name(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_by_name(self:));
 
-void SelfTypeTestStruct_should_exist_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_unannotated(self:));
+void SelfTypeTestStruct_should_exist_unannotated(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_unannotated(self:));
 
-void SelfTypeTestStruct_should_exist_mut_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_mut_unannotated(self:));
+void SelfTypeTestStruct_should_exist_mut_unannotated(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_mut_unannotated(self:));
 
-void free_function_should_exist_ref(const SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref(test_struct:));
+void free_function_should_exist_ref(const struct SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref(test_struct:));
 
-void free_function_should_exist_ref_mut(SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref_mut(test_struct:));
+void free_function_should_exist_ref_mut(struct SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref_mut(test_struct:));
 
-void unnamed_argument(SelfTypeTestStruct*);
+void unnamed_argument(struct SelfTypeTestStruct*);
 
-void free_function_should_not_exist_box(SelfTypeTestStruct *boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
+void free_function_should_not_exist_box(struct SelfTypeTestStruct *boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
 
-void free_function_should_exist_annotated_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_by_name(test_struct:));
+void free_function_should_exist_annotated_by_name(struct SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_by_name(test_struct:));
 
-void free_function_should_exist_annotated_mut_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_mut_by_name(test_struct:));
+void free_function_should_exist_annotated_mut_by_name(struct SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_mut_by_name(test_struct:));
 
-PointerToOpaque PointerToOpaque_create(uint8_t times) CF_SWIFT_NAME(PointerToOpaque.create(times:));
+struct PointerToOpaque PointerToOpaque_create(uint8_t times) CF_SWIFT_NAME(PointerToOpaque.create(times:));
 
-void PointerToOpaque_sayHello(PointerToOpaque self)
+void PointerToOpaque_sayHello(struct PointerToOpaque self)
 /*a comment!*/ CF_SWIFT_NAME(PointerToOpaque.sayHello(self:));

--- a/tests/expectations/swift_name.both.compat.c
+++ b/tests/expectations/swift_name.both.compat.c
@@ -12,7 +12,7 @@ typedef struct SelfTypeTestStruct {
 } SelfTypeTestStruct;
 
 typedef struct PointerToOpaque {
-  Opaque *ptr;
+  struct Opaque *ptr;
 } PointerToOpaque;
 
 #ifdef __cplusplus
@@ -21,41 +21,41 @@ extern "C" {
 
 void rust_print_hello_world(void) CF_SWIFT_NAME(rust_print_hello_world());
 
-void SelfTypeTestStruct_should_exist_ref(const SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref(self:));
+void SelfTypeTestStruct_should_exist_ref(const struct SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref(self:));
 
-void SelfTypeTestStruct_should_exist_ref_mut(SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref_mut(self:));
+void SelfTypeTestStruct_should_exist_ref_mut(struct SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_ref_mut(self:));
 
-void SelfTypeTestStruct_should_not_exist_box(SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_box(self:));
+void SelfTypeTestStruct_should_not_exist_box(struct SelfTypeTestStruct *self) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_box(self:));
 
-SelfTypeTestStruct *SelfTypeTestStruct_should_not_exist_return_box(void) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_return_box());
+struct SelfTypeTestStruct *SelfTypeTestStruct_should_not_exist_return_box(void) CF_SWIFT_NAME(SelfTypeTestStruct.should_not_exist_return_box());
 
-void SelfTypeTestStruct_should_exist_annotated_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_self(self:));
+void SelfTypeTestStruct_should_exist_annotated_self(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_self(self:));
 
-void SelfTypeTestStruct_should_exist_annotated_mut_self(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_self(self:));
+void SelfTypeTestStruct_should_exist_annotated_mut_self(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_self(self:));
 
-void SelfTypeTestStruct_should_exist_annotated_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_by_name(self:));
+void SelfTypeTestStruct_should_exist_annotated_by_name(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_by_name(self:));
 
-void SelfTypeTestStruct_should_exist_annotated_mut_by_name(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_by_name(self:));
+void SelfTypeTestStruct_should_exist_annotated_mut_by_name(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_annotated_mut_by_name(self:));
 
-void SelfTypeTestStruct_should_exist_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_unannotated(self:));
+void SelfTypeTestStruct_should_exist_unannotated(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_unannotated(self:));
 
-void SelfTypeTestStruct_should_exist_mut_unannotated(SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_mut_unannotated(self:));
+void SelfTypeTestStruct_should_exist_mut_unannotated(struct SelfTypeTestStruct self) CF_SWIFT_NAME(SelfTypeTestStruct.should_exist_mut_unannotated(self:));
 
-void free_function_should_exist_ref(const SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref(test_struct:));
+void free_function_should_exist_ref(const struct SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref(test_struct:));
 
-void free_function_should_exist_ref_mut(SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref_mut(test_struct:));
+void free_function_should_exist_ref_mut(struct SelfTypeTestStruct *test_struct) CF_SWIFT_NAME(free_function_should_exist_ref_mut(test_struct:));
 
-void unnamed_argument(SelfTypeTestStruct*);
+void unnamed_argument(struct SelfTypeTestStruct*);
 
-void free_function_should_not_exist_box(SelfTypeTestStruct *boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
+void free_function_should_not_exist_box(struct SelfTypeTestStruct *boxed) CF_SWIFT_NAME(free_function_should_not_exist_box(boxed:));
 
-void free_function_should_exist_annotated_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_by_name(test_struct:));
+void free_function_should_exist_annotated_by_name(struct SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_by_name(test_struct:));
 
-void free_function_should_exist_annotated_mut_by_name(SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_mut_by_name(test_struct:));
+void free_function_should_exist_annotated_mut_by_name(struct SelfTypeTestStruct test_struct) CF_SWIFT_NAME(free_function_should_exist_annotated_mut_by_name(test_struct:));
 
-PointerToOpaque PointerToOpaque_create(uint8_t times) CF_SWIFT_NAME(PointerToOpaque.create(times:));
+struct PointerToOpaque PointerToOpaque_create(uint8_t times) CF_SWIFT_NAME(PointerToOpaque.create(times:));
 
-void PointerToOpaque_sayHello(PointerToOpaque self)
+void PointerToOpaque_sayHello(struct PointerToOpaque self)
 /*a comment!*/ CF_SWIFT_NAME(PointerToOpaque.sayHello(self:));
 
 #ifdef __cplusplus

--- a/tests/expectations/transform_op.both.c
+++ b/tests/expectations/transform_op.both.c
@@ -24,8 +24,8 @@ typedef uint8_t StyleFoo_i32_Tag;
 typedef struct StyleFoo_Body_i32 {
   StyleFoo_i32_Tag tag;
   int32_t x;
-  StylePoint_i32 y;
-  StylePoint_f32 z;
+  struct StylePoint_i32 y;
+  struct StylePoint_f32 z;
 } StyleFoo_Body_i32;
 
 typedef struct StyleBar_Body_i32 {
@@ -35,7 +35,7 @@ typedef struct StyleBar_Body_i32 {
 
 typedef struct StyleBaz_Body_i32 {
   StyleFoo_i32_Tag tag;
-  StylePoint_i32 _0;
+  struct StylePoint_i32 _0;
 } StyleBaz_Body_i32;
 
 typedef union StyleFoo_i32 {
@@ -54,8 +54,8 @@ typedef enum StyleBar_i32_Tag {
 
 typedef struct StyleBar1_Body_i32 {
   int32_t x;
-  StylePoint_i32 y;
-  StylePoint_f32 z;
+  struct StylePoint_i32 y;
+  struct StylePoint_f32 z;
   int32_t (*u)(int32_t);
 } StyleBar1_Body_i32;
 
@@ -64,7 +64,7 @@ typedef struct StyleBar2_Body_i32 {
 } StyleBar2_Body_i32;
 
 typedef struct StyleBar3_Body_i32 {
-  StylePoint_i32 _0;
+  struct StylePoint_i32 _0;
 } StyleBar3_Body_i32;
 
 typedef struct StyleBar_i32 {
@@ -90,8 +90,8 @@ typedef enum StyleBar_u32_Tag {
 
 typedef struct StyleBar1_Body_u32 {
   int32_t x;
-  StylePoint_u32 y;
-  StylePoint_f32 z;
+  struct StylePoint_u32 y;
+  struct StylePoint_f32 z;
   int32_t (*u)(int32_t);
 } StyleBar1_Body_u32;
 
@@ -100,7 +100,7 @@ typedef struct StyleBar2_Body_u32 {
 } StyleBar2_Body_u32;
 
 typedef struct StyleBar3_Body_u32 {
-  StylePoint_u32 _0;
+  struct StylePoint_u32 _0;
 } StyleBar3_Body_u32;
 
 typedef struct StyleBar_u32 {
@@ -121,12 +121,12 @@ typedef uint8_t StyleBaz_Tag;
 
 typedef struct StyleBaz1_Body {
   StyleBaz_Tag tag;
-  StyleBar_u32 _0;
+  struct StyleBar_u32 _0;
 } StyleBaz1_Body;
 
 typedef struct StyleBaz2_Body {
   StyleBaz_Tag tag;
-  StylePoint_i32 _0;
+  struct StylePoint_i32 _0;
 } StyleBaz2_Body;
 
 typedef union StyleBaz {
@@ -143,11 +143,11 @@ enum StyleTaz_Tag {
 typedef uint8_t StyleTaz_Tag;
 
 typedef struct StyleTaz1_Body {
-  StyleBar_u32 _0;
+  struct StyleBar_u32 _0;
 } StyleTaz1_Body;
 
 typedef struct StyleTaz2_Body {
-  StyleBaz _0;
+  union StyleBaz _0;
 } StyleTaz2_Body;
 
 typedef struct StyleTaz {
@@ -158,7 +158,7 @@ typedef struct StyleTaz {
   };
 } StyleTaz;
 
-void foo(const StyleFoo_i32 *foo,
-         const StyleBar_i32 *bar,
-         const StyleBaz *baz,
-         const StyleTaz *taz);
+void foo(const union StyleFoo_i32 *foo,
+         const struct StyleBar_i32 *bar,
+         const union StyleBaz *baz,
+         const struct StyleTaz *taz);

--- a/tests/expectations/transform_op.both.compat.c
+++ b/tests/expectations/transform_op.both.compat.c
@@ -30,8 +30,8 @@ typedef uint8_t StyleFoo_i32_Tag;
 typedef struct StyleFoo_Body_i32 {
   StyleFoo_i32_Tag tag;
   int32_t x;
-  StylePoint_i32 y;
-  StylePoint_f32 z;
+  struct StylePoint_i32 y;
+  struct StylePoint_f32 z;
 } StyleFoo_Body_i32;
 
 typedef struct StyleBar_Body_i32 {
@@ -41,7 +41,7 @@ typedef struct StyleBar_Body_i32 {
 
 typedef struct StyleBaz_Body_i32 {
   StyleFoo_i32_Tag tag;
-  StylePoint_i32 _0;
+  struct StylePoint_i32 _0;
 } StyleBaz_Body_i32;
 
 typedef union StyleFoo_i32 {
@@ -60,8 +60,8 @@ typedef enum StyleBar_i32_Tag {
 
 typedef struct StyleBar1_Body_i32 {
   int32_t x;
-  StylePoint_i32 y;
-  StylePoint_f32 z;
+  struct StylePoint_i32 y;
+  struct StylePoint_f32 z;
   int32_t (*u)(int32_t);
 } StyleBar1_Body_i32;
 
@@ -70,7 +70,7 @@ typedef struct StyleBar2_Body_i32 {
 } StyleBar2_Body_i32;
 
 typedef struct StyleBar3_Body_i32 {
-  StylePoint_i32 _0;
+  struct StylePoint_i32 _0;
 } StyleBar3_Body_i32;
 
 typedef struct StyleBar_i32 {
@@ -96,8 +96,8 @@ typedef enum StyleBar_u32_Tag {
 
 typedef struct StyleBar1_Body_u32 {
   int32_t x;
-  StylePoint_u32 y;
-  StylePoint_f32 z;
+  struct StylePoint_u32 y;
+  struct StylePoint_f32 z;
   int32_t (*u)(int32_t);
 } StyleBar1_Body_u32;
 
@@ -106,7 +106,7 @@ typedef struct StyleBar2_Body_u32 {
 } StyleBar2_Body_u32;
 
 typedef struct StyleBar3_Body_u32 {
-  StylePoint_u32 _0;
+  struct StylePoint_u32 _0;
 } StyleBar3_Body_u32;
 
 typedef struct StyleBar_u32 {
@@ -133,12 +133,12 @@ typedef uint8_t StyleBaz_Tag;
 
 typedef struct StyleBaz1_Body {
   StyleBaz_Tag tag;
-  StyleBar_u32 _0;
+  struct StyleBar_u32 _0;
 } StyleBaz1_Body;
 
 typedef struct StyleBaz2_Body {
   StyleBaz_Tag tag;
-  StylePoint_i32 _0;
+  struct StylePoint_i32 _0;
 } StyleBaz2_Body;
 
 typedef union StyleBaz {
@@ -161,11 +161,11 @@ typedef uint8_t StyleTaz_Tag;
 #endif // __cplusplus
 
 typedef struct StyleTaz1_Body {
-  StyleBar_u32 _0;
+  struct StyleBar_u32 _0;
 } StyleTaz1_Body;
 
 typedef struct StyleTaz2_Body {
-  StyleBaz _0;
+  union StyleBaz _0;
 } StyleTaz2_Body;
 
 typedef struct StyleTaz {
@@ -180,10 +180,10 @@ typedef struct StyleTaz {
 extern "C" {
 #endif // __cplusplus
 
-void foo(const StyleFoo_i32 *foo,
-         const StyleBar_i32 *bar,
-         const StyleBaz *baz,
-         const StyleTaz *taz);
+void foo(const union StyleFoo_i32 *foo,
+         const struct StyleBar_i32 *bar,
+         const union StyleBaz *baz,
+         const struct StyleTaz *taz);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/transparent.both.c
+++ b/tests/expectations/transparent.both.c
@@ -1,0 +1,35 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct DummyStruct DummyStruct;
+
+typedef struct EnumWithAssociatedConstantInImpl EnumWithAssociatedConstantInImpl;
+
+typedef struct DummyStruct TransparentComplexWrappingStructTuple;
+
+typedef uint32_t TransparentPrimitiveWrappingStructTuple;
+
+typedef struct DummyStruct TransparentComplexWrappingStructure;
+
+typedef uint32_t TransparentPrimitiveWrappingStructure;
+
+typedef struct DummyStruct TransparentComplexWrapper_i32;
+
+typedef uint32_t TransparentPrimitiveWrapper_i32;
+
+typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
+#define TransparentPrimitiveWithAssociatedConstants_ZERO 0
+#define TransparentPrimitiveWithAssociatedConstants_ONE 1
+
+#define EnumWithAssociatedConstantInImpl_TEN 10
+
+void root(TransparentComplexWrappingStructTuple a,
+          TransparentPrimitiveWrappingStructTuple b,
+          TransparentComplexWrappingStructure c,
+          TransparentPrimitiveWrappingStructure d,
+          TransparentComplexWrapper_i32 e,
+          TransparentPrimitiveWrapper_i32 f,
+          TransparentPrimitiveWithAssociatedConstants g,
+          struct EnumWithAssociatedConstantInImpl h);

--- a/tests/expectations/transparent.both.compat.c
+++ b/tests/expectations/transparent.both.compat.c
@@ -1,0 +1,43 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct DummyStruct DummyStruct;
+
+typedef struct EnumWithAssociatedConstantInImpl EnumWithAssociatedConstantInImpl;
+
+typedef struct DummyStruct TransparentComplexWrappingStructTuple;
+
+typedef uint32_t TransparentPrimitiveWrappingStructTuple;
+
+typedef struct DummyStruct TransparentComplexWrappingStructure;
+
+typedef uint32_t TransparentPrimitiveWrappingStructure;
+
+typedef struct DummyStruct TransparentComplexWrapper_i32;
+
+typedef uint32_t TransparentPrimitiveWrapper_i32;
+
+typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
+#define TransparentPrimitiveWithAssociatedConstants_ZERO 0
+#define TransparentPrimitiveWithAssociatedConstants_ONE 1
+
+#define EnumWithAssociatedConstantInImpl_TEN 10
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(TransparentComplexWrappingStructTuple a,
+          TransparentPrimitiveWrappingStructTuple b,
+          TransparentComplexWrappingStructure c,
+          TransparentPrimitiveWrappingStructure d,
+          TransparentComplexWrapper_i32 e,
+          TransparentPrimitiveWrapper_i32 f,
+          TransparentPrimitiveWithAssociatedConstants g,
+          struct EnumWithAssociatedConstantInImpl h);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/typedef.both.c
+++ b/tests/expectations/typedef.both.c
@@ -8,6 +8,6 @@ typedef struct Foo_i32__i32 {
   int32_t y;
 } Foo_i32__i32;
 
-typedef Foo_i32__i32 IntFoo_i32;
+typedef struct Foo_i32__i32 IntFoo_i32;
 
 void root(IntFoo_i32 a);

--- a/tests/expectations/typedef.both.compat.c
+++ b/tests/expectations/typedef.both.compat.c
@@ -8,7 +8,7 @@ typedef struct Foo_i32__i32 {
   int32_t y;
 } Foo_i32__i32;
 
-typedef Foo_i32__i32 IntFoo_i32;
+typedef struct Foo_i32__i32 IntFoo_i32;
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/union.both.c
+++ b/tests/expectations/union.both.c
@@ -15,4 +15,4 @@ typedef union NormalWithZST {
   float y;
 } NormalWithZST;
 
-void root(Opaque *a, Normal b, NormalWithZST c);
+void root(struct Opaque *a, union Normal b, union NormalWithZST c);

--- a/tests/expectations/union.both.compat.c
+++ b/tests/expectations/union.both.compat.c
@@ -19,7 +19,7 @@ typedef union NormalWithZST {
 extern "C" {
 #endif // __cplusplus
 
-void root(Opaque *a, Normal b, NormalWithZST c);
+void root(struct Opaque *a, union Normal b, union NormalWithZST c);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/union_self.both.c
+++ b/tests/expectations/union_self.both.c
@@ -9,7 +9,7 @@ typedef struct Foo_Bar {
 
 typedef union Bar {
   int32_t something;
-  Foo_Bar subexpressions;
+  struct Foo_Bar subexpressions;
 } Bar;
 
-void root(Bar b);
+void root(union Bar b);

--- a/tests/expectations/union_self.both.compat.c
+++ b/tests/expectations/union_self.both.compat.c
@@ -9,14 +9,14 @@ typedef struct Foo_Bar {
 
 typedef union Bar {
   int32_t something;
-  Foo_Bar subexpressions;
+  struct Foo_Bar subexpressions;
 } Bar;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(Bar b);
+void root(union Bar b);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/workspace.both.c
+++ b/tests/expectations/workspace.both.c
@@ -9,4 +9,4 @@ typedef struct ExtType {
   uint32_t data;
 } ExtType;
 
-void consume_ext(ExtType _ext);
+void consume_ext(struct ExtType _ext);

--- a/tests/expectations/workspace.both.compat.c
+++ b/tests/expectations/workspace.both.compat.c
@@ -13,7 +13,7 @@ typedef struct ExtType {
 extern "C" {
 #endif // __cplusplus
 
-void consume_ext(ExtType _ext);
+void consume_ext(struct ExtType _ext);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/rust/forward_declaration.rs
+++ b/tests/rust/forward_declaration.rs
@@ -1,0 +1,21 @@
+#[repr(C)]
+struct TypeInfo {
+    data: TypeData,
+}
+
+#[repr(C)]
+enum TypeData {
+    Primitive,
+    Struct(StructInfo),
+}
+
+#[repr(C)]
+struct StructInfo {
+    fields: *const *const TypeInfo, // requires forward declaration
+    num_fields: usize,
+}
+
+#[no_mangle]
+pub extern "C" fn root(
+    x: TypeInfo,
+) {}

--- a/tests/rust/forward_declaration.toml
+++ b/tests/rust/forward_declaration.toml
@@ -1,0 +1,12 @@
+
+header = """
+#if defined(CBINDGEN_STYLE_TYPE)
+/* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
+#endif
+"""
+
+trailer = """
+#if defined(CBINDGEN_STYLE_TYPE)
+*/
+#endif
+"""


### PR DESCRIPTION
Potentially fixes #215. 

Types of structs were not being resolved when the style was set to 'both', resulting in the `struct` keyword not being added to `struct` field types. This caused compiler errors complaining about missing forward declarations.