### PR TITLE
cython: Add options for specifying header and imports

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -979,6 +979,19 @@ features = ["cbindgen"]
 # `&mut T` and `NonNull<T>` all require a valid pointer value. 
 non_null_attribute = "_Nonnull"
 
+# Options specific to Cython bindings.
+
+[cython]
+
+# Header specified in the top level `cdef extern from header:` declaration.
+#
+# default: *
+header = '"my_header.h"'
+
+# `from module cimport name1, name2` declarations added in the same place
+# where you'd get includes in C.
+[cython.cimports]
+module = ["name1", "name2"]
 ```
 
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -835,6 +835,19 @@ pub struct PtrConfig {
     pub non_null_attribute: Option<String>,
 }
 
+/// Settings specific to Cython bindings.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
+pub struct CythonConfig {
+    /// Header specified in the top level `cdef extern from header:` declaration.
+    pub header: Option<String>,
+    /// `from module cimport name1, name2, ...` declarations added in the same place
+    /// where you'd get includes in C.
+    pub cimports: HashMap<String, Vec<String>>,
+}
+
 /// A collection of settings to customize the generated bindings.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -918,6 +931,8 @@ pub struct Config {
     /// Configuration options for pointers
     #[serde(rename = "ptr")]
     pub pointer: PtrConfig,
+    /// Configuration options specific to Cython.
+    pub cython: CythonConfig,
 }
 
 impl Default for Config {
@@ -957,6 +972,7 @@ impl Default for Config {
             documentation: true,
             documentation_style: DocumentationStyle::Auto,
             pointer: PtrConfig::default(),
+            cython: CythonConfig::default(),
         }
     }
 }

--- a/tests/expectations/cython_options.compat.c
+++ b/tests/expectations/cython_options.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/cython_options.cpp
+++ b/tests/expectations/cython_options.cpp
@@ -1,0 +1,5 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>

--- a/tests/expectations/cython_options.pyx
+++ b/tests/expectations/cython_options.pyx
@@ -1,0 +1,10 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+from libc.stddef cimport *
+from libc.stdint cimport int8_t, int16_t
+
+cdef extern from "my_header.h":
+  pass

--- a/tests/expectations/cython_options.tag.pyx
+++ b/tests/expectations/cython_options.tag.pyx
@@ -1,0 +1,10 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+from libc.stdint cimport int8_t, int16_t
+from libc.stddef cimport *
+
+cdef extern from "my_header.h":
+  pass

--- a/tests/rust/cython_options.toml
+++ b/tests/rust/cython_options.toml
@@ -1,0 +1,6 @@
+[cython]
+header = '"my_header.h"'
+
+[cython.cimports]
+"libc.stdint" = ["int8_t", "int16_t"]
+"libc.stddef" = ["*"]


### PR DESCRIPTION
C header `.h` and Cython `.pxd` are generated as a pair, so it's important to be able to generate them from a single config file.
Two new options in this PR allow to do it without hacks.
One option allows to "link" the `.pxd` to `.h`, and another one allows to add some imports.

(I don't plan to add any more Cython-specific options in the near future, these two are the ones with highest return-on-investment.)