### PR TITLE
cython: Fix a non-reproducible test

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::default::Default;
 use std::str::FromStr;
 use std::{fmt, fs, path::Path as StdPath};
@@ -851,7 +851,7 @@ pub struct CythonConfig {
     pub header: Option<String>,
     /// `from module cimport name1, name2, ...` declarations added in the same place
     /// where you'd get includes in C.
-    pub cimports: HashMap<String, Vec<String>>,
+    pub cimports: BTreeMap<String, Vec<String>>,
 }
 
 /// A collection of settings to customize the generated bindings.

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -244,6 +244,7 @@ impl EnumVariant {
 impl Source for EnumVariant {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         let condition = self.cfg.to_condition(config);
+        // Cython doesn't support conditional enum variants.
         if config.language != Language::Cython {
             condition.write_before(config, out);
         }
@@ -846,6 +847,7 @@ impl Source for Enum {
                     out.new_line();
                     out.new_line();
                     let condition = variant.cfg.to_condition(config);
+                    // Cython doesn't support conditional enum variants.
                     if config.language != Language::Cython {
                         condition.write_before(config, out);
                     }
@@ -928,6 +930,7 @@ impl Source for Enum {
                     }
                     first = false;
                     let condition = variant.cfg.to_condition(config);
+                    // Cython doesn't support conditional enum variants.
                     if config.language != Language::Cython {
                         condition.write_before(config, out);
                     }


### PR DESCRIPTION
Fixes the CI failure on master - https://github.com/eqrion/cbindgen/runs/1454777165.

Also add comments for https://github.com/eqrion/cbindgen/pull/620#discussion_r526255315

UPD: Looks like other `HashMap`s in config are used for search rather than for output, so they don't introduce this kind of randomness.