### PR TITLE
parser: Fix resolution of #[path] dependencies from certain modules.

### DIFF
--- a/tests/expectations/mod_2018.both.c
+++ b/tests/expectations/mod_2018.both.c
@@ -9,4 +9,10 @@ typedef struct ExportMe {
   uint64_t val;
 } ExportMe;
 
+typedef struct ExportMe2 {
+  uint64_t val;
+} ExportMe2;
+
 void export_me(struct ExportMe *val);
+
+void export_me_2(struct ExportMe2*);

--- a/tests/expectations/mod_2018.both.compat.c
+++ b/tests/expectations/mod_2018.both.compat.c
@@ -9,11 +9,17 @@ typedef struct ExportMe {
   uint64_t val;
 } ExportMe;
 
+typedef struct ExportMe2 {
+  uint64_t val;
+} ExportMe2;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
 void export_me(struct ExportMe *val);
+
+void export_me_2(struct ExportMe2*);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/mod_2018.c
+++ b/tests/expectations/mod_2018.c
@@ -9,4 +9,10 @@ typedef struct {
   uint64_t val;
 } ExportMe;
 
+typedef struct {
+  uint64_t val;
+} ExportMe2;
+
 void export_me(ExportMe *val);
+
+void export_me_2(ExportMe2*);

--- a/tests/expectations/mod_2018.compat.c
+++ b/tests/expectations/mod_2018.compat.c
@@ -9,11 +9,17 @@ typedef struct {
   uint64_t val;
 } ExportMe;
 
+typedef struct {
+  uint64_t val;
+} ExportMe2;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
 void export_me(ExportMe *val);
+
+void export_me_2(ExportMe2*);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/mod_2018.cpp
+++ b/tests/expectations/mod_2018.cpp
@@ -10,8 +10,14 @@ struct ExportMe {
   uint64_t val;
 };
 
+struct ExportMe2 {
+  uint64_t val;
+};
+
 extern "C" {
 
 void export_me(ExportMe *val);
+
+void export_me_2(ExportMe2*);
 
 } // extern "C"

--- a/tests/expectations/mod_2018.pyx
+++ b/tests/expectations/mod_2018.pyx
@@ -11,4 +11,9 @@ cdef extern from *:
   ctypedef struct ExportMe:
     uint64_t val;
 
+  ctypedef struct ExportMe2:
+    uint64_t val;
+
   void export_me(ExportMe *val);
+
+  void export_me_2(ExportMe2*);

--- a/tests/expectations/mod_2018.tag.c
+++ b/tests/expectations/mod_2018.tag.c
@@ -9,4 +9,10 @@ struct ExportMe {
   uint64_t val;
 };
 
+struct ExportMe2 {
+  uint64_t val;
+};
+
 void export_me(struct ExportMe *val);
+
+void export_me_2(struct ExportMe2*);

--- a/tests/expectations/mod_2018.tag.compat.c
+++ b/tests/expectations/mod_2018.tag.compat.c
@@ -9,11 +9,17 @@ struct ExportMe {
   uint64_t val;
 };
 
+struct ExportMe2 {
+  uint64_t val;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
 void export_me(struct ExportMe *val);
+
+void export_me_2(struct ExportMe2*);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/mod_2018.tag.pyx
+++ b/tests/expectations/mod_2018.tag.pyx
@@ -11,4 +11,9 @@ cdef extern from *:
   cdef struct ExportMe:
     uint64_t val;
 
+  cdef struct ExportMe2:
+    uint64_t val;
+
   void export_me(ExportMe *val);
+
+  void export_me_2(ExportMe2*);

--- a/tests/rust/mod_2018/src/nested.rs
+++ b/tests/rust/mod_2018/src/nested.rs
@@ -1,1 +1,4 @@
 pub mod other;
+
+#[path = "other2.rs"]
+pub mod other2;

--- a/tests/rust/mod_2018/src/other2.rs
+++ b/tests/rust/mod_2018/src/other2.rs
@@ -1,0 +1,7 @@
+#[repr(C)]
+pub struct ExportMe2 {
+    val: u64
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn export_me_2(_: *mut ExportMe2) { }


### PR DESCRIPTION
We need the current mod dir to resolve #[path], not the one we get for
rust 2018.

Fixes #599