### PR TITLE
enum: Support inlined definitions for tuple variants with a single field

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -27,7 +27,13 @@ pub enum VariantBody {
         name: String,
         /// The struct with all the items.
         body: Struct,
+        /// A separate named struct is not created for this variant,
+        /// an unnamed struct is inlined at the point of use instead.
+        /// This is a reasonable thing to do only for tuple variants with a single field.
+        inline: bool,
         /// Generated cast methods return the variant's only field instead of the variant itself.
+        /// For backward compatibility casts are inlined in a slightly
+        /// larger set of cases than whole variants.
         inline_casts: bool,
     },
 }
@@ -62,10 +68,12 @@ impl VariantBody {
             Self::Body {
                 ref name,
                 ref body,
+                inline,
                 inline_casts,
             } => Self::Body {
                 name: name.clone(),
                 body: body.specialize(generic_values, mappings, config),
+                inline,
                 inline_casts,
             },
         }
@@ -90,6 +98,7 @@ impl EnumVariant {
         mod_cfg: Option<&Cfg>,
         self_path: &Path,
         enum_annotations: &AnnotationSet,
+        config: &Config,
     ) -> Result<Self, String> {
         let discriminant = match variant.discriminant {
             Some((_, ref expr)) => Some(Literal::load(expr)?),
@@ -100,12 +109,13 @@ impl EnumVariant {
             inline_tag_field: bool,
             fields: &syn::punctuated::Punctuated<syn::Field, syn::token::Comma>,
             self_path: &Path,
+            inline_name: Option<&str>,
         ) -> Result<Vec<Field>, String> {
             let mut res = Vec::new();
 
             if inline_tag_field {
                 res.push(Field::from_name_and_type(
-                    "tag".to_string(),
+                    inline_name.map_or_else(|| "tag".to_string(), |name| format!("{}_tag", name)),
                     Type::Path(GenericPath::new(Path::new("Tag"), vec![])),
                 ));
             }
@@ -114,10 +124,13 @@ impl EnumVariant {
                 if let Some(mut ty) = Type::load(&field.ty)? {
                     ty.replace_self_with(self_path);
                     res.push(Field {
-                        name: match field.ident {
-                            Some(ref ident) => ident.to_string(),
-                            None => i.to_string(),
-                        },
+                        name: inline_name.map_or_else(
+                            || match field.ident {
+                                Some(ref ident) => ident.to_string(),
+                                None => i.to_string(),
+                            },
+                            |name| name.to_string(),
+                        ),
                         ty,
                         cfg: Cfg::load(&field.attrs),
                         annotations: AnnotationSet::load(&field.attrs)?,
@@ -142,11 +155,10 @@ impl EnumVariant {
                     .apply(&variant.ident.to_string(), IdentifierType::StructMember)
                     .into_owned();
                 VariantBody::Body {
-                    name,
                     body: Struct::new(
                         path,
                         generic_params,
-                        parse_fields(inline_tag_field, &fields.named, self_path)?,
+                        parse_fields(inline_tag_field, &fields.named, self_path, None)?,
                         inline_tag_field,
                         true,
                         None,
@@ -155,6 +167,8 @@ impl EnumVariant {
                         annotations,
                         Documentation::none(),
                     ),
+                    name,
+                    inline: false,
                     inline_casts: false,
                 }
             }
@@ -163,12 +177,19 @@ impl EnumVariant {
                 let name = RenameRule::SnakeCase
                     .apply(&variant.ident.to_string(), IdentifierType::StructMember)
                     .into_owned();
+                let inline_casts = fields.unnamed.len() == 1;
+                // In C++ types with destructors cannot be put into unnamed structs like the
+                // inlining requires, and it's hard to detect such types.
+                // Besides that for C++ we generate casts/getters that can be used instead of
+                // direct field accesses and also have a benefit of being checked.
+                // As a result we don't currently inline variant definitions in C++ mode at all.
+                let inline = inline_casts && config.language != Language::Cxx;
+                let inline_name = if inline { Some(&*name) } else { None };
                 VariantBody::Body {
-                    name,
                     body: Struct::new(
                         path,
                         generic_params,
-                        parse_fields(inline_tag_field, &fields.unnamed, self_path)?,
+                        parse_fields(inline_tag_field, &fields.unnamed, self_path, inline_name)?,
                         inline_tag_field,
                         true,
                         None,
@@ -177,7 +198,9 @@ impl EnumVariant {
                         annotations,
                         Documentation::none(),
                     ),
-                    inline_casts: fields.unnamed.len() == 1,
+                    name,
+                    inline,
+                    inline_casts,
                 }
             }
         };
@@ -355,6 +378,7 @@ impl Enum {
                 mod_cfg,
                 &path,
                 &annotations,
+                config,
             )?;
             has_data = has_data || !variant.body.is_empty();
             variants.push(variant);
@@ -531,10 +555,12 @@ impl Item for Enum {
                             VariantBody::Body {
                                 ref name,
                                 ref body,
+                                inline,
                                 inline_casts,
                             } => VariantBody::Body {
                                 name: r.apply(&name, IdentifierType::StructMember).into_owned(),
                                 body: body.clone(),
+                                inline,
                                 inline_casts,
                             },
                         },
@@ -836,7 +862,12 @@ impl Enum {
     /// Emit struct definitions for variants having data.
     fn write_variant_defs<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         for variant in &self.variants {
-            if let VariantBody::Body { ref body, .. } = variant.body {
+            if let VariantBody::Body {
+                ref body,
+                inline: false,
+                ..
+            } = variant.body
+            {
                 out.new_line();
                 out.new_line();
                 let condition = variant.cfg.to_condition(config);
@@ -888,7 +919,10 @@ impl Enum {
     fn write_variant_fields<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
         let mut first = true;
         for variant in &self.variants {
-            if let VariantBody::Body { name, body, .. } = &variant.body {
+            if let VariantBody::Body {
+                name, body, inline, ..
+            } = &variant.body
+            {
                 if !first {
                     out.new_line();
                 }
@@ -898,7 +932,21 @@ impl Enum {
                 if config.language != Language::Cython {
                     condition.write_before(config, out);
                 }
-                if config.style.generate_typedef() || config.language == Language::Cython {
+                if *inline {
+                    // Write definition of an inlined variant with data.
+                    // Cython extern declarations don't manage layouts, layouts are defined entierly
+                    // by the corresponding C code. So we can inline the unnamed struct and get the
+                    // same observable result. Moreother we have to do it because Cython doesn't
+                    // support unnamed structs.
+                    if config.language != Language::Cython {
+                        out.write("struct");
+                        out.open_brace();
+                    }
+                    out.write_vertical_source_list(&body.fields, ListType::Cap(";"));
+                    if config.language != Language::Cython {
+                        out.close_brace(true);
+                    }
+                } else if config.style.generate_typedef() || config.language == Language::Cython {
                     write!(out, "{} {};", body.export_name(), name);
                 } else {
                     write!(out, "struct {} {};", body.export_name(), name);
@@ -1176,6 +1224,7 @@ impl Enum {
                             ref name,
                             ref body,
                             inline_casts,
+                            ..
                         } => (name, body, inline_casts),
                         VariantBody::Empty(..) => return,
                     };
@@ -1217,11 +1266,11 @@ impl Enum {
                     out.open_brace();
                     write!(out, "{}(Is{}());", assert_name, variant.export_name);
                     out.new_line();
+                    write!(out, "return {}", member_name);
                     if inline_casts {
-                        write!(out, "return {}._0;", member_name);
-                    } else {
-                        write!(out, "return {};", member_name);
+                        write!(out, "._0");
                     }
+                    write!(out, ";");
                     out.close_brace(false);
                 };
 

--- a/src/bindgen/writer.rs
+++ b/src/bindgen/writer.rs
@@ -176,9 +176,9 @@ impl<'a, F: Write> SourceWriter<'a, F> {
     }
 
     pub fn close_brace(&mut self, semicolon: bool) {
+        self.pop_tab();
         match self.bindings.config.language {
             Language::Cxx | Language::C => {
-                self.pop_tab();
                 self.new_line();
                 if semicolon {
                     self.write("};");
@@ -186,9 +186,7 @@ impl<'a, F: Write> SourceWriter<'a, F> {
                     self.write("}");
                 }
             }
-            Language::Cython => {
-                self.pop_tab();
-            }
+            Language::Cython => {}
         }
     }
 

--- a/tests/expectations/annotation.both.c
+++ b/tests/expectations/annotation.both.c
@@ -25,11 +25,6 @@ enum F_Tag {
 };
 typedef uint8_t F_Tag;
 
-typedef struct Foo_Body {
-  F_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
 typedef struct Bar_Body {
   F_Tag tag;
   uint8_t x;
@@ -38,7 +33,10 @@ typedef struct Bar_Body {
 
 typedef union F {
   F_Tag tag;
-  Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } F;
 
@@ -49,10 +47,6 @@ enum H_Tag {
 };
 typedef uint8_t H_Tag;
 
-typedef struct Hello_Body {
-  int16_t _0;
-} Hello_Body;
-
 typedef struct There_Body {
   uint8_t x;
   int16_t y;
@@ -61,7 +55,9 @@ typedef struct There_Body {
 typedef struct H {
   H_Tag tag;
   union {
-    Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     There_Body there;
   };
 } H;

--- a/tests/expectations/annotation.both.compat.c
+++ b/tests/expectations/annotation.both.compat.c
@@ -37,11 +37,6 @@ enum F_Tag
 typedef uint8_t F_Tag;
 #endif // __cplusplus
 
-typedef struct Foo_Body {
-  F_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
 typedef struct Bar_Body {
   F_Tag tag;
   uint8_t x;
@@ -50,7 +45,10 @@ typedef struct Bar_Body {
 
 typedef union F {
   F_Tag tag;
-  Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } F;
 
@@ -67,10 +65,6 @@ enum H_Tag
 typedef uint8_t H_Tag;
 #endif // __cplusplus
 
-typedef struct Hello_Body {
-  int16_t _0;
-} Hello_Body;
-
 typedef struct There_Body {
   uint8_t x;
   int16_t y;
@@ -79,7 +73,9 @@ typedef struct There_Body {
 typedef struct H {
   H_Tag tag;
   union {
-    Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     There_Body there;
   };
 } H;

--- a/tests/expectations/annotation.c
+++ b/tests/expectations/annotation.c
@@ -27,18 +27,16 @@ typedef uint8_t F_Tag;
 
 typedef struct {
   F_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
-typedef struct {
-  F_Tag tag;
   uint8_t x;
   int16_t y;
 } Bar_Body;
 
 typedef union {
   F_Tag tag;
-  Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } F;
 
@@ -50,10 +48,6 @@ enum H_Tag {
 typedef uint8_t H_Tag;
 
 typedef struct {
-  int16_t _0;
-} Hello_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } There_Body;
@@ -61,7 +55,9 @@ typedef struct {
 typedef struct {
   H_Tag tag;
   union {
-    Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     There_Body there;
   };
 } H;

--- a/tests/expectations/annotation.compat.c
+++ b/tests/expectations/annotation.compat.c
@@ -39,18 +39,16 @@ typedef uint8_t F_Tag;
 
 typedef struct {
   F_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
-typedef struct {
-  F_Tag tag;
   uint8_t x;
   int16_t y;
 } Bar_Body;
 
 typedef union {
   F_Tag tag;
-  Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } F;
 
@@ -68,10 +66,6 @@ typedef uint8_t H_Tag;
 #endif // __cplusplus
 
 typedef struct {
-  int16_t _0;
-} Hello_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } There_Body;
@@ -79,7 +73,9 @@ typedef struct {
 typedef struct {
   H_Tag tag;
   union {
-    Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     There_Body there;
   };
 } H;

--- a/tests/expectations/annotation.pyx
+++ b/tests/expectations/annotation.pyx
@@ -24,10 +24,6 @@ cdef extern from *:
     Baz,
   ctypedef uint8_t F_Tag;
 
-  ctypedef struct Foo_Body:
-    F_Tag tag;
-    int16_t _0;
-
   ctypedef struct Bar_Body:
     F_Tag tag;
     uint8_t x;
@@ -35,7 +31,8 @@ cdef extern from *:
 
   ctypedef union F:
     F_Tag tag;
-    Foo_Body foo;
+    F_Tag foo_tag;
+    int16_t foo;
     Bar_Body bar;
 
   cdef enum:
@@ -44,16 +41,13 @@ cdef extern from *:
     Everyone,
   ctypedef uint8_t H_Tag;
 
-  ctypedef struct Hello_Body:
-    int16_t _0;
-
   ctypedef struct There_Body:
     uint8_t x;
     int16_t y;
 
   ctypedef struct H:
     H_Tag tag;
-    Hello_Body hello;
+    int16_t hello;
     There_Body there;
 
   void root(A x, B y, C z, F f, H h);

--- a/tests/expectations/annotation.tag.c
+++ b/tests/expectations/annotation.tag.c
@@ -25,11 +25,6 @@ enum F_Tag {
 };
 typedef uint8_t F_Tag;
 
-struct Foo_Body {
-  F_Tag tag;
-  int16_t _0;
-};
-
 struct Bar_Body {
   F_Tag tag;
   uint8_t x;
@@ -38,7 +33,10 @@ struct Bar_Body {
 
 union F {
   F_Tag tag;
-  struct Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   struct Bar_Body bar;
 };
 
@@ -49,10 +47,6 @@ enum H_Tag {
 };
 typedef uint8_t H_Tag;
 
-struct Hello_Body {
-  int16_t _0;
-};
-
 struct There_Body {
   uint8_t x;
   int16_t y;
@@ -61,7 +55,9 @@ struct There_Body {
 struct H {
   H_Tag tag;
   union {
-    struct Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     struct There_Body there;
   };
 };

--- a/tests/expectations/annotation.tag.compat.c
+++ b/tests/expectations/annotation.tag.compat.c
@@ -37,11 +37,6 @@ enum F_Tag
 typedef uint8_t F_Tag;
 #endif // __cplusplus
 
-struct Foo_Body {
-  F_Tag tag;
-  int16_t _0;
-};
-
 struct Bar_Body {
   F_Tag tag;
   uint8_t x;
@@ -50,7 +45,10 @@ struct Bar_Body {
 
 union F {
   F_Tag tag;
-  struct Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   struct Bar_Body bar;
 };
 
@@ -67,10 +65,6 @@ enum H_Tag
 typedef uint8_t H_Tag;
 #endif // __cplusplus
 
-struct Hello_Body {
-  int16_t _0;
-};
-
 struct There_Body {
   uint8_t x;
   int16_t y;
@@ -79,7 +73,9 @@ struct There_Body {
 struct H {
   H_Tag tag;
   union {
-    struct Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     struct There_Body there;
   };
 };

--- a/tests/expectations/annotation.tag.pyx
+++ b/tests/expectations/annotation.tag.pyx
@@ -24,10 +24,6 @@ cdef extern from *:
     Baz,
   ctypedef uint8_t F_Tag;
 
-  cdef struct Foo_Body:
-    F_Tag tag;
-    int16_t _0;
-
   cdef struct Bar_Body:
     F_Tag tag;
     uint8_t x;
@@ -35,7 +31,8 @@ cdef extern from *:
 
   cdef union F:
     F_Tag tag;
-    Foo_Body foo;
+    F_Tag foo_tag;
+    int16_t foo;
     Bar_Body bar;
 
   cdef enum:
@@ -44,16 +41,13 @@ cdef extern from *:
     Everyone,
   ctypedef uint8_t H_Tag;
 
-  cdef struct Hello_Body:
-    int16_t _0;
-
   cdef struct There_Body:
     uint8_t x;
     int16_t y;
 
   cdef struct H:
     H_Tag tag;
-    Hello_Body hello;
+    int16_t hello;
     There_Body there;
 
   void root(A x, B y, C z, F f, H h);

--- a/tests/expectations/array.both.c
+++ b/tests/expectations/array.both.c
@@ -7,14 +7,12 @@ typedef enum Foo_Tag {
   A,
 } Foo_Tag;
 
-typedef struct A_Body {
-  float _0[20];
-} A_Body;
-
 typedef struct Foo {
   Foo_Tag tag;
   union {
-    A_Body a;
+    struct {
+      float a[20];
+    };
   };
 } Foo;
 

--- a/tests/expectations/array.both.compat.c
+++ b/tests/expectations/array.both.compat.c
@@ -7,14 +7,12 @@ typedef enum Foo_Tag {
   A,
 } Foo_Tag;
 
-typedef struct A_Body {
-  float _0[20];
-} A_Body;
-
 typedef struct Foo {
   Foo_Tag tag;
   union {
-    A_Body a;
+    struct {
+      float a[20];
+    };
   };
 } Foo;
 

--- a/tests/expectations/array.c
+++ b/tests/expectations/array.c
@@ -8,13 +8,11 @@ typedef enum {
 } Foo_Tag;
 
 typedef struct {
-  float _0[20];
-} A_Body;
-
-typedef struct {
   Foo_Tag tag;
   union {
-    A_Body a;
+    struct {
+      float a[20];
+    };
   };
 } Foo;
 

--- a/tests/expectations/array.compat.c
+++ b/tests/expectations/array.compat.c
@@ -8,13 +8,11 @@ typedef enum {
 } Foo_Tag;
 
 typedef struct {
-  float _0[20];
-} A_Body;
-
-typedef struct {
   Foo_Tag tag;
   union {
-    A_Body a;
+    struct {
+      float a[20];
+    };
   };
 } Foo;
 

--- a/tests/expectations/array.pyx
+++ b/tests/expectations/array.pyx
@@ -9,11 +9,8 @@ cdef extern from *:
   ctypedef enum Foo_Tag:
     A,
 
-  ctypedef struct A_Body:
-    float _0[20];
-
   ctypedef struct Foo:
     Foo_Tag tag;
-    A_Body a;
+    float a[20];
 
   void root(Foo a);

--- a/tests/expectations/array.tag.c
+++ b/tests/expectations/array.tag.c
@@ -7,14 +7,12 @@ enum Foo_Tag {
   A,
 };
 
-struct A_Body {
-  float _0[20];
-};
-
 struct Foo {
   enum Foo_Tag tag;
   union {
-    struct A_Body a;
+    struct {
+      float a[20];
+    };
   };
 };
 

--- a/tests/expectations/array.tag.compat.c
+++ b/tests/expectations/array.tag.compat.c
@@ -7,14 +7,12 @@ enum Foo_Tag {
   A,
 };
 
-struct A_Body {
-  float _0[20];
-};
-
 struct Foo {
   enum Foo_Tag tag;
   union {
-    struct A_Body a;
+    struct {
+      float a[20];
+    };
   };
 };
 

--- a/tests/expectations/array.tag.pyx
+++ b/tests/expectations/array.tag.pyx
@@ -9,11 +9,8 @@ cdef extern from *:
   cdef enum Foo_Tag:
     A,
 
-  cdef struct A_Body:
-    float _0[20];
-
   cdef struct Foo:
     Foo_Tag tag;
-    A_Body a;
+    float a[20];
 
   void root(Foo a);

--- a/tests/expectations/asserted_cast.both.c
+++ b/tests/expectations/asserted_cast.both.c
@@ -16,10 +16,6 @@ enum H_Tag {
 };
 typedef uint8_t H_Tag;
 
-typedef struct H_Foo_Body {
-  int16_t _0;
-} H_Foo_Body;
-
 typedef struct H_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -28,7 +24,9 @@ typedef struct H_Bar_Body {
 typedef struct H {
   H_Tag tag;
   union {
-    H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     H_Bar_Body bar;
   };
 } H;
@@ -40,10 +38,6 @@ enum J_Tag {
 };
 typedef uint8_t J_Tag;
 
-typedef struct J_Foo_Body {
-  int16_t _0;
-} J_Foo_Body;
-
 typedef struct J_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -52,7 +46,9 @@ typedef struct J_Bar_Body {
 typedef struct J {
   J_Tag tag;
   union {
-    J_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     J_Bar_Body bar;
   };
 } J;
@@ -64,11 +60,6 @@ enum K_Tag {
 };
 typedef uint8_t K_Tag;
 
-typedef struct K_Foo_Body {
-  K_Tag tag;
-  int16_t _0;
-} K_Foo_Body;
-
 typedef struct K_Bar_Body {
   K_Tag tag;
   uint8_t x;
@@ -77,7 +68,10 @@ typedef struct K_Bar_Body {
 
 typedef union K {
   K_Tag tag;
-  K_Foo_Body foo;
+  struct {
+    K_Tag foo_tag;
+    int16_t foo;
+  };
   K_Bar_Body bar;
 } K;
 

--- a/tests/expectations/asserted_cast.both.compat.c
+++ b/tests/expectations/asserted_cast.both.compat.c
@@ -22,10 +22,6 @@ enum H_Tag
 typedef uint8_t H_Tag;
 #endif // __cplusplus
 
-typedef struct H_Foo_Body {
-  int16_t _0;
-} H_Foo_Body;
-
 typedef struct H_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -34,7 +30,9 @@ typedef struct H_Bar_Body {
 typedef struct H {
   H_Tag tag;
   union {
-    H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     H_Bar_Body bar;
   };
 } H;
@@ -52,10 +50,6 @@ enum J_Tag
 typedef uint8_t J_Tag;
 #endif // __cplusplus
 
-typedef struct J_Foo_Body {
-  int16_t _0;
-} J_Foo_Body;
-
 typedef struct J_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -64,7 +58,9 @@ typedef struct J_Bar_Body {
 typedef struct J {
   J_Tag tag;
   union {
-    J_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     J_Bar_Body bar;
   };
 } J;
@@ -82,11 +78,6 @@ enum K_Tag
 typedef uint8_t K_Tag;
 #endif // __cplusplus
 
-typedef struct K_Foo_Body {
-  K_Tag tag;
-  int16_t _0;
-} K_Foo_Body;
-
 typedef struct K_Bar_Body {
   K_Tag tag;
   uint8_t x;
@@ -95,7 +86,10 @@ typedef struct K_Bar_Body {
 
 typedef union K {
   K_Tag tag;
-  K_Foo_Body foo;
+  struct {
+    K_Tag foo_tag;
+    int16_t foo;
+  };
   K_Bar_Body bar;
 } K;
 

--- a/tests/expectations/asserted_cast.c
+++ b/tests/expectations/asserted_cast.c
@@ -17,10 +17,6 @@ enum H_Tag {
 typedef uint8_t H_Tag;
 
 typedef struct {
-  int16_t _0;
-} H_Foo_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } H_Bar_Body;
@@ -28,7 +24,9 @@ typedef struct {
 typedef struct {
   H_Tag tag;
   union {
-    H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     H_Bar_Body bar;
   };
 } H;
@@ -41,10 +39,6 @@ enum J_Tag {
 typedef uint8_t J_Tag;
 
 typedef struct {
-  int16_t _0;
-} J_Foo_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } J_Bar_Body;
@@ -52,7 +46,9 @@ typedef struct {
 typedef struct {
   J_Tag tag;
   union {
-    J_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     J_Bar_Body bar;
   };
 } J;
@@ -66,18 +62,16 @@ typedef uint8_t K_Tag;
 
 typedef struct {
   K_Tag tag;
-  int16_t _0;
-} K_Foo_Body;
-
-typedef struct {
-  K_Tag tag;
   uint8_t x;
   int16_t y;
 } K_Bar_Body;
 
 typedef union {
   K_Tag tag;
-  K_Foo_Body foo;
+  struct {
+    K_Tag foo_tag;
+    int16_t foo;
+  };
   K_Bar_Body bar;
 } K;
 

--- a/tests/expectations/asserted_cast.compat.c
+++ b/tests/expectations/asserted_cast.compat.c
@@ -23,10 +23,6 @@ typedef uint8_t H_Tag;
 #endif // __cplusplus
 
 typedef struct {
-  int16_t _0;
-} H_Foo_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } H_Bar_Body;
@@ -34,7 +30,9 @@ typedef struct {
 typedef struct {
   H_Tag tag;
   union {
-    H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     H_Bar_Body bar;
   };
 } H;
@@ -53,10 +51,6 @@ typedef uint8_t J_Tag;
 #endif // __cplusplus
 
 typedef struct {
-  int16_t _0;
-} J_Foo_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } J_Bar_Body;
@@ -64,7 +58,9 @@ typedef struct {
 typedef struct {
   J_Tag tag;
   union {
-    J_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     J_Bar_Body bar;
   };
 } J;
@@ -84,18 +80,16 @@ typedef uint8_t K_Tag;
 
 typedef struct {
   K_Tag tag;
-  int16_t _0;
-} K_Foo_Body;
-
-typedef struct {
-  K_Tag tag;
   uint8_t x;
   int16_t y;
 } K_Bar_Body;
 
 typedef union {
   K_Tag tag;
-  K_Foo_Body foo;
+  struct {
+    K_Tag foo_tag;
+    int16_t foo;
+  };
   K_Bar_Body bar;
 } K;
 

--- a/tests/expectations/asserted_cast.pyx
+++ b/tests/expectations/asserted_cast.pyx
@@ -19,16 +19,13 @@ cdef extern from *:
     H_Baz,
   ctypedef uint8_t H_Tag;
 
-  ctypedef struct H_Foo_Body:
-    int16_t _0;
-
   ctypedef struct H_Bar_Body:
     uint8_t x;
     int16_t y;
 
   ctypedef struct H:
     H_Tag tag;
-    H_Foo_Body foo;
+    int16_t foo;
     H_Bar_Body bar;
 
   cdef enum:
@@ -37,16 +34,13 @@ cdef extern from *:
     J_Baz,
   ctypedef uint8_t J_Tag;
 
-  ctypedef struct J_Foo_Body:
-    int16_t _0;
-
   ctypedef struct J_Bar_Body:
     uint8_t x;
     int16_t y;
 
   ctypedef struct J:
     J_Tag tag;
-    J_Foo_Body foo;
+    int16_t foo;
     J_Bar_Body bar;
 
   cdef enum:
@@ -55,10 +49,6 @@ cdef extern from *:
     K_Baz,
   ctypedef uint8_t K_Tag;
 
-  ctypedef struct K_Foo_Body:
-    K_Tag tag;
-    int16_t _0;
-
   ctypedef struct K_Bar_Body:
     K_Tag tag;
     uint8_t x;
@@ -66,7 +56,8 @@ cdef extern from *:
 
   ctypedef union K:
     K_Tag tag;
-    K_Foo_Body foo;
+    K_Tag foo_tag;
+    int16_t foo;
     K_Bar_Body bar;
 
   void foo(H h, I i, J j, K k);

--- a/tests/expectations/asserted_cast.tag.c
+++ b/tests/expectations/asserted_cast.tag.c
@@ -16,10 +16,6 @@ enum H_Tag {
 };
 typedef uint8_t H_Tag;
 
-struct H_Foo_Body {
-  int16_t _0;
-};
-
 struct H_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -28,7 +24,9 @@ struct H_Bar_Body {
 struct H {
   H_Tag tag;
   union {
-    struct H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     struct H_Bar_Body bar;
   };
 };
@@ -40,10 +38,6 @@ enum J_Tag {
 };
 typedef uint8_t J_Tag;
 
-struct J_Foo_Body {
-  int16_t _0;
-};
-
 struct J_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -52,7 +46,9 @@ struct J_Bar_Body {
 struct J {
   J_Tag tag;
   union {
-    struct J_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     struct J_Bar_Body bar;
   };
 };
@@ -64,11 +60,6 @@ enum K_Tag {
 };
 typedef uint8_t K_Tag;
 
-struct K_Foo_Body {
-  K_Tag tag;
-  int16_t _0;
-};
-
 struct K_Bar_Body {
   K_Tag tag;
   uint8_t x;
@@ -77,7 +68,10 @@ struct K_Bar_Body {
 
 union K {
   K_Tag tag;
-  struct K_Foo_Body foo;
+  struct {
+    K_Tag foo_tag;
+    int16_t foo;
+  };
   struct K_Bar_Body bar;
 };
 

--- a/tests/expectations/asserted_cast.tag.compat.c
+++ b/tests/expectations/asserted_cast.tag.compat.c
@@ -22,10 +22,6 @@ enum H_Tag
 typedef uint8_t H_Tag;
 #endif // __cplusplus
 
-struct H_Foo_Body {
-  int16_t _0;
-};
-
 struct H_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -34,7 +30,9 @@ struct H_Bar_Body {
 struct H {
   H_Tag tag;
   union {
-    struct H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     struct H_Bar_Body bar;
   };
 };
@@ -52,10 +50,6 @@ enum J_Tag
 typedef uint8_t J_Tag;
 #endif // __cplusplus
 
-struct J_Foo_Body {
-  int16_t _0;
-};
-
 struct J_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -64,7 +58,9 @@ struct J_Bar_Body {
 struct J {
   J_Tag tag;
   union {
-    struct J_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     struct J_Bar_Body bar;
   };
 };
@@ -82,11 +78,6 @@ enum K_Tag
 typedef uint8_t K_Tag;
 #endif // __cplusplus
 
-struct K_Foo_Body {
-  K_Tag tag;
-  int16_t _0;
-};
-
 struct K_Bar_Body {
   K_Tag tag;
   uint8_t x;
@@ -95,7 +86,10 @@ struct K_Bar_Body {
 
 union K {
   K_Tag tag;
-  struct K_Foo_Body foo;
+  struct {
+    K_Tag foo_tag;
+    int16_t foo;
+  };
   struct K_Bar_Body bar;
 };
 

--- a/tests/expectations/asserted_cast.tag.pyx
+++ b/tests/expectations/asserted_cast.tag.pyx
@@ -19,16 +19,13 @@ cdef extern from *:
     H_Baz,
   ctypedef uint8_t H_Tag;
 
-  cdef struct H_Foo_Body:
-    int16_t _0;
-
   cdef struct H_Bar_Body:
     uint8_t x;
     int16_t y;
 
   cdef struct H:
     H_Tag tag;
-    H_Foo_Body foo;
+    int16_t foo;
     H_Bar_Body bar;
 
   cdef enum:
@@ -37,16 +34,13 @@ cdef extern from *:
     J_Baz,
   ctypedef uint8_t J_Tag;
 
-  cdef struct J_Foo_Body:
-    int16_t _0;
-
   cdef struct J_Bar_Body:
     uint8_t x;
     int16_t y;
 
   cdef struct J:
     J_Tag tag;
-    J_Foo_Body foo;
+    int16_t foo;
     J_Bar_Body bar;
 
   cdef enum:
@@ -55,10 +49,6 @@ cdef extern from *:
     K_Baz,
   ctypedef uint8_t K_Tag;
 
-  cdef struct K_Foo_Body:
-    K_Tag tag;
-    int16_t _0;
-
   cdef struct K_Bar_Body:
     K_Tag tag;
     uint8_t x;
@@ -66,7 +56,8 @@ cdef extern from *:
 
   cdef union K:
     K_Tag tag;
-    K_Foo_Body foo;
+    K_Tag foo_tag;
+    int16_t foo;
     K_Bar_Body bar;
 
   void foo(H h, I i, J j, K k);

--- a/tests/expectations/body.both.c
+++ b/tests/expectations/body.both.c
@@ -28,19 +28,15 @@ typedef enum MyFancyEnum_Tag {
   Baz,
 } MyFancyEnum_Tag;
 
-typedef struct Bar_Body {
-  int32_t _0;
-} Bar_Body;
-
-typedef struct Baz_Body {
-  int32_t _0;
-} Baz_Body;
-
 typedef struct MyFancyEnum {
   MyFancyEnum_Tag tag;
   union {
-    Bar_Body bar;
-    Baz_Body baz;
+    struct {
+      int32_t bar;
+    };
+    struct {
+      int32_t baz;
+    };
   };
 #ifdef __cplusplus
     inline void wohoo();
@@ -66,22 +62,18 @@ typedef enum MyFancyEnum_Prepended_Tag {
   Baz_Prepended,
 } MyFancyEnum_Prepended_Tag;
 
-typedef struct Bar_Prepended_Body {
-  int32_t _0;
-} Bar_Prepended_Body;
-
-typedef struct Baz_Prepended_Body {
-  int32_t _0;
-} Baz_Prepended_Body;
-
 typedef struct MyFancyEnum_Prepended {
 #ifdef __cplusplus
     inline void wohoo();
 #endif
   MyFancyEnum_Prepended_Tag tag;
   union {
-    Bar_Prepended_Body bar_prepended;
-    Baz_Prepended_Body baz_prepended;
+    struct {
+      int32_t bar_prepended;
+    };
+    struct {
+      int32_t baz_prepended;
+    };
   };
 } MyFancyEnum_Prepended;
 

--- a/tests/expectations/body.both.compat.c
+++ b/tests/expectations/body.both.compat.c
@@ -28,19 +28,15 @@ typedef enum MyFancyEnum_Tag {
   Baz,
 } MyFancyEnum_Tag;
 
-typedef struct Bar_Body {
-  int32_t _0;
-} Bar_Body;
-
-typedef struct Baz_Body {
-  int32_t _0;
-} Baz_Body;
-
 typedef struct MyFancyEnum {
   MyFancyEnum_Tag tag;
   union {
-    Bar_Body bar;
-    Baz_Body baz;
+    struct {
+      int32_t bar;
+    };
+    struct {
+      int32_t baz;
+    };
   };
 #ifdef __cplusplus
     inline void wohoo();
@@ -66,22 +62,18 @@ typedef enum MyFancyEnum_Prepended_Tag {
   Baz_Prepended,
 } MyFancyEnum_Prepended_Tag;
 
-typedef struct Bar_Prepended_Body {
-  int32_t _0;
-} Bar_Prepended_Body;
-
-typedef struct Baz_Prepended_Body {
-  int32_t _0;
-} Baz_Prepended_Body;
-
 typedef struct MyFancyEnum_Prepended {
 #ifdef __cplusplus
     inline void wohoo();
 #endif
   MyFancyEnum_Prepended_Tag tag;
   union {
-    Bar_Prepended_Body bar_prepended;
-    Baz_Prepended_Body baz_prepended;
+    struct {
+      int32_t bar_prepended;
+    };
+    struct {
+      int32_t baz_prepended;
+    };
   };
 } MyFancyEnum_Prepended;
 

--- a/tests/expectations/body.c
+++ b/tests/expectations/body.c
@@ -29,18 +29,14 @@ typedef enum {
 } MyFancyEnum_Tag;
 
 typedef struct {
-  int32_t _0;
-} Bar_Body;
-
-typedef struct {
-  int32_t _0;
-} Baz_Body;
-
-typedef struct {
   MyFancyEnum_Tag tag;
   union {
-    Bar_Body bar;
-    Baz_Body baz;
+    struct {
+      int32_t bar;
+    };
+    struct {
+      int32_t baz;
+    };
   };
 #ifdef __cplusplus
     inline void wohoo();
@@ -67,21 +63,17 @@ typedef enum {
 } MyFancyEnum_Prepended_Tag;
 
 typedef struct {
-  int32_t _0;
-} Bar_Prepended_Body;
-
-typedef struct {
-  int32_t _0;
-} Baz_Prepended_Body;
-
-typedef struct {
 #ifdef __cplusplus
     inline void wohoo();
 #endif
   MyFancyEnum_Prepended_Tag tag;
   union {
-    Bar_Prepended_Body bar_prepended;
-    Baz_Prepended_Body baz_prepended;
+    struct {
+      int32_t bar_prepended;
+    };
+    struct {
+      int32_t baz_prepended;
+    };
   };
 } MyFancyEnum_Prepended;
 

--- a/tests/expectations/body.compat.c
+++ b/tests/expectations/body.compat.c
@@ -29,18 +29,14 @@ typedef enum {
 } MyFancyEnum_Tag;
 
 typedef struct {
-  int32_t _0;
-} Bar_Body;
-
-typedef struct {
-  int32_t _0;
-} Baz_Body;
-
-typedef struct {
   MyFancyEnum_Tag tag;
   union {
-    Bar_Body bar;
-    Baz_Body baz;
+    struct {
+      int32_t bar;
+    };
+    struct {
+      int32_t baz;
+    };
   };
 #ifdef __cplusplus
     inline void wohoo();
@@ -67,21 +63,17 @@ typedef enum {
 } MyFancyEnum_Prepended_Tag;
 
 typedef struct {
-  int32_t _0;
-} Bar_Prepended_Body;
-
-typedef struct {
-  int32_t _0;
-} Baz_Prepended_Body;
-
-typedef struct {
 #ifdef __cplusplus
     inline void wohoo();
 #endif
   MyFancyEnum_Prepended_Tag tag;
   union {
-    Bar_Prepended_Body bar_prepended;
-    Baz_Prepended_Body baz_prepended;
+    struct {
+      int32_t bar_prepended;
+    };
+    struct {
+      int32_t baz_prepended;
+    };
   };
 } MyFancyEnum_Prepended;
 

--- a/tests/expectations/body.pyx
+++ b/tests/expectations/body.pyx
@@ -27,16 +27,10 @@ cdef extern from *:
     Bar,
     Baz,
 
-  ctypedef struct Bar_Body:
-    int32_t _0;
-
-  ctypedef struct Baz_Body:
-    int32_t _0;
-
   ctypedef struct MyFancyEnum:
     MyFancyEnum_Tag tag;
-    Bar_Body bar;
-    Baz_Body baz;
+    int32_t bar;
+    int32_t baz;
 #ifdef __cplusplus
     inline void wohoo();
 #endif
@@ -57,19 +51,13 @@ cdef extern from *:
     Bar_Prepended,
     Baz_Prepended,
 
-  ctypedef struct Bar_Prepended_Body:
-    int32_t _0;
-
-  ctypedef struct Baz_Prepended_Body:
-    int32_t _0;
-
   ctypedef struct MyFancyEnum_Prepended:
 #ifdef __cplusplus
     inline void wohoo();
 #endif
     MyFancyEnum_Prepended_Tag tag;
-    Bar_Prepended_Body bar_prepended;
-    Baz_Prepended_Body baz_prepended;
+    int32_t bar_prepended;
+    int32_t baz_prepended;
 
   ctypedef union MyUnion_Prepended:
     int32_t extra_member;

--- a/tests/expectations/body.tag.c
+++ b/tests/expectations/body.tag.c
@@ -28,19 +28,15 @@ enum MyFancyEnum_Tag {
   Baz,
 };
 
-struct Bar_Body {
-  int32_t _0;
-};
-
-struct Baz_Body {
-  int32_t _0;
-};
-
 struct MyFancyEnum {
   enum MyFancyEnum_Tag tag;
   union {
-    struct Bar_Body bar;
-    struct Baz_Body baz;
+    struct {
+      int32_t bar;
+    };
+    struct {
+      int32_t baz;
+    };
   };
 #ifdef __cplusplus
     inline void wohoo();
@@ -66,22 +62,18 @@ enum MyFancyEnum_Prepended_Tag {
   Baz_Prepended,
 };
 
-struct Bar_Prepended_Body {
-  int32_t _0;
-};
-
-struct Baz_Prepended_Body {
-  int32_t _0;
-};
-
 struct MyFancyEnum_Prepended {
 #ifdef __cplusplus
     inline void wohoo();
 #endif
   enum MyFancyEnum_Prepended_Tag tag;
   union {
-    struct Bar_Prepended_Body bar_prepended;
-    struct Baz_Prepended_Body baz_prepended;
+    struct {
+      int32_t bar_prepended;
+    };
+    struct {
+      int32_t baz_prepended;
+    };
   };
 };
 

--- a/tests/expectations/body.tag.compat.c
+++ b/tests/expectations/body.tag.compat.c
@@ -28,19 +28,15 @@ enum MyFancyEnum_Tag {
   Baz,
 };
 
-struct Bar_Body {
-  int32_t _0;
-};
-
-struct Baz_Body {
-  int32_t _0;
-};
-
 struct MyFancyEnum {
   enum MyFancyEnum_Tag tag;
   union {
-    struct Bar_Body bar;
-    struct Baz_Body baz;
+    struct {
+      int32_t bar;
+    };
+    struct {
+      int32_t baz;
+    };
   };
 #ifdef __cplusplus
     inline void wohoo();
@@ -66,22 +62,18 @@ enum MyFancyEnum_Prepended_Tag {
   Baz_Prepended,
 };
 
-struct Bar_Prepended_Body {
-  int32_t _0;
-};
-
-struct Baz_Prepended_Body {
-  int32_t _0;
-};
-
 struct MyFancyEnum_Prepended {
 #ifdef __cplusplus
     inline void wohoo();
 #endif
   enum MyFancyEnum_Prepended_Tag tag;
   union {
-    struct Bar_Prepended_Body bar_prepended;
-    struct Baz_Prepended_Body baz_prepended;
+    struct {
+      int32_t bar_prepended;
+    };
+    struct {
+      int32_t baz_prepended;
+    };
   };
 };
 

--- a/tests/expectations/body.tag.pyx
+++ b/tests/expectations/body.tag.pyx
@@ -27,16 +27,10 @@ cdef extern from *:
     Bar,
     Baz,
 
-  cdef struct Bar_Body:
-    int32_t _0;
-
-  cdef struct Baz_Body:
-    int32_t _0;
-
   cdef struct MyFancyEnum:
     MyFancyEnum_Tag tag;
-    Bar_Body bar;
-    Baz_Body baz;
+    int32_t bar;
+    int32_t baz;
 #ifdef __cplusplus
     inline void wohoo();
 #endif
@@ -57,19 +51,13 @@ cdef extern from *:
     Bar_Prepended,
     Baz_Prepended,
 
-  cdef struct Bar_Prepended_Body:
-    int32_t _0;
-
-  cdef struct Baz_Prepended_Body:
-    int32_t _0;
-
   cdef struct MyFancyEnum_Prepended:
 #ifdef __cplusplus
     inline void wohoo();
 #endif
     MyFancyEnum_Prepended_Tag tag;
-    Bar_Prepended_Body bar_prepended;
-    Baz_Prepended_Body baz_prepended;
+    int32_t bar_prepended;
+    int32_t baz_prepended;
 
   cdef union MyUnion_Prepended:
     int32_t extra_member;

--- a/tests/expectations/derive_ostream.both.c
+++ b/tests/expectations/derive_ostream.both.c
@@ -31,11 +31,6 @@ enum F_Tag {
 };
 typedef uint8_t F_Tag;
 
-typedef struct Foo_Body {
-  F_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
 typedef struct Bar_Body {
   F_Tag tag;
   uint8_t x;
@@ -44,7 +39,10 @@ typedef struct Bar_Body {
 
 typedef union F {
   F_Tag tag;
-  Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } F;
 
@@ -55,10 +53,6 @@ enum H_Tag {
 };
 typedef uint8_t H_Tag;
 
-typedef struct Hello_Body {
-  int16_t _0;
-} Hello_Body;
-
 typedef struct There_Body {
   uint8_t x;
   int16_t y;
@@ -67,7 +61,9 @@ typedef struct There_Body {
 typedef struct H {
   H_Tag tag;
   union {
-    Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     There_Body there;
   };
 } H;

--- a/tests/expectations/derive_ostream.both.compat.c
+++ b/tests/expectations/derive_ostream.both.compat.c
@@ -43,11 +43,6 @@ enum F_Tag
 typedef uint8_t F_Tag;
 #endif // __cplusplus
 
-typedef struct Foo_Body {
-  F_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
 typedef struct Bar_Body {
   F_Tag tag;
   uint8_t x;
@@ -56,7 +51,10 @@ typedef struct Bar_Body {
 
 typedef union F {
   F_Tag tag;
-  Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } F;
 
@@ -73,10 +71,6 @@ enum H_Tag
 typedef uint8_t H_Tag;
 #endif // __cplusplus
 
-typedef struct Hello_Body {
-  int16_t _0;
-} Hello_Body;
-
 typedef struct There_Body {
   uint8_t x;
   int16_t y;
@@ -85,7 +79,9 @@ typedef struct There_Body {
 typedef struct H {
   H_Tag tag;
   union {
-    Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     There_Body there;
   };
 } H;

--- a/tests/expectations/derive_ostream.c
+++ b/tests/expectations/derive_ostream.c
@@ -33,18 +33,16 @@ typedef uint8_t F_Tag;
 
 typedef struct {
   F_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
-typedef struct {
-  F_Tag tag;
   uint8_t x;
   int16_t y;
 } Bar_Body;
 
 typedef union {
   F_Tag tag;
-  Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } F;
 
@@ -56,10 +54,6 @@ enum H_Tag {
 typedef uint8_t H_Tag;
 
 typedef struct {
-  int16_t _0;
-} Hello_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } There_Body;
@@ -67,7 +61,9 @@ typedef struct {
 typedef struct {
   H_Tag tag;
   union {
-    Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     There_Body there;
   };
 } H;

--- a/tests/expectations/derive_ostream.compat.c
+++ b/tests/expectations/derive_ostream.compat.c
@@ -45,18 +45,16 @@ typedef uint8_t F_Tag;
 
 typedef struct {
   F_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
-typedef struct {
-  F_Tag tag;
   uint8_t x;
   int16_t y;
 } Bar_Body;
 
 typedef union {
   F_Tag tag;
-  Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } F;
 
@@ -74,10 +72,6 @@ typedef uint8_t H_Tag;
 #endif // __cplusplus
 
 typedef struct {
-  int16_t _0;
-} Hello_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } There_Body;
@@ -85,7 +79,9 @@ typedef struct {
 typedef struct {
   H_Tag tag;
   union {
-    Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     There_Body there;
   };
 } H;

--- a/tests/expectations/derive_ostream.pyx
+++ b/tests/expectations/derive_ostream.pyx
@@ -29,10 +29,6 @@ cdef extern from *:
     Baz,
   ctypedef uint8_t F_Tag;
 
-  ctypedef struct Foo_Body:
-    F_Tag tag;
-    int16_t _0;
-
   ctypedef struct Bar_Body:
     F_Tag tag;
     uint8_t x;
@@ -40,7 +36,8 @@ cdef extern from *:
 
   ctypedef union F:
     F_Tag tag;
-    Foo_Body foo;
+    F_Tag foo_tag;
+    int16_t foo;
     Bar_Body bar;
 
   cdef enum:
@@ -49,16 +46,13 @@ cdef extern from *:
     Everyone,
   ctypedef uint8_t H_Tag;
 
-  ctypedef struct Hello_Body:
-    int16_t _0;
-
   ctypedef struct There_Body:
     uint8_t x;
     int16_t y;
 
   ctypedef struct H:
     H_Tag tag;
-    Hello_Body hello;
+    int16_t hello;
     There_Body there;
 
   cdef enum:

--- a/tests/expectations/derive_ostream.tag.c
+++ b/tests/expectations/derive_ostream.tag.c
@@ -31,11 +31,6 @@ enum F_Tag {
 };
 typedef uint8_t F_Tag;
 
-struct Foo_Body {
-  F_Tag tag;
-  int16_t _0;
-};
-
 struct Bar_Body {
   F_Tag tag;
   uint8_t x;
@@ -44,7 +39,10 @@ struct Bar_Body {
 
 union F {
   F_Tag tag;
-  struct Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   struct Bar_Body bar;
 };
 
@@ -55,10 +53,6 @@ enum H_Tag {
 };
 typedef uint8_t H_Tag;
 
-struct Hello_Body {
-  int16_t _0;
-};
-
 struct There_Body {
   uint8_t x;
   int16_t y;
@@ -67,7 +61,9 @@ struct There_Body {
 struct H {
   H_Tag tag;
   union {
-    struct Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     struct There_Body there;
   };
 };

--- a/tests/expectations/derive_ostream.tag.compat.c
+++ b/tests/expectations/derive_ostream.tag.compat.c
@@ -43,11 +43,6 @@ enum F_Tag
 typedef uint8_t F_Tag;
 #endif // __cplusplus
 
-struct Foo_Body {
-  F_Tag tag;
-  int16_t _0;
-};
-
 struct Bar_Body {
   F_Tag tag;
   uint8_t x;
@@ -56,7 +51,10 @@ struct Bar_Body {
 
 union F {
   F_Tag tag;
-  struct Foo_Body foo;
+  struct {
+    F_Tag foo_tag;
+    int16_t foo;
+  };
   struct Bar_Body bar;
 };
 
@@ -73,10 +71,6 @@ enum H_Tag
 typedef uint8_t H_Tag;
 #endif // __cplusplus
 
-struct Hello_Body {
-  int16_t _0;
-};
-
 struct There_Body {
   uint8_t x;
   int16_t y;
@@ -85,7 +79,9 @@ struct There_Body {
 struct H {
   H_Tag tag;
   union {
-    struct Hello_Body hello;
+    struct {
+      int16_t hello;
+    };
     struct There_Body there;
   };
 };

--- a/tests/expectations/derive_ostream.tag.pyx
+++ b/tests/expectations/derive_ostream.tag.pyx
@@ -29,10 +29,6 @@ cdef extern from *:
     Baz,
   ctypedef uint8_t F_Tag;
 
-  cdef struct Foo_Body:
-    F_Tag tag;
-    int16_t _0;
-
   cdef struct Bar_Body:
     F_Tag tag;
     uint8_t x;
@@ -40,7 +36,8 @@ cdef extern from *:
 
   cdef union F:
     F_Tag tag;
-    Foo_Body foo;
+    F_Tag foo_tag;
+    int16_t foo;
     Bar_Body bar;
 
   cdef enum:
@@ -49,16 +46,13 @@ cdef extern from *:
     Everyone,
   ctypedef uint8_t H_Tag;
 
-  cdef struct Hello_Body:
-    int16_t _0;
-
   cdef struct There_Body:
     uint8_t x;
     int16_t y;
 
   cdef struct H:
     H_Tag tag;
-    Hello_Body hello;
+    int16_t hello;
     There_Body there;
 
   cdef enum:

--- a/tests/expectations/destructor_and_copy_ctor.both.c
+++ b/tests/expectations/destructor_and_copy_ctor.both.c
@@ -46,18 +46,6 @@ enum Foo_u32_Tag {
 };
 typedef uint8_t Foo_u32_Tag;
 
-typedef struct Polygon1_Body_u32 {
-  struct Polygon_u32 _0;
-} Polygon1_Body_u32;
-
-typedef struct Slice1_Body_u32 {
-  struct OwnedSlice_u32 _0;
-} Slice1_Body_u32;
-
-typedef struct Slice2_Body_u32 {
-  struct OwnedSlice_i32 _0;
-} Slice2_Body_u32;
-
 typedef struct Slice3_Body_u32 {
   FillRule fill;
   struct OwnedSlice_u32 coords;
@@ -71,9 +59,15 @@ typedef struct Slice4_Body_u32 {
 typedef struct Foo_u32 {
   Foo_u32_Tag tag;
   union {
-    Polygon1_Body_u32 polygon1;
-    Slice1_Body_u32 slice1;
-    Slice2_Body_u32 slice2;
+    struct {
+      struct Polygon_u32 polygon1;
+    };
+    struct {
+      struct OwnedSlice_u32 slice1;
+    };
+    struct {
+      struct OwnedSlice_i32 slice2;
+    };
     Slice3_Body_u32 slice3;
     Slice4_Body_u32 slice4;
   };
@@ -94,21 +88,6 @@ enum Baz_i32_Tag {
 };
 typedef uint8_t Baz_i32_Tag;
 
-typedef struct Polygon21_Body_i32 {
-  Baz_i32_Tag tag;
-  struct Polygon_i32 _0;
-} Polygon21_Body_i32;
-
-typedef struct Slice21_Body_i32 {
-  Baz_i32_Tag tag;
-  struct OwnedSlice_i32 _0;
-} Slice21_Body_i32;
-
-typedef struct Slice22_Body_i32 {
-  Baz_i32_Tag tag;
-  struct OwnedSlice_i32 _0;
-} Slice22_Body_i32;
-
 typedef struct Slice23_Body_i32 {
   Baz_i32_Tag tag;
   FillRule fill;
@@ -123,9 +102,18 @@ typedef struct Slice24_Body_i32 {
 
 typedef union Baz_i32 {
   Baz_i32_Tag tag;
-  Polygon21_Body_i32 polygon21;
-  Slice21_Body_i32 slice21;
-  Slice22_Body_i32 slice22;
+  struct {
+    Baz_i32_Tag polygon21_tag;
+    struct Polygon_i32 polygon21;
+  };
+  struct {
+    Baz_i32_Tag slice21_tag;
+    struct OwnedSlice_i32 slice21;
+  };
+  struct {
+    Baz_i32_Tag slice22_tag;
+    struct OwnedSlice_i32 slice22;
+  };
   Slice23_Body_i32 slice23;
   Slice24_Body_i32 slice24;
 } Baz_i32;
@@ -137,20 +125,16 @@ enum Taz_Tag {
 };
 typedef uint8_t Taz_Tag;
 
-typedef struct Taz1_Body {
-  Taz_Tag tag;
-  int32_t _0;
-} Taz1_Body;
-
-typedef struct Taz3_Body {
-  Taz_Tag tag;
-  struct OwnedSlice_i32 _0;
-} Taz3_Body;
-
 typedef union Taz {
   Taz_Tag tag;
-  Taz1_Body taz1;
-  Taz3_Body taz3;
+  struct {
+    Taz_Tag taz1_tag;
+    int32_t taz1;
+  };
+  struct {
+    Taz_Tag taz3_tag;
+    struct OwnedSlice_i32 taz3;
+  };
 } Taz;
 
 enum Tazz_Tag {
@@ -159,14 +143,12 @@ enum Tazz_Tag {
 };
 typedef uint8_t Tazz_Tag;
 
-typedef struct Taz2_Body {
-  Tazz_Tag tag;
-  int32_t _0;
-} Taz2_Body;
-
 typedef union Tazz {
   Tazz_Tag tag;
-  Taz2_Body taz2;
+  struct {
+    Tazz_Tag taz2_tag;
+    int32_t taz2;
+  };
 } Tazz;
 
 enum Tazzz_Tag {
@@ -175,14 +157,12 @@ enum Tazzz_Tag {
 };
 typedef uint8_t Tazzz_Tag;
 
-typedef struct Taz5_Body {
-  Tazzz_Tag tag;
-  int32_t _0;
-} Taz5_Body;
-
 typedef union Tazzz {
   Tazzz_Tag tag;
-  Taz5_Body taz5;
+  struct {
+    Tazzz_Tag taz5_tag;
+    int32_t taz5;
+  };
 } Tazzz;
 
 enum Tazzzz_Tag {
@@ -191,20 +171,16 @@ enum Tazzzz_Tag {
 };
 typedef uint8_t Tazzzz_Tag;
 
-typedef struct Taz6_Body {
-  Tazzzz_Tag tag;
-  int32_t _0;
-} Taz6_Body;
-
-typedef struct Taz7_Body {
-  Tazzzz_Tag tag;
-  uint32_t _0;
-} Taz7_Body;
-
 typedef union Tazzzz {
   Tazzzz_Tag tag;
-  Taz6_Body taz6;
-  Taz7_Body taz7;
+  struct {
+    Tazzzz_Tag taz6_tag;
+    int32_t taz6;
+  };
+  struct {
+    Tazzzz_Tag taz7_tag;
+    uint32_t taz7;
+  };
 } Tazzzz;
 
 enum Qux_Tag {
@@ -213,20 +189,16 @@ enum Qux_Tag {
 };
 typedef uint8_t Qux_Tag;
 
-typedef struct Qux1_Body {
-  Qux_Tag tag;
-  int32_t _0;
-} Qux1_Body;
-
-typedef struct Qux2_Body {
-  Qux_Tag tag;
-  uint32_t _0;
-} Qux2_Body;
-
 typedef union Qux {
   Qux_Tag tag;
-  Qux1_Body qux1;
-  Qux2_Body qux2;
+  struct {
+    Qux_Tag qux1_tag;
+    int32_t qux1;
+  };
+  struct {
+    Qux_Tag qux2_tag;
+    uint32_t qux2;
+  };
 } Qux;
 
 void root(const struct Foo_u32 *a,

--- a/tests/expectations/destructor_and_copy_ctor.both.compat.c
+++ b/tests/expectations/destructor_and_copy_ctor.both.compat.c
@@ -58,18 +58,6 @@ enum Foo_u32_Tag
 typedef uint8_t Foo_u32_Tag;
 #endif // __cplusplus
 
-typedef struct Polygon1_Body_u32 {
-  struct Polygon_u32 _0;
-} Polygon1_Body_u32;
-
-typedef struct Slice1_Body_u32 {
-  struct OwnedSlice_u32 _0;
-} Slice1_Body_u32;
-
-typedef struct Slice2_Body_u32 {
-  struct OwnedSlice_i32 _0;
-} Slice2_Body_u32;
-
 typedef struct Slice3_Body_u32 {
   FillRule fill;
   struct OwnedSlice_u32 coords;
@@ -83,9 +71,15 @@ typedef struct Slice4_Body_u32 {
 typedef struct Foo_u32 {
   Foo_u32_Tag tag;
   union {
-    Polygon1_Body_u32 polygon1;
-    Slice1_Body_u32 slice1;
-    Slice2_Body_u32 slice2;
+    struct {
+      struct Polygon_u32 polygon1;
+    };
+    struct {
+      struct OwnedSlice_u32 slice1;
+    };
+    struct {
+      struct OwnedSlice_i32 slice2;
+    };
     Slice3_Body_u32 slice3;
     Slice4_Body_u32 slice4;
   };
@@ -112,21 +106,6 @@ enum Baz_i32_Tag
 typedef uint8_t Baz_i32_Tag;
 #endif // __cplusplus
 
-typedef struct Polygon21_Body_i32 {
-  Baz_i32_Tag tag;
-  struct Polygon_i32 _0;
-} Polygon21_Body_i32;
-
-typedef struct Slice21_Body_i32 {
-  Baz_i32_Tag tag;
-  struct OwnedSlice_i32 _0;
-} Slice21_Body_i32;
-
-typedef struct Slice22_Body_i32 {
-  Baz_i32_Tag tag;
-  struct OwnedSlice_i32 _0;
-} Slice22_Body_i32;
-
 typedef struct Slice23_Body_i32 {
   Baz_i32_Tag tag;
   FillRule fill;
@@ -141,9 +120,18 @@ typedef struct Slice24_Body_i32 {
 
 typedef union Baz_i32 {
   Baz_i32_Tag tag;
-  Polygon21_Body_i32 polygon21;
-  Slice21_Body_i32 slice21;
-  Slice22_Body_i32 slice22;
+  struct {
+    Baz_i32_Tag polygon21_tag;
+    struct Polygon_i32 polygon21;
+  };
+  struct {
+    Baz_i32_Tag slice21_tag;
+    struct OwnedSlice_i32 slice21;
+  };
+  struct {
+    Baz_i32_Tag slice22_tag;
+    struct OwnedSlice_i32 slice22;
+  };
   Slice23_Body_i32 slice23;
   Slice24_Body_i32 slice24;
 } Baz_i32;
@@ -161,20 +149,16 @@ enum Taz_Tag
 typedef uint8_t Taz_Tag;
 #endif // __cplusplus
 
-typedef struct Taz1_Body {
-  Taz_Tag tag;
-  int32_t _0;
-} Taz1_Body;
-
-typedef struct Taz3_Body {
-  Taz_Tag tag;
-  struct OwnedSlice_i32 _0;
-} Taz3_Body;
-
 typedef union Taz {
   Taz_Tag tag;
-  Taz1_Body taz1;
-  Taz3_Body taz3;
+  struct {
+    Taz_Tag taz1_tag;
+    int32_t taz1;
+  };
+  struct {
+    Taz_Tag taz3_tag;
+    struct OwnedSlice_i32 taz3;
+  };
 } Taz;
 
 enum Tazz_Tag
@@ -189,14 +173,12 @@ enum Tazz_Tag
 typedef uint8_t Tazz_Tag;
 #endif // __cplusplus
 
-typedef struct Taz2_Body {
-  Tazz_Tag tag;
-  int32_t _0;
-} Taz2_Body;
-
 typedef union Tazz {
   Tazz_Tag tag;
-  Taz2_Body taz2;
+  struct {
+    Tazz_Tag taz2_tag;
+    int32_t taz2;
+  };
 } Tazz;
 
 enum Tazzz_Tag
@@ -211,14 +193,12 @@ enum Tazzz_Tag
 typedef uint8_t Tazzz_Tag;
 #endif // __cplusplus
 
-typedef struct Taz5_Body {
-  Tazzz_Tag tag;
-  int32_t _0;
-} Taz5_Body;
-
 typedef union Tazzz {
   Tazzz_Tag tag;
-  Taz5_Body taz5;
+  struct {
+    Tazzz_Tag taz5_tag;
+    int32_t taz5;
+  };
 } Tazzz;
 
 enum Tazzzz_Tag
@@ -233,20 +213,16 @@ enum Tazzzz_Tag
 typedef uint8_t Tazzzz_Tag;
 #endif // __cplusplus
 
-typedef struct Taz6_Body {
-  Tazzzz_Tag tag;
-  int32_t _0;
-} Taz6_Body;
-
-typedef struct Taz7_Body {
-  Tazzzz_Tag tag;
-  uint32_t _0;
-} Taz7_Body;
-
 typedef union Tazzzz {
   Tazzzz_Tag tag;
-  Taz6_Body taz6;
-  Taz7_Body taz7;
+  struct {
+    Tazzzz_Tag taz6_tag;
+    int32_t taz6;
+  };
+  struct {
+    Tazzzz_Tag taz7_tag;
+    uint32_t taz7;
+  };
 } Tazzzz;
 
 enum Qux_Tag
@@ -261,20 +237,16 @@ enum Qux_Tag
 typedef uint8_t Qux_Tag;
 #endif // __cplusplus
 
-typedef struct Qux1_Body {
-  Qux_Tag tag;
-  int32_t _0;
-} Qux1_Body;
-
-typedef struct Qux2_Body {
-  Qux_Tag tag;
-  uint32_t _0;
-} Qux2_Body;
-
 typedef union Qux {
   Qux_Tag tag;
-  Qux1_Body qux1;
-  Qux2_Body qux2;
+  struct {
+    Qux_Tag qux1_tag;
+    int32_t qux1;
+  };
+  struct {
+    Qux_Tag qux2_tag;
+    uint32_t qux2;
+  };
 } Qux;
 
 #ifdef __cplusplus

--- a/tests/expectations/destructor_and_copy_ctor.c
+++ b/tests/expectations/destructor_and_copy_ctor.c
@@ -47,18 +47,6 @@ enum Foo_u32_Tag {
 typedef uint8_t Foo_u32_Tag;
 
 typedef struct {
-  Polygon_u32 _0;
-} Polygon1_Body_u32;
-
-typedef struct {
-  OwnedSlice_u32 _0;
-} Slice1_Body_u32;
-
-typedef struct {
-  OwnedSlice_i32 _0;
-} Slice2_Body_u32;
-
-typedef struct {
   FillRule fill;
   OwnedSlice_u32 coords;
 } Slice3_Body_u32;
@@ -71,9 +59,15 @@ typedef struct {
 typedef struct {
   Foo_u32_Tag tag;
   union {
-    Polygon1_Body_u32 polygon1;
-    Slice1_Body_u32 slice1;
-    Slice2_Body_u32 slice2;
+    struct {
+      Polygon_u32 polygon1;
+    };
+    struct {
+      OwnedSlice_u32 slice1;
+    };
+    struct {
+      OwnedSlice_i32 slice2;
+    };
     Slice3_Body_u32 slice3;
     Slice4_Body_u32 slice4;
   };
@@ -96,21 +90,6 @@ typedef uint8_t Baz_i32_Tag;
 
 typedef struct {
   Baz_i32_Tag tag;
-  Polygon_i32 _0;
-} Polygon21_Body_i32;
-
-typedef struct {
-  Baz_i32_Tag tag;
-  OwnedSlice_i32 _0;
-} Slice21_Body_i32;
-
-typedef struct {
-  Baz_i32_Tag tag;
-  OwnedSlice_i32 _0;
-} Slice22_Body_i32;
-
-typedef struct {
-  Baz_i32_Tag tag;
   FillRule fill;
   OwnedSlice_i32 coords;
 } Slice23_Body_i32;
@@ -123,9 +102,18 @@ typedef struct {
 
 typedef union {
   Baz_i32_Tag tag;
-  Polygon21_Body_i32 polygon21;
-  Slice21_Body_i32 slice21;
-  Slice22_Body_i32 slice22;
+  struct {
+    Baz_i32_Tag polygon21_tag;
+    Polygon_i32 polygon21;
+  };
+  struct {
+    Baz_i32_Tag slice21_tag;
+    OwnedSlice_i32 slice21;
+  };
+  struct {
+    Baz_i32_Tag slice22_tag;
+    OwnedSlice_i32 slice22;
+  };
   Slice23_Body_i32 slice23;
   Slice24_Body_i32 slice24;
 } Baz_i32;
@@ -137,20 +125,16 @@ enum Taz_Tag {
 };
 typedef uint8_t Taz_Tag;
 
-typedef struct {
-  Taz_Tag tag;
-  int32_t _0;
-} Taz1_Body;
-
-typedef struct {
-  Taz_Tag tag;
-  OwnedSlice_i32 _0;
-} Taz3_Body;
-
 typedef union {
   Taz_Tag tag;
-  Taz1_Body taz1;
-  Taz3_Body taz3;
+  struct {
+    Taz_Tag taz1_tag;
+    int32_t taz1;
+  };
+  struct {
+    Taz_Tag taz3_tag;
+    OwnedSlice_i32 taz3;
+  };
 } Taz;
 
 enum Tazz_Tag {
@@ -159,14 +143,12 @@ enum Tazz_Tag {
 };
 typedef uint8_t Tazz_Tag;
 
-typedef struct {
-  Tazz_Tag tag;
-  int32_t _0;
-} Taz2_Body;
-
 typedef union {
   Tazz_Tag tag;
-  Taz2_Body taz2;
+  struct {
+    Tazz_Tag taz2_tag;
+    int32_t taz2;
+  };
 } Tazz;
 
 enum Tazzz_Tag {
@@ -175,14 +157,12 @@ enum Tazzz_Tag {
 };
 typedef uint8_t Tazzz_Tag;
 
-typedef struct {
-  Tazzz_Tag tag;
-  int32_t _0;
-} Taz5_Body;
-
 typedef union {
   Tazzz_Tag tag;
-  Taz5_Body taz5;
+  struct {
+    Tazzz_Tag taz5_tag;
+    int32_t taz5;
+  };
 } Tazzz;
 
 enum Tazzzz_Tag {
@@ -191,20 +171,16 @@ enum Tazzzz_Tag {
 };
 typedef uint8_t Tazzzz_Tag;
 
-typedef struct {
-  Tazzzz_Tag tag;
-  int32_t _0;
-} Taz6_Body;
-
-typedef struct {
-  Tazzzz_Tag tag;
-  uint32_t _0;
-} Taz7_Body;
-
 typedef union {
   Tazzzz_Tag tag;
-  Taz6_Body taz6;
-  Taz7_Body taz7;
+  struct {
+    Tazzzz_Tag taz6_tag;
+    int32_t taz6;
+  };
+  struct {
+    Tazzzz_Tag taz7_tag;
+    uint32_t taz7;
+  };
 } Tazzzz;
 
 enum Qux_Tag {
@@ -213,20 +189,16 @@ enum Qux_Tag {
 };
 typedef uint8_t Qux_Tag;
 
-typedef struct {
-  Qux_Tag tag;
-  int32_t _0;
-} Qux1_Body;
-
-typedef struct {
-  Qux_Tag tag;
-  uint32_t _0;
-} Qux2_Body;
-
 typedef union {
   Qux_Tag tag;
-  Qux1_Body qux1;
-  Qux2_Body qux2;
+  struct {
+    Qux_Tag qux1_tag;
+    int32_t qux1;
+  };
+  struct {
+    Qux_Tag qux2_tag;
+    uint32_t qux2;
+  };
 } Qux;
 
 void root(const Foo_u32 *a,

--- a/tests/expectations/destructor_and_copy_ctor.compat.c
+++ b/tests/expectations/destructor_and_copy_ctor.compat.c
@@ -59,18 +59,6 @@ typedef uint8_t Foo_u32_Tag;
 #endif // __cplusplus
 
 typedef struct {
-  Polygon_u32 _0;
-} Polygon1_Body_u32;
-
-typedef struct {
-  OwnedSlice_u32 _0;
-} Slice1_Body_u32;
-
-typedef struct {
-  OwnedSlice_i32 _0;
-} Slice2_Body_u32;
-
-typedef struct {
   FillRule fill;
   OwnedSlice_u32 coords;
 } Slice3_Body_u32;
@@ -83,9 +71,15 @@ typedef struct {
 typedef struct {
   Foo_u32_Tag tag;
   union {
-    Polygon1_Body_u32 polygon1;
-    Slice1_Body_u32 slice1;
-    Slice2_Body_u32 slice2;
+    struct {
+      Polygon_u32 polygon1;
+    };
+    struct {
+      OwnedSlice_u32 slice1;
+    };
+    struct {
+      OwnedSlice_i32 slice2;
+    };
     Slice3_Body_u32 slice3;
     Slice4_Body_u32 slice4;
   };
@@ -114,21 +108,6 @@ typedef uint8_t Baz_i32_Tag;
 
 typedef struct {
   Baz_i32_Tag tag;
-  Polygon_i32 _0;
-} Polygon21_Body_i32;
-
-typedef struct {
-  Baz_i32_Tag tag;
-  OwnedSlice_i32 _0;
-} Slice21_Body_i32;
-
-typedef struct {
-  Baz_i32_Tag tag;
-  OwnedSlice_i32 _0;
-} Slice22_Body_i32;
-
-typedef struct {
-  Baz_i32_Tag tag;
   FillRule fill;
   OwnedSlice_i32 coords;
 } Slice23_Body_i32;
@@ -141,9 +120,18 @@ typedef struct {
 
 typedef union {
   Baz_i32_Tag tag;
-  Polygon21_Body_i32 polygon21;
-  Slice21_Body_i32 slice21;
-  Slice22_Body_i32 slice22;
+  struct {
+    Baz_i32_Tag polygon21_tag;
+    Polygon_i32 polygon21;
+  };
+  struct {
+    Baz_i32_Tag slice21_tag;
+    OwnedSlice_i32 slice21;
+  };
+  struct {
+    Baz_i32_Tag slice22_tag;
+    OwnedSlice_i32 slice22;
+  };
   Slice23_Body_i32 slice23;
   Slice24_Body_i32 slice24;
 } Baz_i32;
@@ -161,20 +149,16 @@ enum Taz_Tag
 typedef uint8_t Taz_Tag;
 #endif // __cplusplus
 
-typedef struct {
-  Taz_Tag tag;
-  int32_t _0;
-} Taz1_Body;
-
-typedef struct {
-  Taz_Tag tag;
-  OwnedSlice_i32 _0;
-} Taz3_Body;
-
 typedef union {
   Taz_Tag tag;
-  Taz1_Body taz1;
-  Taz3_Body taz3;
+  struct {
+    Taz_Tag taz1_tag;
+    int32_t taz1;
+  };
+  struct {
+    Taz_Tag taz3_tag;
+    OwnedSlice_i32 taz3;
+  };
 } Taz;
 
 enum Tazz_Tag
@@ -189,14 +173,12 @@ enum Tazz_Tag
 typedef uint8_t Tazz_Tag;
 #endif // __cplusplus
 
-typedef struct {
-  Tazz_Tag tag;
-  int32_t _0;
-} Taz2_Body;
-
 typedef union {
   Tazz_Tag tag;
-  Taz2_Body taz2;
+  struct {
+    Tazz_Tag taz2_tag;
+    int32_t taz2;
+  };
 } Tazz;
 
 enum Tazzz_Tag
@@ -211,14 +193,12 @@ enum Tazzz_Tag
 typedef uint8_t Tazzz_Tag;
 #endif // __cplusplus
 
-typedef struct {
-  Tazzz_Tag tag;
-  int32_t _0;
-} Taz5_Body;
-
 typedef union {
   Tazzz_Tag tag;
-  Taz5_Body taz5;
+  struct {
+    Tazzz_Tag taz5_tag;
+    int32_t taz5;
+  };
 } Tazzz;
 
 enum Tazzzz_Tag
@@ -233,20 +213,16 @@ enum Tazzzz_Tag
 typedef uint8_t Tazzzz_Tag;
 #endif // __cplusplus
 
-typedef struct {
-  Tazzzz_Tag tag;
-  int32_t _0;
-} Taz6_Body;
-
-typedef struct {
-  Tazzzz_Tag tag;
-  uint32_t _0;
-} Taz7_Body;
-
 typedef union {
   Tazzzz_Tag tag;
-  Taz6_Body taz6;
-  Taz7_Body taz7;
+  struct {
+    Tazzzz_Tag taz6_tag;
+    int32_t taz6;
+  };
+  struct {
+    Tazzzz_Tag taz7_tag;
+    uint32_t taz7;
+  };
 } Tazzzz;
 
 enum Qux_Tag
@@ -261,20 +237,16 @@ enum Qux_Tag
 typedef uint8_t Qux_Tag;
 #endif // __cplusplus
 
-typedef struct {
-  Qux_Tag tag;
-  int32_t _0;
-} Qux1_Body;
-
-typedef struct {
-  Qux_Tag tag;
-  uint32_t _0;
-} Qux2_Body;
-
 typedef union {
   Qux_Tag tag;
-  Qux1_Body qux1;
-  Qux2_Body qux2;
+  struct {
+    Qux_Tag qux1_tag;
+    int32_t qux1;
+  };
+  struct {
+    Qux_Tag qux2_tag;
+    uint32_t qux2;
+  };
 } Qux;
 
 #ifdef __cplusplus

--- a/tests/expectations/destructor_and_copy_ctor.pyx
+++ b/tests/expectations/destructor_and_copy_ctor.pyx
@@ -40,15 +40,6 @@ cdef extern from *:
     Slice4_u32,
   ctypedef uint8_t Foo_u32_Tag;
 
-  ctypedef struct Polygon1_Body_u32:
-    Polygon_u32 _0;
-
-  ctypedef struct Slice1_Body_u32:
-    OwnedSlice_u32 _0;
-
-  ctypedef struct Slice2_Body_u32:
-    OwnedSlice_i32 _0;
-
   ctypedef struct Slice3_Body_u32:
     FillRule fill;
     OwnedSlice_u32 coords;
@@ -59,9 +50,9 @@ cdef extern from *:
 
   ctypedef struct Foo_u32:
     Foo_u32_Tag tag;
-    Polygon1_Body_u32 polygon1;
-    Slice1_Body_u32 slice1;
-    Slice2_Body_u32 slice2;
+    Polygon_u32 polygon1;
+    OwnedSlice_u32 slice1;
+    OwnedSlice_i32 slice2;
     Slice3_Body_u32 slice3;
     Slice4_Body_u32 slice4;
 
@@ -78,18 +69,6 @@ cdef extern from *:
     Slice24_i32,
   ctypedef uint8_t Baz_i32_Tag;
 
-  ctypedef struct Polygon21_Body_i32:
-    Baz_i32_Tag tag;
-    Polygon_i32 _0;
-
-  ctypedef struct Slice21_Body_i32:
-    Baz_i32_Tag tag;
-    OwnedSlice_i32 _0;
-
-  ctypedef struct Slice22_Body_i32:
-    Baz_i32_Tag tag;
-    OwnedSlice_i32 _0;
-
   ctypedef struct Slice23_Body_i32:
     Baz_i32_Tag tag;
     FillRule fill;
@@ -102,9 +81,12 @@ cdef extern from *:
 
   ctypedef union Baz_i32:
     Baz_i32_Tag tag;
-    Polygon21_Body_i32 polygon21;
-    Slice21_Body_i32 slice21;
-    Slice22_Body_i32 slice22;
+    Baz_i32_Tag polygon21_tag;
+    Polygon_i32 polygon21;
+    Baz_i32_Tag slice21_tag;
+    OwnedSlice_i32 slice21;
+    Baz_i32_Tag slice22_tag;
+    OwnedSlice_i32 slice22;
     Slice23_Body_i32 slice23;
     Slice24_Body_i32 slice24;
 
@@ -114,80 +96,56 @@ cdef extern from *:
     Taz3,
   ctypedef uint8_t Taz_Tag;
 
-  ctypedef struct Taz1_Body:
-    Taz_Tag tag;
-    int32_t _0;
-
-  ctypedef struct Taz3_Body:
-    Taz_Tag tag;
-    OwnedSlice_i32 _0;
-
   ctypedef union Taz:
     Taz_Tag tag;
-    Taz1_Body taz1;
-    Taz3_Body taz3;
+    Taz_Tag taz1_tag;
+    int32_t taz1;
+    Taz_Tag taz3_tag;
+    OwnedSlice_i32 taz3;
 
   cdef enum:
     Bar4,
     Taz2,
   ctypedef uint8_t Tazz_Tag;
 
-  ctypedef struct Taz2_Body:
-    Tazz_Tag tag;
-    int32_t _0;
-
   ctypedef union Tazz:
     Tazz_Tag tag;
-    Taz2_Body taz2;
+    Tazz_Tag taz2_tag;
+    int32_t taz2;
 
   cdef enum:
     Bar5,
     Taz5,
   ctypedef uint8_t Tazzz_Tag;
 
-  ctypedef struct Taz5_Body:
-    Tazzz_Tag tag;
-    int32_t _0;
-
   ctypedef union Tazzz:
     Tazzz_Tag tag;
-    Taz5_Body taz5;
+    Tazzz_Tag taz5_tag;
+    int32_t taz5;
 
   cdef enum:
     Taz6,
     Taz7,
   ctypedef uint8_t Tazzzz_Tag;
 
-  ctypedef struct Taz6_Body:
-    Tazzzz_Tag tag;
-    int32_t _0;
-
-  ctypedef struct Taz7_Body:
-    Tazzzz_Tag tag;
-    uint32_t _0;
-
   ctypedef union Tazzzz:
     Tazzzz_Tag tag;
-    Taz6_Body taz6;
-    Taz7_Body taz7;
+    Tazzzz_Tag taz6_tag;
+    int32_t taz6;
+    Tazzzz_Tag taz7_tag;
+    uint32_t taz7;
 
   cdef enum:
     Qux1,
     Qux2,
   ctypedef uint8_t Qux_Tag;
 
-  ctypedef struct Qux1_Body:
-    Qux_Tag tag;
-    int32_t _0;
-
-  ctypedef struct Qux2_Body:
-    Qux_Tag tag;
-    uint32_t _0;
-
   ctypedef union Qux:
     Qux_Tag tag;
-    Qux1_Body qux1;
-    Qux2_Body qux2;
+    Qux_Tag qux1_tag;
+    int32_t qux1;
+    Qux_Tag qux2_tag;
+    uint32_t qux2;
 
   void root(const Foo_u32 *a,
             const Baz_i32 *b,

--- a/tests/expectations/destructor_and_copy_ctor.tag.c
+++ b/tests/expectations/destructor_and_copy_ctor.tag.c
@@ -46,18 +46,6 @@ enum Foo_u32_Tag {
 };
 typedef uint8_t Foo_u32_Tag;
 
-struct Polygon1_Body_u32 {
-  struct Polygon_u32 _0;
-};
-
-struct Slice1_Body_u32 {
-  struct OwnedSlice_u32 _0;
-};
-
-struct Slice2_Body_u32 {
-  struct OwnedSlice_i32 _0;
-};
-
 struct Slice3_Body_u32 {
   FillRule fill;
   struct OwnedSlice_u32 coords;
@@ -71,9 +59,15 @@ struct Slice4_Body_u32 {
 struct Foo_u32 {
   Foo_u32_Tag tag;
   union {
-    struct Polygon1_Body_u32 polygon1;
-    struct Slice1_Body_u32 slice1;
-    struct Slice2_Body_u32 slice2;
+    struct {
+      struct Polygon_u32 polygon1;
+    };
+    struct {
+      struct OwnedSlice_u32 slice1;
+    };
+    struct {
+      struct OwnedSlice_i32 slice2;
+    };
     struct Slice3_Body_u32 slice3;
     struct Slice4_Body_u32 slice4;
   };
@@ -94,21 +88,6 @@ enum Baz_i32_Tag {
 };
 typedef uint8_t Baz_i32_Tag;
 
-struct Polygon21_Body_i32 {
-  Baz_i32_Tag tag;
-  struct Polygon_i32 _0;
-};
-
-struct Slice21_Body_i32 {
-  Baz_i32_Tag tag;
-  struct OwnedSlice_i32 _0;
-};
-
-struct Slice22_Body_i32 {
-  Baz_i32_Tag tag;
-  struct OwnedSlice_i32 _0;
-};
-
 struct Slice23_Body_i32 {
   Baz_i32_Tag tag;
   FillRule fill;
@@ -123,9 +102,18 @@ struct Slice24_Body_i32 {
 
 union Baz_i32 {
   Baz_i32_Tag tag;
-  struct Polygon21_Body_i32 polygon21;
-  struct Slice21_Body_i32 slice21;
-  struct Slice22_Body_i32 slice22;
+  struct {
+    Baz_i32_Tag polygon21_tag;
+    struct Polygon_i32 polygon21;
+  };
+  struct {
+    Baz_i32_Tag slice21_tag;
+    struct OwnedSlice_i32 slice21;
+  };
+  struct {
+    Baz_i32_Tag slice22_tag;
+    struct OwnedSlice_i32 slice22;
+  };
   struct Slice23_Body_i32 slice23;
   struct Slice24_Body_i32 slice24;
 };
@@ -137,20 +125,16 @@ enum Taz_Tag {
 };
 typedef uint8_t Taz_Tag;
 
-struct Taz1_Body {
-  Taz_Tag tag;
-  int32_t _0;
-};
-
-struct Taz3_Body {
-  Taz_Tag tag;
-  struct OwnedSlice_i32 _0;
-};
-
 union Taz {
   Taz_Tag tag;
-  struct Taz1_Body taz1;
-  struct Taz3_Body taz3;
+  struct {
+    Taz_Tag taz1_tag;
+    int32_t taz1;
+  };
+  struct {
+    Taz_Tag taz3_tag;
+    struct OwnedSlice_i32 taz3;
+  };
 };
 
 enum Tazz_Tag {
@@ -159,14 +143,12 @@ enum Tazz_Tag {
 };
 typedef uint8_t Tazz_Tag;
 
-struct Taz2_Body {
-  Tazz_Tag tag;
-  int32_t _0;
-};
-
 union Tazz {
   Tazz_Tag tag;
-  struct Taz2_Body taz2;
+  struct {
+    Tazz_Tag taz2_tag;
+    int32_t taz2;
+  };
 };
 
 enum Tazzz_Tag {
@@ -175,14 +157,12 @@ enum Tazzz_Tag {
 };
 typedef uint8_t Tazzz_Tag;
 
-struct Taz5_Body {
-  Tazzz_Tag tag;
-  int32_t _0;
-};
-
 union Tazzz {
   Tazzz_Tag tag;
-  struct Taz5_Body taz5;
+  struct {
+    Tazzz_Tag taz5_tag;
+    int32_t taz5;
+  };
 };
 
 enum Tazzzz_Tag {
@@ -191,20 +171,16 @@ enum Tazzzz_Tag {
 };
 typedef uint8_t Tazzzz_Tag;
 
-struct Taz6_Body {
-  Tazzzz_Tag tag;
-  int32_t _0;
-};
-
-struct Taz7_Body {
-  Tazzzz_Tag tag;
-  uint32_t _0;
-};
-
 union Tazzzz {
   Tazzzz_Tag tag;
-  struct Taz6_Body taz6;
-  struct Taz7_Body taz7;
+  struct {
+    Tazzzz_Tag taz6_tag;
+    int32_t taz6;
+  };
+  struct {
+    Tazzzz_Tag taz7_tag;
+    uint32_t taz7;
+  };
 };
 
 enum Qux_Tag {
@@ -213,20 +189,16 @@ enum Qux_Tag {
 };
 typedef uint8_t Qux_Tag;
 
-struct Qux1_Body {
-  Qux_Tag tag;
-  int32_t _0;
-};
-
-struct Qux2_Body {
-  Qux_Tag tag;
-  uint32_t _0;
-};
-
 union Qux {
   Qux_Tag tag;
-  struct Qux1_Body qux1;
-  struct Qux2_Body qux2;
+  struct {
+    Qux_Tag qux1_tag;
+    int32_t qux1;
+  };
+  struct {
+    Qux_Tag qux2_tag;
+    uint32_t qux2;
+  };
 };
 
 void root(const struct Foo_u32 *a,

--- a/tests/expectations/destructor_and_copy_ctor.tag.compat.c
+++ b/tests/expectations/destructor_and_copy_ctor.tag.compat.c
@@ -58,18 +58,6 @@ enum Foo_u32_Tag
 typedef uint8_t Foo_u32_Tag;
 #endif // __cplusplus
 
-struct Polygon1_Body_u32 {
-  struct Polygon_u32 _0;
-};
-
-struct Slice1_Body_u32 {
-  struct OwnedSlice_u32 _0;
-};
-
-struct Slice2_Body_u32 {
-  struct OwnedSlice_i32 _0;
-};
-
 struct Slice3_Body_u32 {
   FillRule fill;
   struct OwnedSlice_u32 coords;
@@ -83,9 +71,15 @@ struct Slice4_Body_u32 {
 struct Foo_u32 {
   Foo_u32_Tag tag;
   union {
-    struct Polygon1_Body_u32 polygon1;
-    struct Slice1_Body_u32 slice1;
-    struct Slice2_Body_u32 slice2;
+    struct {
+      struct Polygon_u32 polygon1;
+    };
+    struct {
+      struct OwnedSlice_u32 slice1;
+    };
+    struct {
+      struct OwnedSlice_i32 slice2;
+    };
     struct Slice3_Body_u32 slice3;
     struct Slice4_Body_u32 slice4;
   };
@@ -112,21 +106,6 @@ enum Baz_i32_Tag
 typedef uint8_t Baz_i32_Tag;
 #endif // __cplusplus
 
-struct Polygon21_Body_i32 {
-  Baz_i32_Tag tag;
-  struct Polygon_i32 _0;
-};
-
-struct Slice21_Body_i32 {
-  Baz_i32_Tag tag;
-  struct OwnedSlice_i32 _0;
-};
-
-struct Slice22_Body_i32 {
-  Baz_i32_Tag tag;
-  struct OwnedSlice_i32 _0;
-};
-
 struct Slice23_Body_i32 {
   Baz_i32_Tag tag;
   FillRule fill;
@@ -141,9 +120,18 @@ struct Slice24_Body_i32 {
 
 union Baz_i32 {
   Baz_i32_Tag tag;
-  struct Polygon21_Body_i32 polygon21;
-  struct Slice21_Body_i32 slice21;
-  struct Slice22_Body_i32 slice22;
+  struct {
+    Baz_i32_Tag polygon21_tag;
+    struct Polygon_i32 polygon21;
+  };
+  struct {
+    Baz_i32_Tag slice21_tag;
+    struct OwnedSlice_i32 slice21;
+  };
+  struct {
+    Baz_i32_Tag slice22_tag;
+    struct OwnedSlice_i32 slice22;
+  };
   struct Slice23_Body_i32 slice23;
   struct Slice24_Body_i32 slice24;
 };
@@ -161,20 +149,16 @@ enum Taz_Tag
 typedef uint8_t Taz_Tag;
 #endif // __cplusplus
 
-struct Taz1_Body {
-  Taz_Tag tag;
-  int32_t _0;
-};
-
-struct Taz3_Body {
-  Taz_Tag tag;
-  struct OwnedSlice_i32 _0;
-};
-
 union Taz {
   Taz_Tag tag;
-  struct Taz1_Body taz1;
-  struct Taz3_Body taz3;
+  struct {
+    Taz_Tag taz1_tag;
+    int32_t taz1;
+  };
+  struct {
+    Taz_Tag taz3_tag;
+    struct OwnedSlice_i32 taz3;
+  };
 };
 
 enum Tazz_Tag
@@ -189,14 +173,12 @@ enum Tazz_Tag
 typedef uint8_t Tazz_Tag;
 #endif // __cplusplus
 
-struct Taz2_Body {
-  Tazz_Tag tag;
-  int32_t _0;
-};
-
 union Tazz {
   Tazz_Tag tag;
-  struct Taz2_Body taz2;
+  struct {
+    Tazz_Tag taz2_tag;
+    int32_t taz2;
+  };
 };
 
 enum Tazzz_Tag
@@ -211,14 +193,12 @@ enum Tazzz_Tag
 typedef uint8_t Tazzz_Tag;
 #endif // __cplusplus
 
-struct Taz5_Body {
-  Tazzz_Tag tag;
-  int32_t _0;
-};
-
 union Tazzz {
   Tazzz_Tag tag;
-  struct Taz5_Body taz5;
+  struct {
+    Tazzz_Tag taz5_tag;
+    int32_t taz5;
+  };
 };
 
 enum Tazzzz_Tag
@@ -233,20 +213,16 @@ enum Tazzzz_Tag
 typedef uint8_t Tazzzz_Tag;
 #endif // __cplusplus
 
-struct Taz6_Body {
-  Tazzzz_Tag tag;
-  int32_t _0;
-};
-
-struct Taz7_Body {
-  Tazzzz_Tag tag;
-  uint32_t _0;
-};
-
 union Tazzzz {
   Tazzzz_Tag tag;
-  struct Taz6_Body taz6;
-  struct Taz7_Body taz7;
+  struct {
+    Tazzzz_Tag taz6_tag;
+    int32_t taz6;
+  };
+  struct {
+    Tazzzz_Tag taz7_tag;
+    uint32_t taz7;
+  };
 };
 
 enum Qux_Tag
@@ -261,20 +237,16 @@ enum Qux_Tag
 typedef uint8_t Qux_Tag;
 #endif // __cplusplus
 
-struct Qux1_Body {
-  Qux_Tag tag;
-  int32_t _0;
-};
-
-struct Qux2_Body {
-  Qux_Tag tag;
-  uint32_t _0;
-};
-
 union Qux {
   Qux_Tag tag;
-  struct Qux1_Body qux1;
-  struct Qux2_Body qux2;
+  struct {
+    Qux_Tag qux1_tag;
+    int32_t qux1;
+  };
+  struct {
+    Qux_Tag qux2_tag;
+    uint32_t qux2;
+  };
 };
 
 #ifdef __cplusplus

--- a/tests/expectations/destructor_and_copy_ctor.tag.pyx
+++ b/tests/expectations/destructor_and_copy_ctor.tag.pyx
@@ -40,15 +40,6 @@ cdef extern from *:
     Slice4_u32,
   ctypedef uint8_t Foo_u32_Tag;
 
-  cdef struct Polygon1_Body_u32:
-    Polygon_u32 _0;
-
-  cdef struct Slice1_Body_u32:
-    OwnedSlice_u32 _0;
-
-  cdef struct Slice2_Body_u32:
-    OwnedSlice_i32 _0;
-
   cdef struct Slice3_Body_u32:
     FillRule fill;
     OwnedSlice_u32 coords;
@@ -59,9 +50,9 @@ cdef extern from *:
 
   cdef struct Foo_u32:
     Foo_u32_Tag tag;
-    Polygon1_Body_u32 polygon1;
-    Slice1_Body_u32 slice1;
-    Slice2_Body_u32 slice2;
+    Polygon_u32 polygon1;
+    OwnedSlice_u32 slice1;
+    OwnedSlice_i32 slice2;
     Slice3_Body_u32 slice3;
     Slice4_Body_u32 slice4;
 
@@ -78,18 +69,6 @@ cdef extern from *:
     Slice24_i32,
   ctypedef uint8_t Baz_i32_Tag;
 
-  cdef struct Polygon21_Body_i32:
-    Baz_i32_Tag tag;
-    Polygon_i32 _0;
-
-  cdef struct Slice21_Body_i32:
-    Baz_i32_Tag tag;
-    OwnedSlice_i32 _0;
-
-  cdef struct Slice22_Body_i32:
-    Baz_i32_Tag tag;
-    OwnedSlice_i32 _0;
-
   cdef struct Slice23_Body_i32:
     Baz_i32_Tag tag;
     FillRule fill;
@@ -102,9 +81,12 @@ cdef extern from *:
 
   cdef union Baz_i32:
     Baz_i32_Tag tag;
-    Polygon21_Body_i32 polygon21;
-    Slice21_Body_i32 slice21;
-    Slice22_Body_i32 slice22;
+    Baz_i32_Tag polygon21_tag;
+    Polygon_i32 polygon21;
+    Baz_i32_Tag slice21_tag;
+    OwnedSlice_i32 slice21;
+    Baz_i32_Tag slice22_tag;
+    OwnedSlice_i32 slice22;
     Slice23_Body_i32 slice23;
     Slice24_Body_i32 slice24;
 
@@ -114,80 +96,56 @@ cdef extern from *:
     Taz3,
   ctypedef uint8_t Taz_Tag;
 
-  cdef struct Taz1_Body:
-    Taz_Tag tag;
-    int32_t _0;
-
-  cdef struct Taz3_Body:
-    Taz_Tag tag;
-    OwnedSlice_i32 _0;
-
   cdef union Taz:
     Taz_Tag tag;
-    Taz1_Body taz1;
-    Taz3_Body taz3;
+    Taz_Tag taz1_tag;
+    int32_t taz1;
+    Taz_Tag taz3_tag;
+    OwnedSlice_i32 taz3;
 
   cdef enum:
     Bar4,
     Taz2,
   ctypedef uint8_t Tazz_Tag;
 
-  cdef struct Taz2_Body:
-    Tazz_Tag tag;
-    int32_t _0;
-
   cdef union Tazz:
     Tazz_Tag tag;
-    Taz2_Body taz2;
+    Tazz_Tag taz2_tag;
+    int32_t taz2;
 
   cdef enum:
     Bar5,
     Taz5,
   ctypedef uint8_t Tazzz_Tag;
 
-  cdef struct Taz5_Body:
-    Tazzz_Tag tag;
-    int32_t _0;
-
   cdef union Tazzz:
     Tazzz_Tag tag;
-    Taz5_Body taz5;
+    Tazzz_Tag taz5_tag;
+    int32_t taz5;
 
   cdef enum:
     Taz6,
     Taz7,
   ctypedef uint8_t Tazzzz_Tag;
 
-  cdef struct Taz6_Body:
-    Tazzzz_Tag tag;
-    int32_t _0;
-
-  cdef struct Taz7_Body:
-    Tazzzz_Tag tag;
-    uint32_t _0;
-
   cdef union Tazzzz:
     Tazzzz_Tag tag;
-    Taz6_Body taz6;
-    Taz7_Body taz7;
+    Tazzzz_Tag taz6_tag;
+    int32_t taz6;
+    Tazzzz_Tag taz7_tag;
+    uint32_t taz7;
 
   cdef enum:
     Qux1,
     Qux2,
   ctypedef uint8_t Qux_Tag;
 
-  cdef struct Qux1_Body:
-    Qux_Tag tag;
-    int32_t _0;
-
-  cdef struct Qux2_Body:
-    Qux_Tag tag;
-    uint32_t _0;
-
   cdef union Qux:
     Qux_Tag tag;
-    Qux1_Body qux1;
-    Qux2_Body qux2;
+    Qux_Tag qux1_tag;
+    int32_t qux1;
+    Qux_Tag qux2_tag;
+    uint32_t qux2;
 
   void root(const Foo_u32 *a,
             const Baz_i32 *b,

--- a/tests/expectations/enum.both.c
+++ b/tests/expectations/enum.both.c
@@ -93,11 +93,6 @@ enum G_Tag {
 };
 typedef uint8_t G_Tag;
 
-typedef struct Foo_Body {
-  G_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
 typedef struct Bar_Body {
   G_Tag tag;
   uint8_t x;
@@ -106,7 +101,10 @@ typedef struct Bar_Body {
 
 typedef union G {
   G_Tag tag;
-  Foo_Body foo;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } G;
 
@@ -116,10 +114,6 @@ typedef enum H_Tag {
   H_Baz,
 } H_Tag;
 
-typedef struct H_Foo_Body {
-  int16_t _0;
-} H_Foo_Body;
-
 typedef struct H_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -128,7 +122,9 @@ typedef struct H_Bar_Body {
 typedef struct H {
   H_Tag tag;
   union {
-    H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     H_Bar_Body bar;
   };
 } H;
@@ -140,10 +136,6 @@ enum I_Tag {
 };
 typedef uint8_t I_Tag;
 
-typedef struct I_Foo_Body {
-  int16_t _0;
-} I_Foo_Body;
-
 typedef struct I_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -152,7 +144,9 @@ typedef struct I_Bar_Body {
 typedef struct I {
   I_Tag tag;
   union {
-    I_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     I_Bar_Body bar;
   };
 } I;
@@ -163,10 +157,6 @@ enum P_Tag {
 };
 typedef uint8_t P_Tag;
 
-typedef struct P0_Body {
-  uint8_t _0;
-} P0_Body;
-
 typedef struct P1_Body {
   uint8_t _0;
   uint8_t _1;
@@ -176,7 +166,9 @@ typedef struct P1_Body {
 typedef struct P {
   P_Tag tag;
   union {
-    P0_Body p0;
+    struct {
+      uint8_t p0;
+    };
     P1_Body p1;
   };
 } P;

--- a/tests/expectations/enum.both.compat.c
+++ b/tests/expectations/enum.both.compat.c
@@ -147,11 +147,6 @@ enum G_Tag
 typedef uint8_t G_Tag;
 #endif // __cplusplus
 
-typedef struct Foo_Body {
-  G_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
 typedef struct Bar_Body {
   G_Tag tag;
   uint8_t x;
@@ -160,7 +155,10 @@ typedef struct Bar_Body {
 
 typedef union G {
   G_Tag tag;
-  Foo_Body foo;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } G;
 
@@ -170,10 +168,6 @@ typedef enum H_Tag {
   H_Baz,
 } H_Tag;
 
-typedef struct H_Foo_Body {
-  int16_t _0;
-} H_Foo_Body;
-
 typedef struct H_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -182,7 +176,9 @@ typedef struct H_Bar_Body {
 typedef struct H {
   H_Tag tag;
   union {
-    H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     H_Bar_Body bar;
   };
 } H;
@@ -200,10 +196,6 @@ enum I_Tag
 typedef uint8_t I_Tag;
 #endif // __cplusplus
 
-typedef struct I_Foo_Body {
-  int16_t _0;
-} I_Foo_Body;
-
 typedef struct I_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -212,7 +204,9 @@ typedef struct I_Bar_Body {
 typedef struct I {
   I_Tag tag;
   union {
-    I_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     I_Bar_Body bar;
   };
 } I;
@@ -229,10 +223,6 @@ enum P_Tag
 typedef uint8_t P_Tag;
 #endif // __cplusplus
 
-typedef struct P0_Body {
-  uint8_t _0;
-} P0_Body;
-
 typedef struct P1_Body {
   uint8_t _0;
   uint8_t _1;
@@ -242,7 +232,9 @@ typedef struct P1_Body {
 typedef struct P {
   P_Tag tag;
   union {
-    P0_Body p0;
+    struct {
+      uint8_t p0;
+    };
     P1_Body p1;
   };
 } P;

--- a/tests/expectations/enum.c
+++ b/tests/expectations/enum.c
@@ -95,18 +95,16 @@ typedef uint8_t G_Tag;
 
 typedef struct {
   G_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
-typedef struct {
-  G_Tag tag;
   uint8_t x;
   int16_t y;
 } Bar_Body;
 
 typedef union {
   G_Tag tag;
-  Foo_Body foo;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } G;
 
@@ -117,10 +115,6 @@ typedef enum {
 } H_Tag;
 
 typedef struct {
-  int16_t _0;
-} H_Foo_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } H_Bar_Body;
@@ -128,7 +122,9 @@ typedef struct {
 typedef struct {
   H_Tag tag;
   union {
-    H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     H_Bar_Body bar;
   };
 } H;
@@ -141,10 +137,6 @@ enum I_Tag {
 typedef uint8_t I_Tag;
 
 typedef struct {
-  int16_t _0;
-} I_Foo_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } I_Bar_Body;
@@ -152,7 +144,9 @@ typedef struct {
 typedef struct {
   I_Tag tag;
   union {
-    I_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     I_Bar_Body bar;
   };
 } I;
@@ -165,10 +159,6 @@ typedef uint8_t P_Tag;
 
 typedef struct {
   uint8_t _0;
-} P0_Body;
-
-typedef struct {
-  uint8_t _0;
   uint8_t _1;
   uint8_t _2;
 } P1_Body;
@@ -176,7 +166,9 @@ typedef struct {
 typedef struct {
   P_Tag tag;
   union {
-    P0_Body p0;
+    struct {
+      uint8_t p0;
+    };
     P1_Body p1;
   };
 } P;

--- a/tests/expectations/enum.compat.c
+++ b/tests/expectations/enum.compat.c
@@ -149,18 +149,16 @@ typedef uint8_t G_Tag;
 
 typedef struct {
   G_Tag tag;
-  int16_t _0;
-} Foo_Body;
-
-typedef struct {
-  G_Tag tag;
   uint8_t x;
   int16_t y;
 } Bar_Body;
 
 typedef union {
   G_Tag tag;
-  Foo_Body foo;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
   Bar_Body bar;
 } G;
 
@@ -171,10 +169,6 @@ typedef enum {
 } H_Tag;
 
 typedef struct {
-  int16_t _0;
-} H_Foo_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } H_Bar_Body;
@@ -182,7 +176,9 @@ typedef struct {
 typedef struct {
   H_Tag tag;
   union {
-    H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     H_Bar_Body bar;
   };
 } H;
@@ -201,10 +197,6 @@ typedef uint8_t I_Tag;
 #endif // __cplusplus
 
 typedef struct {
-  int16_t _0;
-} I_Foo_Body;
-
-typedef struct {
   uint8_t x;
   int16_t y;
 } I_Bar_Body;
@@ -212,7 +204,9 @@ typedef struct {
 typedef struct {
   I_Tag tag;
   union {
-    I_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     I_Bar_Body bar;
   };
 } I;
@@ -231,10 +225,6 @@ typedef uint8_t P_Tag;
 
 typedef struct {
   uint8_t _0;
-} P0_Body;
-
-typedef struct {
-  uint8_t _0;
   uint8_t _1;
   uint8_t _2;
 } P1_Body;
@@ -242,7 +232,9 @@ typedef struct {
 typedef struct {
   P_Tag tag;
   union {
-    P0_Body p0;
+    struct {
+      uint8_t p0;
+    };
     P1_Body p1;
   };
 } P;

--- a/tests/expectations/enum.pyx
+++ b/tests/expectations/enum.pyx
@@ -88,10 +88,6 @@ cdef extern from *:
     Baz,
   ctypedef uint8_t G_Tag;
 
-  ctypedef struct Foo_Body:
-    G_Tag tag;
-    int16_t _0;
-
   ctypedef struct Bar_Body:
     G_Tag tag;
     uint8_t x;
@@ -99,7 +95,8 @@ cdef extern from *:
 
   ctypedef union G:
     G_Tag tag;
-    Foo_Body foo;
+    G_Tag foo_tag;
+    int16_t foo;
     Bar_Body bar;
 
   ctypedef enum H_Tag:
@@ -107,16 +104,13 @@ cdef extern from *:
     H_Bar,
     H_Baz,
 
-  ctypedef struct H_Foo_Body:
-    int16_t _0;
-
   ctypedef struct H_Bar_Body:
     uint8_t x;
     int16_t y;
 
   ctypedef struct H:
     H_Tag tag;
-    H_Foo_Body foo;
+    int16_t foo;
     H_Bar_Body bar;
 
   cdef enum:
@@ -125,25 +119,19 @@ cdef extern from *:
     I_Baz,
   ctypedef uint8_t I_Tag;
 
-  ctypedef struct I_Foo_Body:
-    int16_t _0;
-
   ctypedef struct I_Bar_Body:
     uint8_t x;
     int16_t y;
 
   ctypedef struct I:
     I_Tag tag;
-    I_Foo_Body foo;
+    int16_t foo;
     I_Bar_Body bar;
 
   cdef enum:
     P0,
     P1,
   ctypedef uint8_t P_Tag;
-
-  ctypedef struct P0_Body:
-    uint8_t _0;
 
   ctypedef struct P1_Body:
     uint8_t _0;
@@ -152,7 +140,7 @@ cdef extern from *:
 
   ctypedef struct P:
     P_Tag tag;
-    P0_Body p0;
+    uint8_t p0;
     P1_Body p1;
 
   void root(Opaque *opaque,

--- a/tests/expectations/enum.tag.c
+++ b/tests/expectations/enum.tag.c
@@ -93,11 +93,6 @@ enum G_Tag {
 };
 typedef uint8_t G_Tag;
 
-struct Foo_Body {
-  G_Tag tag;
-  int16_t _0;
-};
-
 struct Bar_Body {
   G_Tag tag;
   uint8_t x;
@@ -106,7 +101,10 @@ struct Bar_Body {
 
 union G {
   G_Tag tag;
-  struct Foo_Body foo;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
   struct Bar_Body bar;
 };
 
@@ -114,10 +112,6 @@ enum H_Tag {
   H_Foo,
   H_Bar,
   H_Baz,
-};
-
-struct H_Foo_Body {
-  int16_t _0;
 };
 
 struct H_Bar_Body {
@@ -128,7 +122,9 @@ struct H_Bar_Body {
 struct H {
   enum H_Tag tag;
   union {
-    struct H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     struct H_Bar_Body bar;
   };
 };
@@ -140,10 +136,6 @@ enum I_Tag {
 };
 typedef uint8_t I_Tag;
 
-struct I_Foo_Body {
-  int16_t _0;
-};
-
 struct I_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -152,7 +144,9 @@ struct I_Bar_Body {
 struct I {
   I_Tag tag;
   union {
-    struct I_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     struct I_Bar_Body bar;
   };
 };
@@ -163,10 +157,6 @@ enum P_Tag {
 };
 typedef uint8_t P_Tag;
 
-struct P0_Body {
-  uint8_t _0;
-};
-
 struct P1_Body {
   uint8_t _0;
   uint8_t _1;
@@ -176,7 +166,9 @@ struct P1_Body {
 struct P {
   P_Tag tag;
   union {
-    struct P0_Body p0;
+    struct {
+      uint8_t p0;
+    };
     struct P1_Body p1;
   };
 };

--- a/tests/expectations/enum.tag.compat.c
+++ b/tests/expectations/enum.tag.compat.c
@@ -147,11 +147,6 @@ enum G_Tag
 typedef uint8_t G_Tag;
 #endif // __cplusplus
 
-struct Foo_Body {
-  G_Tag tag;
-  int16_t _0;
-};
-
 struct Bar_Body {
   G_Tag tag;
   uint8_t x;
@@ -160,7 +155,10 @@ struct Bar_Body {
 
 union G {
   G_Tag tag;
-  struct Foo_Body foo;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
   struct Bar_Body bar;
 };
 
@@ -168,10 +166,6 @@ enum H_Tag {
   H_Foo,
   H_Bar,
   H_Baz,
-};
-
-struct H_Foo_Body {
-  int16_t _0;
 };
 
 struct H_Bar_Body {
@@ -182,7 +176,9 @@ struct H_Bar_Body {
 struct H {
   enum H_Tag tag;
   union {
-    struct H_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     struct H_Bar_Body bar;
   };
 };
@@ -200,10 +196,6 @@ enum I_Tag
 typedef uint8_t I_Tag;
 #endif // __cplusplus
 
-struct I_Foo_Body {
-  int16_t _0;
-};
-
 struct I_Bar_Body {
   uint8_t x;
   int16_t y;
@@ -212,7 +204,9 @@ struct I_Bar_Body {
 struct I {
   I_Tag tag;
   union {
-    struct I_Foo_Body foo;
+    struct {
+      int16_t foo;
+    };
     struct I_Bar_Body bar;
   };
 };
@@ -229,10 +223,6 @@ enum P_Tag
 typedef uint8_t P_Tag;
 #endif // __cplusplus
 
-struct P0_Body {
-  uint8_t _0;
-};
-
 struct P1_Body {
   uint8_t _0;
   uint8_t _1;
@@ -242,7 +232,9 @@ struct P1_Body {
 struct P {
   P_Tag tag;
   union {
-    struct P0_Body p0;
+    struct {
+      uint8_t p0;
+    };
     struct P1_Body p1;
   };
 };

--- a/tests/expectations/enum.tag.pyx
+++ b/tests/expectations/enum.tag.pyx
@@ -88,10 +88,6 @@ cdef extern from *:
     Baz,
   ctypedef uint8_t G_Tag;
 
-  cdef struct Foo_Body:
-    G_Tag tag;
-    int16_t _0;
-
   cdef struct Bar_Body:
     G_Tag tag;
     uint8_t x;
@@ -99,7 +95,8 @@ cdef extern from *:
 
   cdef union G:
     G_Tag tag;
-    Foo_Body foo;
+    G_Tag foo_tag;
+    int16_t foo;
     Bar_Body bar;
 
   cdef enum H_Tag:
@@ -107,16 +104,13 @@ cdef extern from *:
     H_Bar,
     H_Baz,
 
-  cdef struct H_Foo_Body:
-    int16_t _0;
-
   cdef struct H_Bar_Body:
     uint8_t x;
     int16_t y;
 
   cdef struct H:
     H_Tag tag;
-    H_Foo_Body foo;
+    int16_t foo;
     H_Bar_Body bar;
 
   cdef enum:
@@ -125,25 +119,19 @@ cdef extern from *:
     I_Baz,
   ctypedef uint8_t I_Tag;
 
-  cdef struct I_Foo_Body:
-    int16_t _0;
-
   cdef struct I_Bar_Body:
     uint8_t x;
     int16_t y;
 
   cdef struct I:
     I_Tag tag;
-    I_Foo_Body foo;
+    int16_t foo;
     I_Bar_Body bar;
 
   cdef enum:
     P0,
     P1,
   ctypedef uint8_t P_Tag;
-
-  cdef struct P0_Body:
-    uint8_t _0;
 
   cdef struct P1_Body:
     uint8_t _0;
@@ -152,7 +140,7 @@ cdef extern from *:
 
   cdef struct P:
     P_Tag tag;
-    P0_Body p0;
+    uint8_t p0;
     P1_Body p1;
 
   void root(Opaque *opaque,

--- a/tests/expectations/enum_self.both.c
+++ b/tests/expectations/enum_self.both.c
@@ -14,20 +14,16 @@ enum Bar_Tag {
 };
 typedef uint8_t Bar_Tag;
 
-typedef struct Min_Body {
-  Bar_Tag tag;
-  struct Foo_Bar _0;
-} Min_Body;
-
-typedef struct Max_Body {
-  Bar_Tag tag;
-  struct Foo_Bar _0;
-} Max_Body;
-
 typedef union Bar {
   Bar_Tag tag;
-  Min_Body min;
-  Max_Body max;
+  struct {
+    Bar_Tag min_tag;
+    struct Foo_Bar min;
+  };
+  struct {
+    Bar_Tag max_tag;
+    struct Foo_Bar max;
+  };
 } Bar;
 
 void root(union Bar b);

--- a/tests/expectations/enum_self.both.compat.c
+++ b/tests/expectations/enum_self.both.compat.c
@@ -20,20 +20,16 @@ enum Bar_Tag
 typedef uint8_t Bar_Tag;
 #endif // __cplusplus
 
-typedef struct Min_Body {
-  Bar_Tag tag;
-  struct Foo_Bar _0;
-} Min_Body;
-
-typedef struct Max_Body {
-  Bar_Tag tag;
-  struct Foo_Bar _0;
-} Max_Body;
-
 typedef union Bar {
   Bar_Tag tag;
-  Min_Body min;
-  Max_Body max;
+  struct {
+    Bar_Tag min_tag;
+    struct Foo_Bar min;
+  };
+  struct {
+    Bar_Tag max_tag;
+    struct Foo_Bar max;
+  };
 } Bar;
 
 #ifdef __cplusplus

--- a/tests/expectations/enum_self.c
+++ b/tests/expectations/enum_self.c
@@ -14,20 +14,16 @@ enum Bar_Tag {
 };
 typedef uint8_t Bar_Tag;
 
-typedef struct {
-  Bar_Tag tag;
-  Foo_Bar _0;
-} Min_Body;
-
-typedef struct {
-  Bar_Tag tag;
-  Foo_Bar _0;
-} Max_Body;
-
 typedef union {
   Bar_Tag tag;
-  Min_Body min;
-  Max_Body max;
+  struct {
+    Bar_Tag min_tag;
+    Foo_Bar min;
+  };
+  struct {
+    Bar_Tag max_tag;
+    Foo_Bar max;
+  };
 } Bar;
 
 void root(Bar b);

--- a/tests/expectations/enum_self.compat.c
+++ b/tests/expectations/enum_self.compat.c
@@ -20,20 +20,16 @@ enum Bar_Tag
 typedef uint8_t Bar_Tag;
 #endif // __cplusplus
 
-typedef struct {
-  Bar_Tag tag;
-  Foo_Bar _0;
-} Min_Body;
-
-typedef struct {
-  Bar_Tag tag;
-  Foo_Bar _0;
-} Max_Body;
-
 typedef union {
   Bar_Tag tag;
-  Min_Body min;
-  Max_Body max;
+  struct {
+    Bar_Tag min_tag;
+    Foo_Bar min;
+  };
+  struct {
+    Bar_Tag max_tag;
+    Foo_Bar max;
+  };
 } Bar;
 
 #ifdef __cplusplus

--- a/tests/expectations/enum_self.pyx
+++ b/tests/expectations/enum_self.pyx
@@ -15,17 +15,11 @@ cdef extern from *:
     Other,
   ctypedef uint8_t Bar_Tag;
 
-  ctypedef struct Min_Body:
-    Bar_Tag tag;
-    Foo_Bar _0;
-
-  ctypedef struct Max_Body:
-    Bar_Tag tag;
-    Foo_Bar _0;
-
   ctypedef union Bar:
     Bar_Tag tag;
-    Min_Body min;
-    Max_Body max;
+    Bar_Tag min_tag;
+    Foo_Bar min;
+    Bar_Tag max_tag;
+    Foo_Bar max;
 
   void root(Bar b);

--- a/tests/expectations/enum_self.tag.c
+++ b/tests/expectations/enum_self.tag.c
@@ -14,20 +14,16 @@ enum Bar_Tag {
 };
 typedef uint8_t Bar_Tag;
 
-struct Min_Body {
-  Bar_Tag tag;
-  struct Foo_Bar _0;
-};
-
-struct Max_Body {
-  Bar_Tag tag;
-  struct Foo_Bar _0;
-};
-
 union Bar {
   Bar_Tag tag;
-  struct Min_Body min;
-  struct Max_Body max;
+  struct {
+    Bar_Tag min_tag;
+    struct Foo_Bar min;
+  };
+  struct {
+    Bar_Tag max_tag;
+    struct Foo_Bar max;
+  };
 };
 
 void root(union Bar b);

--- a/tests/expectations/enum_self.tag.compat.c
+++ b/tests/expectations/enum_self.tag.compat.c
@@ -20,20 +20,16 @@ enum Bar_Tag
 typedef uint8_t Bar_Tag;
 #endif // __cplusplus
 
-struct Min_Body {
-  Bar_Tag tag;
-  struct Foo_Bar _0;
-};
-
-struct Max_Body {
-  Bar_Tag tag;
-  struct Foo_Bar _0;
-};
-
 union Bar {
   Bar_Tag tag;
-  struct Min_Body min;
-  struct Max_Body max;
+  struct {
+    Bar_Tag min_tag;
+    struct Foo_Bar min;
+  };
+  struct {
+    Bar_Tag max_tag;
+    struct Foo_Bar max;
+  };
 };
 
 #ifdef __cplusplus

--- a/tests/expectations/enum_self.tag.pyx
+++ b/tests/expectations/enum_self.tag.pyx
@@ -15,17 +15,11 @@ cdef extern from *:
     Other,
   ctypedef uint8_t Bar_Tag;
 
-  cdef struct Min_Body:
-    Bar_Tag tag;
-    Foo_Bar _0;
-
-  cdef struct Max_Body:
-    Bar_Tag tag;
-    Foo_Bar _0;
-
   cdef union Bar:
     Bar_Tag tag;
-    Min_Body min;
-    Max_Body max;
+    Bar_Tag min_tag;
+    Foo_Bar min;
+    Bar_Tag max_tag;
+    Foo_Bar max;
 
   void root(Bar b);

--- a/tests/expectations/forward_declaration.both.c
+++ b/tests/expectations/forward_declaration.both.c
@@ -24,14 +24,12 @@ typedef enum TypeData_Tag {
   Struct,
 } TypeData_Tag;
 
-typedef struct Struct_Body {
-  struct StructInfo _0;
-} Struct_Body;
-
 typedef struct TypeData {
   TypeData_Tag tag;
   union {
-    Struct_Body struct_;
+    struct {
+      struct StructInfo struct_;
+    };
   };
 } TypeData;
 

--- a/tests/expectations/forward_declaration.both.compat.c
+++ b/tests/expectations/forward_declaration.both.compat.c
@@ -24,14 +24,12 @@ typedef enum TypeData_Tag {
   Struct,
 } TypeData_Tag;
 
-typedef struct Struct_Body {
-  struct StructInfo _0;
-} Struct_Body;
-
 typedef struct TypeData {
   TypeData_Tag tag;
   union {
-    Struct_Body struct_;
+    struct {
+      struct StructInfo struct_;
+    };
   };
 } TypeData;
 

--- a/tests/expectations/forward_declaration.c
+++ b/tests/expectations/forward_declaration.c
@@ -25,13 +25,11 @@ typedef enum {
 } TypeData_Tag;
 
 typedef struct {
-  StructInfo _0;
-} Struct_Body;
-
-typedef struct {
   TypeData_Tag tag;
   union {
-    Struct_Body struct_;
+    struct {
+      StructInfo struct_;
+    };
   };
 } TypeData;
 

--- a/tests/expectations/forward_declaration.compat.c
+++ b/tests/expectations/forward_declaration.compat.c
@@ -25,13 +25,11 @@ typedef enum {
 } TypeData_Tag;
 
 typedef struct {
-  StructInfo _0;
-} Struct_Body;
-
-typedef struct {
   TypeData_Tag tag;
   union {
-    Struct_Body struct_;
+    struct {
+      StructInfo struct_;
+    };
   };
 } TypeData;
 

--- a/tests/expectations/forward_declaration.pyx
+++ b/tests/expectations/forward_declaration.pyx
@@ -25,12 +25,9 @@ cdef extern from *:
     Primitive,
     Struct,
 
-  ctypedef struct Struct_Body:
-    StructInfo _0;
-
   ctypedef struct TypeData:
     TypeData_Tag tag;
-    Struct_Body struct_;
+    StructInfo struct_;
 
   ctypedef struct TypeInfo:
     TypeData data;

--- a/tests/expectations/forward_declaration.tag.c
+++ b/tests/expectations/forward_declaration.tag.c
@@ -24,14 +24,12 @@ enum TypeData_Tag {
   Struct,
 };
 
-struct Struct_Body {
-  struct StructInfo _0;
-};
-
 struct TypeData {
   enum TypeData_Tag tag;
   union {
-    struct Struct_Body struct_;
+    struct {
+      struct StructInfo struct_;
+    };
   };
 };
 

--- a/tests/expectations/forward_declaration.tag.compat.c
+++ b/tests/expectations/forward_declaration.tag.compat.c
@@ -24,14 +24,12 @@ enum TypeData_Tag {
   Struct,
 };
 
-struct Struct_Body {
-  struct StructInfo _0;
-};
-
 struct TypeData {
   enum TypeData_Tag tag;
   union {
-    struct Struct_Body struct_;
+    struct {
+      struct StructInfo struct_;
+    };
   };
 };
 

--- a/tests/expectations/forward_declaration.tag.pyx
+++ b/tests/expectations/forward_declaration.tag.pyx
@@ -25,12 +25,9 @@ cdef extern from *:
     Primitive,
     Struct,
 
-  cdef struct Struct_Body:
-    StructInfo _0;
-
   cdef struct TypeData:
     TypeData_Tag tag;
-    Struct_Body struct_;
+    StructInfo struct_;
 
   cdef struct TypeInfo:
     TypeData data;

--- a/tests/expectations/lifetime_arg.both.c
+++ b/tests/expectations/lifetime_arg.both.c
@@ -12,14 +12,12 @@ typedef enum E_Tag {
   U,
 } E_Tag;
 
-typedef struct U_Body {
-  const uint8_t *_0;
-} U_Body;
-
 typedef struct E {
   E_Tag tag;
   union {
-    U_Body u;
+    struct {
+      const uint8_t *u;
+    };
   };
 } E;
 

--- a/tests/expectations/lifetime_arg.both.compat.c
+++ b/tests/expectations/lifetime_arg.both.compat.c
@@ -12,14 +12,12 @@ typedef enum E_Tag {
   U,
 } E_Tag;
 
-typedef struct U_Body {
-  const uint8_t *_0;
-} U_Body;
-
 typedef struct E {
   E_Tag tag;
   union {
-    U_Body u;
+    struct {
+      const uint8_t *u;
+    };
   };
 } E;
 

--- a/tests/expectations/lifetime_arg.c
+++ b/tests/expectations/lifetime_arg.c
@@ -13,13 +13,11 @@ typedef enum {
 } E_Tag;
 
 typedef struct {
-  const uint8_t *_0;
-} U_Body;
-
-typedef struct {
   E_Tag tag;
   union {
-    U_Body u;
+    struct {
+      const uint8_t *u;
+    };
   };
 } E;
 

--- a/tests/expectations/lifetime_arg.compat.c
+++ b/tests/expectations/lifetime_arg.compat.c
@@ -13,13 +13,11 @@ typedef enum {
 } E_Tag;
 
 typedef struct {
-  const uint8_t *_0;
-} U_Body;
-
-typedef struct {
   E_Tag tag;
   union {
-    U_Body u;
+    struct {
+      const uint8_t *u;
+    };
   };
 } E;
 

--- a/tests/expectations/lifetime_arg.pyx
+++ b/tests/expectations/lifetime_arg.pyx
@@ -13,11 +13,8 @@ cdef extern from *:
     V,
     U,
 
-  ctypedef struct U_Body:
-    const uint8_t *_0;
-
   ctypedef struct E:
     E_Tag tag;
-    U_Body u;
+    const uint8_t *u;
 
   void root(A _a, E _e);

--- a/tests/expectations/lifetime_arg.tag.c
+++ b/tests/expectations/lifetime_arg.tag.c
@@ -12,14 +12,12 @@ enum E_Tag {
   U,
 };
 
-struct U_Body {
-  const uint8_t *_0;
-};
-
 struct E {
   enum E_Tag tag;
   union {
-    struct U_Body u;
+    struct {
+      const uint8_t *u;
+    };
   };
 };
 

--- a/tests/expectations/lifetime_arg.tag.compat.c
+++ b/tests/expectations/lifetime_arg.tag.compat.c
@@ -12,14 +12,12 @@ enum E_Tag {
   U,
 };
 
-struct U_Body {
-  const uint8_t *_0;
-};
-
 struct E {
   enum E_Tag tag;
   union {
-    struct U_Body u;
+    struct {
+      const uint8_t *u;
+    };
   };
 };
 

--- a/tests/expectations/lifetime_arg.tag.pyx
+++ b/tests/expectations/lifetime_arg.tag.pyx
@@ -13,11 +13,8 @@ cdef extern from *:
     V,
     U,
 
-  cdef struct U_Body:
-    const uint8_t *_0;
-
   cdef struct E:
     E_Tag tag;
-    U_Body u;
+    const uint8_t *u;
 
   void root(A _a, E _e);

--- a/tests/expectations/must_use.both.c
+++ b/tests/expectations/must_use.both.c
@@ -14,14 +14,12 @@ enum MaybeOwnedPtr_i32_Tag {
 };
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
 
-typedef struct Owned_Body_i32 {
-  int32_t *_0;
-} Owned_Body_i32;
-
 typedef struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {
   MaybeOwnedPtr_i32_Tag tag;
   union {
-    Owned_Body_i32 owned;
+    struct {
+      int32_t *owned;
+    };
   };
 } MaybeOwnedPtr_i32;
 

--- a/tests/expectations/must_use.both.compat.c
+++ b/tests/expectations/must_use.both.compat.c
@@ -20,14 +20,12 @@ enum MaybeOwnedPtr_i32_Tag
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
 #endif // __cplusplus
 
-typedef struct Owned_Body_i32 {
-  int32_t *_0;
-} Owned_Body_i32;
-
 typedef struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {
   MaybeOwnedPtr_i32_Tag tag;
   union {
-    Owned_Body_i32 owned;
+    struct {
+      int32_t *owned;
+    };
   };
 } MaybeOwnedPtr_i32;
 

--- a/tests/expectations/must_use.c
+++ b/tests/expectations/must_use.c
@@ -14,14 +14,12 @@ enum MaybeOwnedPtr_i32_Tag {
 };
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
 
-typedef struct {
-  int32_t *_0;
-} Owned_Body_i32;
-
 typedef struct MUST_USE_STRUCT {
   MaybeOwnedPtr_i32_Tag tag;
   union {
-    Owned_Body_i32 owned;
+    struct {
+      int32_t *owned;
+    };
   };
 } MaybeOwnedPtr_i32;
 

--- a/tests/expectations/must_use.compat.c
+++ b/tests/expectations/must_use.compat.c
@@ -20,14 +20,12 @@ enum MaybeOwnedPtr_i32_Tag
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
 #endif // __cplusplus
 
-typedef struct {
-  int32_t *_0;
-} Owned_Body_i32;
-
 typedef struct MUST_USE_STRUCT {
   MaybeOwnedPtr_i32_Tag tag;
   union {
-    Owned_Body_i32 owned;
+    struct {
+      int32_t *owned;
+    };
   };
 } MaybeOwnedPtr_i32;
 

--- a/tests/expectations/must_use.pyx
+++ b/tests/expectations/must_use.pyx
@@ -16,12 +16,9 @@ cdef extern from *:
     None_i32,
   ctypedef uint8_t MaybeOwnedPtr_i32_Tag;
 
-  ctypedef struct Owned_Body_i32:
-    int32_t *_0;
-
   ctypedef struct MaybeOwnedPtr_i32:
     MaybeOwnedPtr_i32_Tag tag;
-    Owned_Body_i32 owned;
+    int32_t *owned;
 
   ctypedef struct OwnedPtr_i32:
     int32_t *ptr;

--- a/tests/expectations/must_use.tag.c
+++ b/tests/expectations/must_use.tag.c
@@ -14,14 +14,12 @@ enum MaybeOwnedPtr_i32_Tag {
 };
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
 
-struct Owned_Body_i32 {
-  int32_t *_0;
-};
-
 struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {
   MaybeOwnedPtr_i32_Tag tag;
   union {
-    struct Owned_Body_i32 owned;
+    struct {
+      int32_t *owned;
+    };
   };
 };
 

--- a/tests/expectations/must_use.tag.compat.c
+++ b/tests/expectations/must_use.tag.compat.c
@@ -20,14 +20,12 @@ enum MaybeOwnedPtr_i32_Tag
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
 #endif // __cplusplus
 
-struct Owned_Body_i32 {
-  int32_t *_0;
-};
-
 struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {
   MaybeOwnedPtr_i32_Tag tag;
   union {
-    struct Owned_Body_i32 owned;
+    struct {
+      int32_t *owned;
+    };
   };
 };
 

--- a/tests/expectations/must_use.tag.pyx
+++ b/tests/expectations/must_use.tag.pyx
@@ -16,12 +16,9 @@ cdef extern from *:
     None_i32,
   ctypedef uint8_t MaybeOwnedPtr_i32_Tag;
 
-  cdef struct Owned_Body_i32:
-    int32_t *_0;
-
   cdef struct MaybeOwnedPtr_i32:
     MaybeOwnedPtr_i32_Tag tag;
-    Owned_Body_i32 owned;
+    int32_t *owned;
 
   cdef struct OwnedPtr_i32:
     int32_t *ptr;

--- a/tests/expectations/prefix.both.c
+++ b/tests/expectations/prefix.both.c
@@ -20,14 +20,12 @@ enum PREFIX_AbsoluteFontWeight_Tag {
 };
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 
-typedef struct PREFIX_Weight_Body {
-  PREFIX_AbsoluteFontWeight_Tag tag;
-  float _0;
-} PREFIX_Weight_Body;
-
 typedef union PREFIX_AbsoluteFontWeight {
   PREFIX_AbsoluteFontWeight_Tag tag;
-  PREFIX_Weight_Body weight;
+  struct {
+    PREFIX_AbsoluteFontWeight_Tag weight_tag;
+    float weight;
+  };
 } PREFIX_AbsoluteFontWeight;
 
 void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, union PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/prefix.both.compat.c
+++ b/tests/expectations/prefix.both.compat.c
@@ -26,14 +26,12 @@ enum PREFIX_AbsoluteFontWeight_Tag
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 #endif // __cplusplus
 
-typedef struct PREFIX_Weight_Body {
-  PREFIX_AbsoluteFontWeight_Tag tag;
-  float _0;
-} PREFIX_Weight_Body;
-
 typedef union PREFIX_AbsoluteFontWeight {
   PREFIX_AbsoluteFontWeight_Tag tag;
-  PREFIX_Weight_Body weight;
+  struct {
+    PREFIX_AbsoluteFontWeight_Tag weight_tag;
+    float weight;
+  };
 } PREFIX_AbsoluteFontWeight;
 
 #ifdef __cplusplus

--- a/tests/expectations/prefix.c
+++ b/tests/expectations/prefix.c
@@ -20,14 +20,12 @@ enum PREFIX_AbsoluteFontWeight_Tag {
 };
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 
-typedef struct {
-  PREFIX_AbsoluteFontWeight_Tag tag;
-  float _0;
-} PREFIX_Weight_Body;
-
 typedef union {
   PREFIX_AbsoluteFontWeight_Tag tag;
-  PREFIX_Weight_Body weight;
+  struct {
+    PREFIX_AbsoluteFontWeight_Tag weight_tag;
+    float weight;
+  };
 } PREFIX_AbsoluteFontWeight;
 
 void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/prefix.compat.c
+++ b/tests/expectations/prefix.compat.c
@@ -26,14 +26,12 @@ enum PREFIX_AbsoluteFontWeight_Tag
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 #endif // __cplusplus
 
-typedef struct {
-  PREFIX_AbsoluteFontWeight_Tag tag;
-  float _0;
-} PREFIX_Weight_Body;
-
 typedef union {
   PREFIX_AbsoluteFontWeight_Tag tag;
-  PREFIX_Weight_Body weight;
+  struct {
+    PREFIX_AbsoluteFontWeight_Tag weight_tag;
+    float weight;
+  };
 } PREFIX_AbsoluteFontWeight;
 
 #ifdef __cplusplus

--- a/tests/expectations/prefix.pyx
+++ b/tests/expectations/prefix.pyx
@@ -22,12 +22,9 @@ cdef extern from *:
     Bold,
   ctypedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 
-  ctypedef struct PREFIX_Weight_Body:
-    PREFIX_AbsoluteFontWeight_Tag tag;
-    float _0;
-
   ctypedef union PREFIX_AbsoluteFontWeight:
     PREFIX_AbsoluteFontWeight_Tag tag;
-    PREFIX_Weight_Body weight;
+    PREFIX_AbsoluteFontWeight_Tag weight_tag;
+    float weight;
 
   void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/prefix.tag.c
+++ b/tests/expectations/prefix.tag.c
@@ -20,14 +20,12 @@ enum PREFIX_AbsoluteFontWeight_Tag {
 };
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 
-struct PREFIX_Weight_Body {
-  PREFIX_AbsoluteFontWeight_Tag tag;
-  float _0;
-};
-
 union PREFIX_AbsoluteFontWeight {
   PREFIX_AbsoluteFontWeight_Tag tag;
-  struct PREFIX_Weight_Body weight;
+  struct {
+    PREFIX_AbsoluteFontWeight_Tag weight_tag;
+    float weight;
+  };
 };
 
 void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, union PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/prefix.tag.compat.c
+++ b/tests/expectations/prefix.tag.compat.c
@@ -26,14 +26,12 @@ enum PREFIX_AbsoluteFontWeight_Tag
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 #endif // __cplusplus
 
-struct PREFIX_Weight_Body {
-  PREFIX_AbsoluteFontWeight_Tag tag;
-  float _0;
-};
-
 union PREFIX_AbsoluteFontWeight {
   PREFIX_AbsoluteFontWeight_Tag tag;
-  struct PREFIX_Weight_Body weight;
+  struct {
+    PREFIX_AbsoluteFontWeight_Tag weight_tag;
+    float weight;
+  };
 };
 
 #ifdef __cplusplus

--- a/tests/expectations/prefix.tag.pyx
+++ b/tests/expectations/prefix.tag.pyx
@@ -22,12 +22,9 @@ cdef extern from *:
     Bold,
   ctypedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
 
-  cdef struct PREFIX_Weight_Body:
-    PREFIX_AbsoluteFontWeight_Tag tag;
-    float _0;
-
   cdef union PREFIX_AbsoluteFontWeight:
     PREFIX_AbsoluteFontWeight_Tag tag;
-    PREFIX_Weight_Body weight;
+    PREFIX_AbsoluteFontWeight_Tag weight_tag;
+    float weight;
 
   void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/reserved.both.c
+++ b/tests/expectations/reserved.both.c
@@ -36,19 +36,15 @@ enum E_Tag {
 };
 typedef uint8_t E_Tag;
 
-typedef struct Double_Body {
-  double _0;
-} Double_Body;
-
-typedef struct Float_Body {
-  float _0;
-} Float_Body;
-
 typedef struct E {
   E_Tag tag;
   union {
-    Double_Body double_;
-    Float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 } E;
 
@@ -58,19 +54,15 @@ enum F_Tag {
 };
 typedef uint8_t F_Tag;
 
-typedef struct double_Body {
-  double _0;
-} double_Body;
-
-typedef struct float_Body {
-  float _0;
-} float_Body;
-
 typedef struct F {
   F_Tag tag;
   union {
-    double_Body double_;
-    float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 } F;
 

--- a/tests/expectations/reserved.both.compat.c
+++ b/tests/expectations/reserved.both.compat.c
@@ -48,19 +48,15 @@ enum E_Tag
 typedef uint8_t E_Tag;
 #endif // __cplusplus
 
-typedef struct Double_Body {
-  double _0;
-} Double_Body;
-
-typedef struct Float_Body {
-  float _0;
-} Float_Body;
-
 typedef struct E {
   E_Tag tag;
   union {
-    Double_Body double_;
-    Float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 } E;
 
@@ -76,19 +72,15 @@ enum F_Tag
 typedef uint8_t F_Tag;
 #endif // __cplusplus
 
-typedef struct double_Body {
-  double _0;
-} double_Body;
-
-typedef struct float_Body {
-  float _0;
-} float_Body;
-
 typedef struct F {
   F_Tag tag;
   union {
-    double_Body double_;
-    float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 } F;
 

--- a/tests/expectations/reserved.c
+++ b/tests/expectations/reserved.c
@@ -37,18 +37,14 @@ enum E_Tag {
 typedef uint8_t E_Tag;
 
 typedef struct {
-  double _0;
-} Double_Body;
-
-typedef struct {
-  float _0;
-} Float_Body;
-
-typedef struct {
   E_Tag tag;
   union {
-    Double_Body double_;
-    Float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 } E;
 
@@ -59,18 +55,14 @@ enum F_Tag {
 typedef uint8_t F_Tag;
 
 typedef struct {
-  double _0;
-} double_Body;
-
-typedef struct {
-  float _0;
-} float_Body;
-
-typedef struct {
   F_Tag tag;
   union {
-    double_Body double_;
-    float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 } F;
 

--- a/tests/expectations/reserved.compat.c
+++ b/tests/expectations/reserved.compat.c
@@ -49,18 +49,14 @@ typedef uint8_t E_Tag;
 #endif // __cplusplus
 
 typedef struct {
-  double _0;
-} Double_Body;
-
-typedef struct {
-  float _0;
-} Float_Body;
-
-typedef struct {
   E_Tag tag;
   union {
-    Double_Body double_;
-    Float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 } E;
 
@@ -77,18 +73,14 @@ typedef uint8_t F_Tag;
 #endif // __cplusplus
 
 typedef struct {
-  double _0;
-} double_Body;
-
-typedef struct {
-  float _0;
-} float_Body;
-
-typedef struct {
   F_Tag tag;
   union {
-    double_Body double_;
-    float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 } F;
 

--- a/tests/expectations/reserved.pyx
+++ b/tests/expectations/reserved.pyx
@@ -31,31 +31,19 @@ cdef extern from *:
     Float,
   ctypedef uint8_t E_Tag;
 
-  ctypedef struct Double_Body:
-    double _0;
-
-  ctypedef struct Float_Body:
-    float _0;
-
   ctypedef struct E:
     E_Tag tag;
-    Double_Body double_;
-    Float_Body float_;
+    double double_;
+    float float_;
 
   cdef enum:
     double_,
     float_,
   ctypedef uint8_t F_Tag;
 
-  ctypedef struct double_Body:
-    double _0;
-
-  ctypedef struct float_Body:
-    float _0;
-
   ctypedef struct F:
     F_Tag tag;
-    double_Body double_;
-    float_Body float_;
+    double double_;
+    float float_;
 
   void root(A a, B b, C c, E e, F f, int32_t namespace_, float float_);

--- a/tests/expectations/reserved.tag.c
+++ b/tests/expectations/reserved.tag.c
@@ -36,19 +36,15 @@ enum E_Tag {
 };
 typedef uint8_t E_Tag;
 
-struct Double_Body {
-  double _0;
-};
-
-struct Float_Body {
-  float _0;
-};
-
 struct E {
   E_Tag tag;
   union {
-    struct Double_Body double_;
-    struct Float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 };
 
@@ -58,19 +54,15 @@ enum F_Tag {
 };
 typedef uint8_t F_Tag;
 
-struct double_Body {
-  double _0;
-};
-
-struct float_Body {
-  float _0;
-};
-
 struct F {
   F_Tag tag;
   union {
-    struct double_Body double_;
-    struct float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 };
 

--- a/tests/expectations/reserved.tag.compat.c
+++ b/tests/expectations/reserved.tag.compat.c
@@ -48,19 +48,15 @@ enum E_Tag
 typedef uint8_t E_Tag;
 #endif // __cplusplus
 
-struct Double_Body {
-  double _0;
-};
-
-struct Float_Body {
-  float _0;
-};
-
 struct E {
   E_Tag tag;
   union {
-    struct Double_Body double_;
-    struct Float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 };
 
@@ -76,19 +72,15 @@ enum F_Tag
 typedef uint8_t F_Tag;
 #endif // __cplusplus
 
-struct double_Body {
-  double _0;
-};
-
-struct float_Body {
-  float _0;
-};
-
 struct F {
   F_Tag tag;
   union {
-    struct double_Body double_;
-    struct float_Body float_;
+    struct {
+      double double_;
+    };
+    struct {
+      float float_;
+    };
   };
 };
 

--- a/tests/expectations/reserved.tag.pyx
+++ b/tests/expectations/reserved.tag.pyx
@@ -31,31 +31,19 @@ cdef extern from *:
     Float,
   ctypedef uint8_t E_Tag;
 
-  cdef struct Double_Body:
-    double _0;
-
-  cdef struct Float_Body:
-    float _0;
-
   cdef struct E:
     E_Tag tag;
-    Double_Body double_;
-    Float_Body float_;
+    double double_;
+    float float_;
 
   cdef enum:
     double_,
     float_,
   ctypedef uint8_t F_Tag;
 
-  cdef struct double_Body:
-    double _0;
-
-  cdef struct float_Body:
-    float _0;
-
   cdef struct F:
     F_Tag tag;
-    double_Body double_;
-    float_Body float_;
+    double double_;
+    float float_;
 
   void root(A a, B b, C c, E e, F f, int32_t namespace_, float float_);

--- a/tests/expectations/transform_op.both.c
+++ b/tests/expectations/transform_op.both.c
@@ -28,21 +28,17 @@ typedef struct StyleFoo_Body_i32 {
   struct StylePoint_f32 z;
 } StyleFoo_Body_i32;
 
-typedef struct StyleBar_Body_i32 {
-  StyleFoo_i32_Tag tag;
-  int32_t _0;
-} StyleBar_Body_i32;
-
-typedef struct StyleBaz_Body_i32 {
-  StyleFoo_i32_Tag tag;
-  struct StylePoint_i32 _0;
-} StyleBaz_Body_i32;
-
 typedef union StyleFoo_i32 {
   StyleFoo_i32_Tag tag;
   StyleFoo_Body_i32 foo;
-  StyleBar_Body_i32 bar;
-  StyleBaz_Body_i32 baz;
+  struct {
+    StyleFoo_i32_Tag bar_tag;
+    int32_t bar;
+  };
+  struct {
+    StyleFoo_i32_Tag baz_tag;
+    struct StylePoint_i32 baz;
+  };
 } StyleFoo_i32;
 
 typedef enum StyleBar_i32_Tag {
@@ -59,20 +55,16 @@ typedef struct StyleBar1_Body_i32 {
   int32_t (*u)(int32_t);
 } StyleBar1_Body_i32;
 
-typedef struct StyleBar2_Body_i32 {
-  int32_t _0;
-} StyleBar2_Body_i32;
-
-typedef struct StyleBar3_Body_i32 {
-  struct StylePoint_i32 _0;
-} StyleBar3_Body_i32;
-
 typedef struct StyleBar_i32 {
   StyleBar_i32_Tag tag;
   union {
     StyleBar1_Body_i32 bar1;
-    StyleBar2_Body_i32 bar2;
-    StyleBar3_Body_i32 bar3;
+    struct {
+      int32_t bar2;
+    };
+    struct {
+      struct StylePoint_i32 bar3;
+    };
   };
 } StyleBar_i32;
 
@@ -95,20 +87,16 @@ typedef struct StyleBar1_Body_u32 {
   int32_t (*u)(int32_t);
 } StyleBar1_Body_u32;
 
-typedef struct StyleBar2_Body_u32 {
-  uint32_t _0;
-} StyleBar2_Body_u32;
-
-typedef struct StyleBar3_Body_u32 {
-  struct StylePoint_u32 _0;
-} StyleBar3_Body_u32;
-
 typedef struct StyleBar_u32 {
   StyleBar_u32_Tag tag;
   union {
     StyleBar1_Body_u32 bar1;
-    StyleBar2_Body_u32 bar2;
-    StyleBar3_Body_u32 bar3;
+    struct {
+      uint32_t bar2;
+    };
+    struct {
+      struct StylePoint_u32 bar3;
+    };
   };
 } StyleBar_u32;
 
@@ -119,20 +107,16 @@ enum StyleBaz_Tag {
 };
 typedef uint8_t StyleBaz_Tag;
 
-typedef struct StyleBaz1_Body {
-  StyleBaz_Tag tag;
-  struct StyleBar_u32 _0;
-} StyleBaz1_Body;
-
-typedef struct StyleBaz2_Body {
-  StyleBaz_Tag tag;
-  struct StylePoint_i32 _0;
-} StyleBaz2_Body;
-
 typedef union StyleBaz {
   StyleBaz_Tag tag;
-  StyleBaz1_Body baz1;
-  StyleBaz2_Body baz2;
+  struct {
+    StyleBaz_Tag baz1_tag;
+    struct StyleBar_u32 baz1;
+  };
+  struct {
+    StyleBaz_Tag baz2_tag;
+    struct StylePoint_i32 baz2;
+  };
 } StyleBaz;
 
 enum StyleTaz_Tag {
@@ -142,19 +126,15 @@ enum StyleTaz_Tag {
 };
 typedef uint8_t StyleTaz_Tag;
 
-typedef struct StyleTaz1_Body {
-  struct StyleBar_u32 _0;
-} StyleTaz1_Body;
-
-typedef struct StyleTaz2_Body {
-  union StyleBaz _0;
-} StyleTaz2_Body;
-
 typedef struct StyleTaz {
   StyleTaz_Tag tag;
   union {
-    StyleTaz1_Body taz1;
-    StyleTaz2_Body taz2;
+    struct {
+      struct StyleBar_u32 taz1;
+    };
+    struct {
+      union StyleBaz taz2;
+    };
   };
 } StyleTaz;
 

--- a/tests/expectations/transform_op.both.compat.c
+++ b/tests/expectations/transform_op.both.compat.c
@@ -34,21 +34,17 @@ typedef struct StyleFoo_Body_i32 {
   struct StylePoint_f32 z;
 } StyleFoo_Body_i32;
 
-typedef struct StyleBar_Body_i32 {
-  StyleFoo_i32_Tag tag;
-  int32_t _0;
-} StyleBar_Body_i32;
-
-typedef struct StyleBaz_Body_i32 {
-  StyleFoo_i32_Tag tag;
-  struct StylePoint_i32 _0;
-} StyleBaz_Body_i32;
-
 typedef union StyleFoo_i32 {
   StyleFoo_i32_Tag tag;
   StyleFoo_Body_i32 foo;
-  StyleBar_Body_i32 bar;
-  StyleBaz_Body_i32 baz;
+  struct {
+    StyleFoo_i32_Tag bar_tag;
+    int32_t bar;
+  };
+  struct {
+    StyleFoo_i32_Tag baz_tag;
+    struct StylePoint_i32 baz;
+  };
 } StyleFoo_i32;
 
 typedef enum StyleBar_i32_Tag {
@@ -65,20 +61,16 @@ typedef struct StyleBar1_Body_i32 {
   int32_t (*u)(int32_t);
 } StyleBar1_Body_i32;
 
-typedef struct StyleBar2_Body_i32 {
-  int32_t _0;
-} StyleBar2_Body_i32;
-
-typedef struct StyleBar3_Body_i32 {
-  struct StylePoint_i32 _0;
-} StyleBar3_Body_i32;
-
 typedef struct StyleBar_i32 {
   StyleBar_i32_Tag tag;
   union {
     StyleBar1_Body_i32 bar1;
-    StyleBar2_Body_i32 bar2;
-    StyleBar3_Body_i32 bar3;
+    struct {
+      int32_t bar2;
+    };
+    struct {
+      struct StylePoint_i32 bar3;
+    };
   };
 } StyleBar_i32;
 
@@ -101,20 +93,16 @@ typedef struct StyleBar1_Body_u32 {
   int32_t (*u)(int32_t);
 } StyleBar1_Body_u32;
 
-typedef struct StyleBar2_Body_u32 {
-  uint32_t _0;
-} StyleBar2_Body_u32;
-
-typedef struct StyleBar3_Body_u32 {
-  struct StylePoint_u32 _0;
-} StyleBar3_Body_u32;
-
 typedef struct StyleBar_u32 {
   StyleBar_u32_Tag tag;
   union {
     StyleBar1_Body_u32 bar1;
-    StyleBar2_Body_u32 bar2;
-    StyleBar3_Body_u32 bar3;
+    struct {
+      uint32_t bar2;
+    };
+    struct {
+      struct StylePoint_u32 bar3;
+    };
   };
 } StyleBar_u32;
 
@@ -131,20 +119,16 @@ enum StyleBaz_Tag
 typedef uint8_t StyleBaz_Tag;
 #endif // __cplusplus
 
-typedef struct StyleBaz1_Body {
-  StyleBaz_Tag tag;
-  struct StyleBar_u32 _0;
-} StyleBaz1_Body;
-
-typedef struct StyleBaz2_Body {
-  StyleBaz_Tag tag;
-  struct StylePoint_i32 _0;
-} StyleBaz2_Body;
-
 typedef union StyleBaz {
   StyleBaz_Tag tag;
-  StyleBaz1_Body baz1;
-  StyleBaz2_Body baz2;
+  struct {
+    StyleBaz_Tag baz1_tag;
+    struct StyleBar_u32 baz1;
+  };
+  struct {
+    StyleBaz_Tag baz2_tag;
+    struct StylePoint_i32 baz2;
+  };
 } StyleBaz;
 
 enum StyleTaz_Tag
@@ -160,19 +144,15 @@ enum StyleTaz_Tag
 typedef uint8_t StyleTaz_Tag;
 #endif // __cplusplus
 
-typedef struct StyleTaz1_Body {
-  struct StyleBar_u32 _0;
-} StyleTaz1_Body;
-
-typedef struct StyleTaz2_Body {
-  union StyleBaz _0;
-} StyleTaz2_Body;
-
 typedef struct StyleTaz {
   StyleTaz_Tag tag;
   union {
-    StyleTaz1_Body taz1;
-    StyleTaz2_Body taz2;
+    struct {
+      struct StyleBar_u32 taz1;
+    };
+    struct {
+      union StyleBaz taz2;
+    };
   };
 } StyleTaz;
 

--- a/tests/expectations/transform_op.c
+++ b/tests/expectations/transform_op.c
@@ -28,21 +28,17 @@ typedef struct {
   StylePoint_f32 z;
 } StyleFoo_Body_i32;
 
-typedef struct {
-  StyleFoo_i32_Tag tag;
-  int32_t _0;
-} StyleBar_Body_i32;
-
-typedef struct {
-  StyleFoo_i32_Tag tag;
-  StylePoint_i32 _0;
-} StyleBaz_Body_i32;
-
 typedef union {
   StyleFoo_i32_Tag tag;
   StyleFoo_Body_i32 foo;
-  StyleBar_Body_i32 bar;
-  StyleBaz_Body_i32 baz;
+  struct {
+    StyleFoo_i32_Tag bar_tag;
+    int32_t bar;
+  };
+  struct {
+    StyleFoo_i32_Tag baz_tag;
+    StylePoint_i32 baz;
+  };
 } StyleFoo_i32;
 
 typedef enum {
@@ -60,19 +56,15 @@ typedef struct {
 } StyleBar1_Body_i32;
 
 typedef struct {
-  int32_t _0;
-} StyleBar2_Body_i32;
-
-typedef struct {
-  StylePoint_i32 _0;
-} StyleBar3_Body_i32;
-
-typedef struct {
   StyleBar_i32_Tag tag;
   union {
     StyleBar1_Body_i32 bar1;
-    StyleBar2_Body_i32 bar2;
-    StyleBar3_Body_i32 bar3;
+    struct {
+      int32_t bar2;
+    };
+    struct {
+      StylePoint_i32 bar3;
+    };
   };
 } StyleBar_i32;
 
@@ -96,19 +88,15 @@ typedef struct {
 } StyleBar1_Body_u32;
 
 typedef struct {
-  uint32_t _0;
-} StyleBar2_Body_u32;
-
-typedef struct {
-  StylePoint_u32 _0;
-} StyleBar3_Body_u32;
-
-typedef struct {
   StyleBar_u32_Tag tag;
   union {
     StyleBar1_Body_u32 bar1;
-    StyleBar2_Body_u32 bar2;
-    StyleBar3_Body_u32 bar3;
+    struct {
+      uint32_t bar2;
+    };
+    struct {
+      StylePoint_u32 bar3;
+    };
   };
 } StyleBar_u32;
 
@@ -119,20 +107,16 @@ enum StyleBaz_Tag {
 };
 typedef uint8_t StyleBaz_Tag;
 
-typedef struct {
-  StyleBaz_Tag tag;
-  StyleBar_u32 _0;
-} StyleBaz1_Body;
-
-typedef struct {
-  StyleBaz_Tag tag;
-  StylePoint_i32 _0;
-} StyleBaz2_Body;
-
 typedef union {
   StyleBaz_Tag tag;
-  StyleBaz1_Body baz1;
-  StyleBaz2_Body baz2;
+  struct {
+    StyleBaz_Tag baz1_tag;
+    StyleBar_u32 baz1;
+  };
+  struct {
+    StyleBaz_Tag baz2_tag;
+    StylePoint_i32 baz2;
+  };
 } StyleBaz;
 
 enum StyleTaz_Tag {
@@ -143,18 +127,14 @@ enum StyleTaz_Tag {
 typedef uint8_t StyleTaz_Tag;
 
 typedef struct {
-  StyleBar_u32 _0;
-} StyleTaz1_Body;
-
-typedef struct {
-  StyleBaz _0;
-} StyleTaz2_Body;
-
-typedef struct {
   StyleTaz_Tag tag;
   union {
-    StyleTaz1_Body taz1;
-    StyleTaz2_Body taz2;
+    struct {
+      StyleBar_u32 taz1;
+    };
+    struct {
+      StyleBaz taz2;
+    };
   };
 } StyleTaz;
 

--- a/tests/expectations/transform_op.compat.c
+++ b/tests/expectations/transform_op.compat.c
@@ -34,21 +34,17 @@ typedef struct {
   StylePoint_f32 z;
 } StyleFoo_Body_i32;
 
-typedef struct {
-  StyleFoo_i32_Tag tag;
-  int32_t _0;
-} StyleBar_Body_i32;
-
-typedef struct {
-  StyleFoo_i32_Tag tag;
-  StylePoint_i32 _0;
-} StyleBaz_Body_i32;
-
 typedef union {
   StyleFoo_i32_Tag tag;
   StyleFoo_Body_i32 foo;
-  StyleBar_Body_i32 bar;
-  StyleBaz_Body_i32 baz;
+  struct {
+    StyleFoo_i32_Tag bar_tag;
+    int32_t bar;
+  };
+  struct {
+    StyleFoo_i32_Tag baz_tag;
+    StylePoint_i32 baz;
+  };
 } StyleFoo_i32;
 
 typedef enum {
@@ -66,19 +62,15 @@ typedef struct {
 } StyleBar1_Body_i32;
 
 typedef struct {
-  int32_t _0;
-} StyleBar2_Body_i32;
-
-typedef struct {
-  StylePoint_i32 _0;
-} StyleBar3_Body_i32;
-
-typedef struct {
   StyleBar_i32_Tag tag;
   union {
     StyleBar1_Body_i32 bar1;
-    StyleBar2_Body_i32 bar2;
-    StyleBar3_Body_i32 bar3;
+    struct {
+      int32_t bar2;
+    };
+    struct {
+      StylePoint_i32 bar3;
+    };
   };
 } StyleBar_i32;
 
@@ -102,19 +94,15 @@ typedef struct {
 } StyleBar1_Body_u32;
 
 typedef struct {
-  uint32_t _0;
-} StyleBar2_Body_u32;
-
-typedef struct {
-  StylePoint_u32 _0;
-} StyleBar3_Body_u32;
-
-typedef struct {
   StyleBar_u32_Tag tag;
   union {
     StyleBar1_Body_u32 bar1;
-    StyleBar2_Body_u32 bar2;
-    StyleBar3_Body_u32 bar3;
+    struct {
+      uint32_t bar2;
+    };
+    struct {
+      StylePoint_u32 bar3;
+    };
   };
 } StyleBar_u32;
 
@@ -131,20 +119,16 @@ enum StyleBaz_Tag
 typedef uint8_t StyleBaz_Tag;
 #endif // __cplusplus
 
-typedef struct {
-  StyleBaz_Tag tag;
-  StyleBar_u32 _0;
-} StyleBaz1_Body;
-
-typedef struct {
-  StyleBaz_Tag tag;
-  StylePoint_i32 _0;
-} StyleBaz2_Body;
-
 typedef union {
   StyleBaz_Tag tag;
-  StyleBaz1_Body baz1;
-  StyleBaz2_Body baz2;
+  struct {
+    StyleBaz_Tag baz1_tag;
+    StyleBar_u32 baz1;
+  };
+  struct {
+    StyleBaz_Tag baz2_tag;
+    StylePoint_i32 baz2;
+  };
 } StyleBaz;
 
 enum StyleTaz_Tag
@@ -161,18 +145,14 @@ typedef uint8_t StyleTaz_Tag;
 #endif // __cplusplus
 
 typedef struct {
-  StyleBar_u32 _0;
-} StyleTaz1_Body;
-
-typedef struct {
-  StyleBaz _0;
-} StyleTaz2_Body;
-
-typedef struct {
   StyleTaz_Tag tag;
   union {
-    StyleTaz1_Body taz1;
-    StyleTaz2_Body taz2;
+    struct {
+      StyleBar_u32 taz1;
+    };
+    struct {
+      StyleBaz taz2;
+    };
   };
 } StyleTaz;
 

--- a/tests/expectations/transform_op.pyx
+++ b/tests/expectations/transform_op.pyx
@@ -27,19 +27,13 @@ cdef extern from *:
     StylePoint_i32 y;
     StylePoint_f32 z;
 
-  ctypedef struct StyleBar_Body_i32:
-    StyleFoo_i32_Tag tag;
-    int32_t _0;
-
-  ctypedef struct StyleBaz_Body_i32:
-    StyleFoo_i32_Tag tag;
-    StylePoint_i32 _0;
-
   ctypedef union StyleFoo_i32:
     StyleFoo_i32_Tag tag;
     StyleFoo_Body_i32 foo;
-    StyleBar_Body_i32 bar;
-    StyleBaz_Body_i32 baz;
+    StyleFoo_i32_Tag bar_tag;
+    int32_t bar;
+    StyleFoo_i32_Tag baz_tag;
+    StylePoint_i32 baz;
 
   ctypedef enum StyleBar_i32_Tag:
     Bar1_i32,
@@ -53,17 +47,11 @@ cdef extern from *:
     StylePoint_f32 z;
     int32_t (*u)(int32_t);
 
-  ctypedef struct StyleBar2_Body_i32:
-    int32_t _0;
-
-  ctypedef struct StyleBar3_Body_i32:
-    StylePoint_i32 _0;
-
   ctypedef struct StyleBar_i32:
     StyleBar_i32_Tag tag;
     StyleBar1_Body_i32 bar1;
-    StyleBar2_Body_i32 bar2;
-    StyleBar3_Body_i32 bar3;
+    int32_t bar2;
+    StylePoint_i32 bar3;
 
   ctypedef struct StylePoint_u32:
     uint32_t x;
@@ -81,17 +69,11 @@ cdef extern from *:
     StylePoint_f32 z;
     int32_t (*u)(int32_t);
 
-  ctypedef struct StyleBar2_Body_u32:
-    uint32_t _0;
-
-  ctypedef struct StyleBar3_Body_u32:
-    StylePoint_u32 _0;
-
   ctypedef struct StyleBar_u32:
     StyleBar_u32_Tag tag;
     StyleBar1_Body_u32 bar1;
-    StyleBar2_Body_u32 bar2;
-    StyleBar3_Body_u32 bar3;
+    uint32_t bar2;
+    StylePoint_u32 bar3;
 
   cdef enum:
     Baz1,
@@ -99,18 +81,12 @@ cdef extern from *:
     Baz3,
   ctypedef uint8_t StyleBaz_Tag;
 
-  ctypedef struct StyleBaz1_Body:
-    StyleBaz_Tag tag;
-    StyleBar_u32 _0;
-
-  ctypedef struct StyleBaz2_Body:
-    StyleBaz_Tag tag;
-    StylePoint_i32 _0;
-
   ctypedef union StyleBaz:
     StyleBaz_Tag tag;
-    StyleBaz1_Body baz1;
-    StyleBaz2_Body baz2;
+    StyleBaz_Tag baz1_tag;
+    StyleBar_u32 baz1;
+    StyleBaz_Tag baz2_tag;
+    StylePoint_i32 baz2;
 
   cdef enum:
     Taz1,
@@ -118,16 +94,10 @@ cdef extern from *:
     Taz3,
   ctypedef uint8_t StyleTaz_Tag;
 
-  ctypedef struct StyleTaz1_Body:
-    StyleBar_u32 _0;
-
-  ctypedef struct StyleTaz2_Body:
-    StyleBaz _0;
-
   ctypedef struct StyleTaz:
     StyleTaz_Tag tag;
-    StyleTaz1_Body taz1;
-    StyleTaz2_Body taz2;
+    StyleBar_u32 taz1;
+    StyleBaz taz2;
 
   void foo(const StyleFoo_i32 *foo,
            const StyleBar_i32 *bar,

--- a/tests/expectations/transform_op.tag.c
+++ b/tests/expectations/transform_op.tag.c
@@ -28,21 +28,17 @@ struct StyleFoo_Body_i32 {
   struct StylePoint_f32 z;
 };
 
-struct StyleBar_Body_i32 {
-  StyleFoo_i32_Tag tag;
-  int32_t _0;
-};
-
-struct StyleBaz_Body_i32 {
-  StyleFoo_i32_Tag tag;
-  struct StylePoint_i32 _0;
-};
-
 union StyleFoo_i32 {
   StyleFoo_i32_Tag tag;
   struct StyleFoo_Body_i32 foo;
-  struct StyleBar_Body_i32 bar;
-  struct StyleBaz_Body_i32 baz;
+  struct {
+    StyleFoo_i32_Tag bar_tag;
+    int32_t bar;
+  };
+  struct {
+    StyleFoo_i32_Tag baz_tag;
+    struct StylePoint_i32 baz;
+  };
 };
 
 enum StyleBar_i32_Tag {
@@ -59,20 +55,16 @@ struct StyleBar1_Body_i32 {
   int32_t (*u)(int32_t);
 };
 
-struct StyleBar2_Body_i32 {
-  int32_t _0;
-};
-
-struct StyleBar3_Body_i32 {
-  struct StylePoint_i32 _0;
-};
-
 struct StyleBar_i32 {
   enum StyleBar_i32_Tag tag;
   union {
     struct StyleBar1_Body_i32 bar1;
-    struct StyleBar2_Body_i32 bar2;
-    struct StyleBar3_Body_i32 bar3;
+    struct {
+      int32_t bar2;
+    };
+    struct {
+      struct StylePoint_i32 bar3;
+    };
   };
 };
 
@@ -95,20 +87,16 @@ struct StyleBar1_Body_u32 {
   int32_t (*u)(int32_t);
 };
 
-struct StyleBar2_Body_u32 {
-  uint32_t _0;
-};
-
-struct StyleBar3_Body_u32 {
-  struct StylePoint_u32 _0;
-};
-
 struct StyleBar_u32 {
   enum StyleBar_u32_Tag tag;
   union {
     struct StyleBar1_Body_u32 bar1;
-    struct StyleBar2_Body_u32 bar2;
-    struct StyleBar3_Body_u32 bar3;
+    struct {
+      uint32_t bar2;
+    };
+    struct {
+      struct StylePoint_u32 bar3;
+    };
   };
 };
 
@@ -119,20 +107,16 @@ enum StyleBaz_Tag {
 };
 typedef uint8_t StyleBaz_Tag;
 
-struct StyleBaz1_Body {
-  StyleBaz_Tag tag;
-  struct StyleBar_u32 _0;
-};
-
-struct StyleBaz2_Body {
-  StyleBaz_Tag tag;
-  struct StylePoint_i32 _0;
-};
-
 union StyleBaz {
   StyleBaz_Tag tag;
-  struct StyleBaz1_Body baz1;
-  struct StyleBaz2_Body baz2;
+  struct {
+    StyleBaz_Tag baz1_tag;
+    struct StyleBar_u32 baz1;
+  };
+  struct {
+    StyleBaz_Tag baz2_tag;
+    struct StylePoint_i32 baz2;
+  };
 };
 
 enum StyleTaz_Tag {
@@ -142,19 +126,15 @@ enum StyleTaz_Tag {
 };
 typedef uint8_t StyleTaz_Tag;
 
-struct StyleTaz1_Body {
-  struct StyleBar_u32 _0;
-};
-
-struct StyleTaz2_Body {
-  union StyleBaz _0;
-};
-
 struct StyleTaz {
   StyleTaz_Tag tag;
   union {
-    struct StyleTaz1_Body taz1;
-    struct StyleTaz2_Body taz2;
+    struct {
+      struct StyleBar_u32 taz1;
+    };
+    struct {
+      union StyleBaz taz2;
+    };
   };
 };
 

--- a/tests/expectations/transform_op.tag.compat.c
+++ b/tests/expectations/transform_op.tag.compat.c
@@ -34,21 +34,17 @@ struct StyleFoo_Body_i32 {
   struct StylePoint_f32 z;
 };
 
-struct StyleBar_Body_i32 {
-  StyleFoo_i32_Tag tag;
-  int32_t _0;
-};
-
-struct StyleBaz_Body_i32 {
-  StyleFoo_i32_Tag tag;
-  struct StylePoint_i32 _0;
-};
-
 union StyleFoo_i32 {
   StyleFoo_i32_Tag tag;
   struct StyleFoo_Body_i32 foo;
-  struct StyleBar_Body_i32 bar;
-  struct StyleBaz_Body_i32 baz;
+  struct {
+    StyleFoo_i32_Tag bar_tag;
+    int32_t bar;
+  };
+  struct {
+    StyleFoo_i32_Tag baz_tag;
+    struct StylePoint_i32 baz;
+  };
 };
 
 enum StyleBar_i32_Tag {
@@ -65,20 +61,16 @@ struct StyleBar1_Body_i32 {
   int32_t (*u)(int32_t);
 };
 
-struct StyleBar2_Body_i32 {
-  int32_t _0;
-};
-
-struct StyleBar3_Body_i32 {
-  struct StylePoint_i32 _0;
-};
-
 struct StyleBar_i32 {
   enum StyleBar_i32_Tag tag;
   union {
     struct StyleBar1_Body_i32 bar1;
-    struct StyleBar2_Body_i32 bar2;
-    struct StyleBar3_Body_i32 bar3;
+    struct {
+      int32_t bar2;
+    };
+    struct {
+      struct StylePoint_i32 bar3;
+    };
   };
 };
 
@@ -101,20 +93,16 @@ struct StyleBar1_Body_u32 {
   int32_t (*u)(int32_t);
 };
 
-struct StyleBar2_Body_u32 {
-  uint32_t _0;
-};
-
-struct StyleBar3_Body_u32 {
-  struct StylePoint_u32 _0;
-};
-
 struct StyleBar_u32 {
   enum StyleBar_u32_Tag tag;
   union {
     struct StyleBar1_Body_u32 bar1;
-    struct StyleBar2_Body_u32 bar2;
-    struct StyleBar3_Body_u32 bar3;
+    struct {
+      uint32_t bar2;
+    };
+    struct {
+      struct StylePoint_u32 bar3;
+    };
   };
 };
 
@@ -131,20 +119,16 @@ enum StyleBaz_Tag
 typedef uint8_t StyleBaz_Tag;
 #endif // __cplusplus
 
-struct StyleBaz1_Body {
-  StyleBaz_Tag tag;
-  struct StyleBar_u32 _0;
-};
-
-struct StyleBaz2_Body {
-  StyleBaz_Tag tag;
-  struct StylePoint_i32 _0;
-};
-
 union StyleBaz {
   StyleBaz_Tag tag;
-  struct StyleBaz1_Body baz1;
-  struct StyleBaz2_Body baz2;
+  struct {
+    StyleBaz_Tag baz1_tag;
+    struct StyleBar_u32 baz1;
+  };
+  struct {
+    StyleBaz_Tag baz2_tag;
+    struct StylePoint_i32 baz2;
+  };
 };
 
 enum StyleTaz_Tag
@@ -160,19 +144,15 @@ enum StyleTaz_Tag
 typedef uint8_t StyleTaz_Tag;
 #endif // __cplusplus
 
-struct StyleTaz1_Body {
-  struct StyleBar_u32 _0;
-};
-
-struct StyleTaz2_Body {
-  union StyleBaz _0;
-};
-
 struct StyleTaz {
   StyleTaz_Tag tag;
   union {
-    struct StyleTaz1_Body taz1;
-    struct StyleTaz2_Body taz2;
+    struct {
+      struct StyleBar_u32 taz1;
+    };
+    struct {
+      union StyleBaz taz2;
+    };
   };
 };
 

--- a/tests/expectations/transform_op.tag.pyx
+++ b/tests/expectations/transform_op.tag.pyx
@@ -27,19 +27,13 @@ cdef extern from *:
     StylePoint_i32 y;
     StylePoint_f32 z;
 
-  cdef struct StyleBar_Body_i32:
-    StyleFoo_i32_Tag tag;
-    int32_t _0;
-
-  cdef struct StyleBaz_Body_i32:
-    StyleFoo_i32_Tag tag;
-    StylePoint_i32 _0;
-
   cdef union StyleFoo_i32:
     StyleFoo_i32_Tag tag;
     StyleFoo_Body_i32 foo;
-    StyleBar_Body_i32 bar;
-    StyleBaz_Body_i32 baz;
+    StyleFoo_i32_Tag bar_tag;
+    int32_t bar;
+    StyleFoo_i32_Tag baz_tag;
+    StylePoint_i32 baz;
 
   cdef enum StyleBar_i32_Tag:
     Bar1_i32,
@@ -53,17 +47,11 @@ cdef extern from *:
     StylePoint_f32 z;
     int32_t (*u)(int32_t);
 
-  cdef struct StyleBar2_Body_i32:
-    int32_t _0;
-
-  cdef struct StyleBar3_Body_i32:
-    StylePoint_i32 _0;
-
   cdef struct StyleBar_i32:
     StyleBar_i32_Tag tag;
     StyleBar1_Body_i32 bar1;
-    StyleBar2_Body_i32 bar2;
-    StyleBar3_Body_i32 bar3;
+    int32_t bar2;
+    StylePoint_i32 bar3;
 
   cdef struct StylePoint_u32:
     uint32_t x;
@@ -81,17 +69,11 @@ cdef extern from *:
     StylePoint_f32 z;
     int32_t (*u)(int32_t);
 
-  cdef struct StyleBar2_Body_u32:
-    uint32_t _0;
-
-  cdef struct StyleBar3_Body_u32:
-    StylePoint_u32 _0;
-
   cdef struct StyleBar_u32:
     StyleBar_u32_Tag tag;
     StyleBar1_Body_u32 bar1;
-    StyleBar2_Body_u32 bar2;
-    StyleBar3_Body_u32 bar3;
+    uint32_t bar2;
+    StylePoint_u32 bar3;
 
   cdef enum:
     Baz1,
@@ -99,18 +81,12 @@ cdef extern from *:
     Baz3,
   ctypedef uint8_t StyleBaz_Tag;
 
-  cdef struct StyleBaz1_Body:
-    StyleBaz_Tag tag;
-    StyleBar_u32 _0;
-
-  cdef struct StyleBaz2_Body:
-    StyleBaz_Tag tag;
-    StylePoint_i32 _0;
-
   cdef union StyleBaz:
     StyleBaz_Tag tag;
-    StyleBaz1_Body baz1;
-    StyleBaz2_Body baz2;
+    StyleBaz_Tag baz1_tag;
+    StyleBar_u32 baz1;
+    StyleBaz_Tag baz2_tag;
+    StylePoint_i32 baz2;
 
   cdef enum:
     Taz1,
@@ -118,16 +94,10 @@ cdef extern from *:
     Taz3,
   ctypedef uint8_t StyleTaz_Tag;
 
-  cdef struct StyleTaz1_Body:
-    StyleBar_u32 _0;
-
-  cdef struct StyleTaz2_Body:
-    StyleBaz _0;
-
   cdef struct StyleTaz:
     StyleTaz_Tag tag;
-    StyleTaz1_Body taz1;
-    StyleTaz2_Body taz2;
+    StyleBar_u32 taz1;
+    StyleBaz taz2;
 
   void foo(const StyleFoo_i32 *foo,
            const StyleBar_i32 *bar,


### PR DESCRIPTION
Define nameless structs for enum variants with data inline, without creating separate named `Foo_Body` structs, like described in https://github.com/eqrion/cbindgen/issues/353.
Such inlining is only done for tuple variants with a single field, in other cases it's not an improvement.

#### Unresolved questions:

- The inlining is currently done automatically and cannot be disabled. Do we need control over it? At which granularity exactly? Global config? Annotations for specific variants?

#### Caveats:

- `cbindgen` doesn't currently detect field name conflicts when adding a field named `tag` to structs or unions generated for enums with data. This PR continues that tradition and doesn't detect conflicts when adding fields named `variant_tag` for inlined tags.
- The inlining is not currently done when `derive_tagged_enum_destructor = true` or `derive_tagged_enum_copy_constructor = true` for the given enum. It should be possible to derive destructors and copy constructors when variant definitions are inlined, but it's annoying, e.g. array fields require special cases. I'll probably try to address this limitation next week.

Closes https://github.com/eqrion/cbindgen/issues/353