### PR TITLE
Partially support `#[cfg]`s on fields

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -112,6 +112,7 @@ impl EnumVariant {
                             None => i.to_string(),
                         },
                         ty,
+                        cfg: Cfg::load(&field.attrs),
                         annotations: AnnotationSet::load(&field.attrs)?,
                         documentation: Documentation::load(&field.attrs),
                     });

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -88,6 +88,7 @@ impl Struct {
                         out.push(Field {
                             name: format!("{}", current),
                             ty,
+                            cfg: Cfg::load(&field.attrs),
                             annotations: AnnotationSet::load(&field.attrs)?,
                             documentation: Documentation::load(&field.attrs),
                         });
@@ -191,6 +192,7 @@ impl Struct {
                 .map(|field| Field {
                     name: field.name.clone(),
                     ty: field.ty.specialize(mappings),
+                    cfg: field.cfg.clone(),
                     annotations: field.annotations.clone(),
                     documentation: field.documentation.clone(),
                 })

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -180,6 +180,7 @@ impl Item for Union {
                     overriden_fields.push(Field {
                         name: o[i].clone(),
                         ty: field.ty.clone(),
+                        cfg: field.cfg.clone(),
                         annotations: field.annotations.clone(),
                         documentation: field.documentation.clone(),
                     });
@@ -196,6 +197,7 @@ impl Item for Union {
                         .apply(&field.name, IdentifierType::StructMember)
                         .into_owned(),
                     ty: field.ty.clone(),
+                    cfg: field.cfg.clone(),
                     annotations: field.annotations.clone(),
                     documentation: field.documentation.clone(),
                 })
@@ -256,6 +258,7 @@ impl Item for Union {
                 .map(|field| Field {
                     name: field.name.clone(),
                     ty: field.ty.specialize(&mappings),
+                    cfg: field.cfg.clone(),
                     annotations: field.annotations.clone(),
                     documentation: field.documentation.clone(),
                 })

--- a/tests/expectations/cfg.both.c
+++ b/tests/expectations/cfg.both.c
@@ -71,6 +71,13 @@ typedef struct BarHandle {
 } BarHandle;
 #endif
 
+typedef struct ConditionalField {
+#if defined(X11)
+  int32_t field
+#endif
+  ;
+} ConditionalField;
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(struct FooHandle a, union C c);
 #endif
@@ -78,3 +85,5 @@ void root(struct FooHandle a, union C c);
 #if (defined(PLATFORM_WIN) || defined(M_32))
 void root(struct BarHandle a, union C c);
 #endif
+
+void cond(struct ConditionalField a);

--- a/tests/expectations/cfg.both.compat.c
+++ b/tests/expectations/cfg.both.compat.c
@@ -89,6 +89,13 @@ typedef struct BarHandle {
 } BarHandle;
 #endif
 
+typedef struct ConditionalField {
+#if defined(X11)
+  int32_t field
+#endif
+  ;
+} ConditionalField;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -100,6 +107,8 @@ void root(struct FooHandle a, union C c);
 #if (defined(PLATFORM_WIN) || defined(M_32))
 void root(struct BarHandle a, union C c);
 #endif
+
+void cond(struct ConditionalField a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/cfg.c
+++ b/tests/expectations/cfg.c
@@ -71,6 +71,13 @@ typedef struct {
 } BarHandle;
 #endif
 
+typedef struct {
+#if defined(X11)
+  int32_t field
+#endif
+  ;
+} ConditionalField;
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(FooHandle a, C c);
 #endif
@@ -78,3 +85,5 @@ void root(FooHandle a, C c);
 #if (defined(PLATFORM_WIN) || defined(M_32))
 void root(BarHandle a, C c);
 #endif
+
+void cond(ConditionalField a);

--- a/tests/expectations/cfg.compat.c
+++ b/tests/expectations/cfg.compat.c
@@ -89,6 +89,13 @@ typedef struct {
 } BarHandle;
 #endif
 
+typedef struct {
+#if defined(X11)
+  int32_t field
+#endif
+  ;
+} ConditionalField;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -100,6 +107,8 @@ void root(FooHandle a, C c);
 #if (defined(PLATFORM_WIN) || defined(M_32))
 void root(BarHandle a, C c);
 #endif
+
+void cond(ConditionalField a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/cfg.cpp
+++ b/tests/expectations/cfg.cpp
@@ -195,6 +195,13 @@ struct BarHandle {
 };
 #endif
 
+struct ConditionalField {
+#if defined(X11)
+  int32_t field
+#endif
+  ;
+};
+
 extern "C" {
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
@@ -204,5 +211,7 @@ void root(FooHandle a, C c);
 #if (defined(PLATFORM_WIN) || defined(M_32))
 void root(BarHandle a, C c);
 #endif
+
+void cond(ConditionalField a);
 
 } // extern "C"

--- a/tests/expectations/cfg.pyx
+++ b/tests/expectations/cfg.pyx
@@ -55,8 +55,13 @@ cdef extern from *:
       int32_t x;
       float y;
 
+  ctypedef struct ConditionalField:
+    int32_t field;
+
   IF (PLATFORM_UNIX and X11):
     void root(FooHandle a, C c);
 
   IF (PLATFORM_WIN or M_32):
     void root(BarHandle a, C c);
+
+  void cond(ConditionalField a);

--- a/tests/expectations/cfg.tag.c
+++ b/tests/expectations/cfg.tag.c
@@ -71,6 +71,13 @@ struct BarHandle {
 };
 #endif
 
+struct ConditionalField {
+#if defined(X11)
+  int32_t field
+#endif
+  ;
+};
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(struct FooHandle a, union C c);
 #endif
@@ -78,3 +85,5 @@ void root(struct FooHandle a, union C c);
 #if (defined(PLATFORM_WIN) || defined(M_32))
 void root(struct BarHandle a, union C c);
 #endif
+
+void cond(struct ConditionalField a);

--- a/tests/expectations/cfg.tag.compat.c
+++ b/tests/expectations/cfg.tag.compat.c
@@ -89,6 +89,13 @@ struct BarHandle {
 };
 #endif
 
+struct ConditionalField {
+#if defined(X11)
+  int32_t field
+#endif
+  ;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -100,6 +107,8 @@ void root(struct FooHandle a, union C c);
 #if (defined(PLATFORM_WIN) || defined(M_32))
 void root(struct BarHandle a, union C c);
 #endif
+
+void cond(struct ConditionalField a);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/cfg.tag.pyx
+++ b/tests/expectations/cfg.tag.pyx
@@ -55,8 +55,13 @@ cdef extern from *:
       int32_t x;
       float y;
 
+  cdef struct ConditionalField:
+    int32_t field;
+
   IF (PLATFORM_UNIX and X11):
     void root(FooHandle a, C c);
 
   IF (PLATFORM_WIN or M_32):
     void root(BarHandle a, C c);
+
+  void cond(ConditionalField a);

--- a/tests/rust/cfg.rs
+++ b/tests/rust/cfg.rs
@@ -40,6 +40,15 @@ struct BarHandle {
     y: f32,
 }
 
+// FIXME(#634): Support deriving methods for structs with conditional fields.
+/// cbindgen:derive-eq=false
+/// cbindgen:derive-neq=false
+#[repr(C)]
+struct ConditionalField {
+    #[cfg(x11)]
+    field: i32,
+}
+
 #[cfg(all(unix, x11))]
 #[no_mangle]
 pub extern "C" fn root(a: FooHandle, c: C)
@@ -48,4 +57,8 @@ pub extern "C" fn root(a: FooHandle, c: C)
 #[cfg(any(windows, target_pointer_width="32"))]
 #[no_mangle]
 pub extern "C" fn root(a: BarHandle, c: C)
+{ }
+
+#[no_mangle]
+pub extern "C" fn cond(a: ConditionalField)
 { }


### PR DESCRIPTION
Rebase of https://github.com/eqrion/cbindgen/pull/316.

#### Caveats:
- The ugly (but apparently harmless) stray semicolon
    ```c++
    #if !defined(FOO)
      uint8_t field
    #endif
      ;
    ```
- Deriving C++ methods on structs with conditional fields is not supported.

Both issues should be resolved by supporting configuring individual list elements in `write_vertical_source_list`, but that's a separate task.