### PR TITLE
Refactor `Enum::write`

### DIFF
--- a/tests/expectations/must_use.both.c
+++ b/tests/expectations/must_use.both.c
@@ -18,7 +18,7 @@ typedef struct Owned_Body_i32 {
   int32_t *_0;
 } Owned_Body_i32;
 
-typedef struct MaybeOwnedPtr_i32 {
+typedef struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {
   MaybeOwnedPtr_i32_Tag tag;
   union {
     Owned_Body_i32 owned;

--- a/tests/expectations/must_use.both.compat.c
+++ b/tests/expectations/must_use.both.compat.c
@@ -24,7 +24,7 @@ typedef struct Owned_Body_i32 {
   int32_t *_0;
 } Owned_Body_i32;
 
-typedef struct MaybeOwnedPtr_i32 {
+typedef struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {
   MaybeOwnedPtr_i32_Tag tag;
   union {
     Owned_Body_i32 owned;

--- a/tests/expectations/must_use.c
+++ b/tests/expectations/must_use.c
@@ -18,7 +18,7 @@ typedef struct {
   int32_t *_0;
 } Owned_Body_i32;
 
-typedef struct {
+typedef struct MUST_USE_STRUCT {
   MaybeOwnedPtr_i32_Tag tag;
   union {
     Owned_Body_i32 owned;

--- a/tests/expectations/must_use.compat.c
+++ b/tests/expectations/must_use.compat.c
@@ -24,7 +24,7 @@ typedef struct {
   int32_t *_0;
 } Owned_Body_i32;
 
-typedef struct {
+typedef struct MUST_USE_STRUCT {
   MaybeOwnedPtr_i32_Tag tag;
   union {
     Owned_Body_i32 owned;

--- a/tests/expectations/must_use.tag.c
+++ b/tests/expectations/must_use.tag.c
@@ -18,7 +18,7 @@ struct Owned_Body_i32 {
   int32_t *_0;
 };
 
-struct MaybeOwnedPtr_i32 {
+struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {
   MaybeOwnedPtr_i32_Tag tag;
   union {
     struct Owned_Body_i32 owned;

--- a/tests/expectations/must_use.tag.compat.c
+++ b/tests/expectations/must_use.tag.compat.c
@@ -24,7 +24,7 @@ struct Owned_Body_i32 {
   int32_t *_0;
 };
 
-struct MaybeOwnedPtr_i32 {
+struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {
   MaybeOwnedPtr_i32_Tag tag;
   union {
     struct Owned_Body_i32 owned;


### PR DESCRIPTION
Break up enormous `Enum::write` into several smaller functions, add comments, try to avoid some naming ambiguities.

(Also `must_use` annotations for enums are now added in C mode and not only in C++ code, because they both use common `fn open_struct_or_union` logic now.)

(It's better to review this with whitespace changes ignored.)

This is a preparation for fixing https://github.com/eqrion/cbindgen/issues/353.