### PR TITLE
enum: Do not forget to rename entities in enum discriminants

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -479,7 +479,9 @@ impl Item for Enum {
 
         for variant in &mut self.variants {
             reserved::escape(&mut variant.export_name);
-
+            if let Some(discriminant) = &mut variant.discriminant {
+                discriminant.rename_for_config(config);
+            }
             if let VariantBody::Body {
                 ref mut name,
                 ref mut body,

--- a/tests/expectations/enum_discriminant.c
+++ b/tests/expectations/enum_discriminant.c
@@ -3,13 +3,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define FOUR 4
+#define FOURTY_FOUR 4
 
 enum E {
   A = 1,
   B = -1,
   C = (1 + 2),
-  D = FOUR,
+  D = FOURTY_FOUR,
   F = 5,
   G = (int8_t)54,
   H = (int8_t)false,

--- a/tests/expectations/enum_discriminant.compat.c
+++ b/tests/expectations/enum_discriminant.compat.c
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define FOUR 4
+#define FOURTY_FOUR 4
 
 enum E
 #ifdef __cplusplus
@@ -13,7 +13,7 @@ enum E
   A = 1,
   B = -1,
   C = (1 + 2),
-  D = FOUR,
+  D = FOURTY_FOUR,
   F = 5,
   G = (int8_t)54,
   H = (int8_t)false,

--- a/tests/expectations/enum_discriminant.cpp
+++ b/tests/expectations/enum_discriminant.cpp
@@ -4,13 +4,13 @@
 #include <ostream>
 #include <new>
 
-static const int8_t FOUR = 4;
+static const int8_t FOURTY_FOUR = 4;
 
 enum class E : int8_t {
   A = 1,
   B = -1,
   C = (1 + 2),
-  D = FOUR,
+  D = FOURTY_FOUR,
   F = 5,
   G = (int8_t)54,
   H = (int8_t)false,

--- a/tests/expectations/enum_discriminant.pyx
+++ b/tests/expectations/enum_discriminant.pyx
@@ -6,13 +6,13 @@ cdef extern from *:
 
 cdef extern from *:
 
-  const int8_t FOUR # = 4
+  const int8_t FOURTY_FOUR # = 4
 
   cdef enum:
     A # = 1,
     B # = -1,
     C # = (1 + 2),
-    D # = FOUR,
+    D # = FOURTY_FOUR,
     F # = 5,
     G # = <int8_t>54,
     H # = <int8_t>False,

--- a/tests/rust/enum_discriminant.toml
+++ b/tests/rust/enum_discriminant.toml
@@ -1,0 +1,2 @@
+[export.rename]
+"FOUR" = "FOURTY_FOUR"


### PR DESCRIPTION
A missing piece of https://github.com/eqrion/cbindgen/pull/614.