### PR TITLE
Add support for const generics in structs

### DIFF
--- a/src/bindgen/ir/generic_path.rs
+++ b/src/bindgen/ir/generic_path.rs
@@ -17,7 +17,8 @@ impl GenericParams {
                 .params
                 .iter()
                 .filter_map(|x| match *x {
-                    syn::GenericParam::Type(syn::TypeParam { ref ident, .. }) => {
+                    syn::GenericParam::Type(syn::TypeParam { ref ident, .. })
+                    | syn::GenericParam::Const(syn::ConstParam { ref ident, .. }) => {
                         Some(Path::new(ident.to_string()))
                     }
                     _ => None,

--- a/tests/expectations/const_generics.both.c
+++ b/tests/expectations/const_generics.both.c
@@ -1,0 +1,10 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define SOME_NUMBER 20
+
+typedef struct StructWithConstGeneric_SOME_NUMBER StructWithConstGeneric_SOME_NUMBER;
+
+void root(const struct StructWithConstGeneric_SOME_NUMBER *a);

--- a/tests/expectations/const_generics.both.compat.c
+++ b/tests/expectations/const_generics.both.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define SOME_NUMBER 20
+
+typedef struct StructWithConstGeneric_SOME_NUMBER StructWithConstGeneric_SOME_NUMBER;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(const struct StructWithConstGeneric_SOME_NUMBER *a);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/const_generics.c
+++ b/tests/expectations/const_generics.c
@@ -1,0 +1,10 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define SOME_NUMBER 20
+
+typedef struct StructWithConstGeneric_SOME_NUMBER StructWithConstGeneric_SOME_NUMBER;
+
+void root(const StructWithConstGeneric_SOME_NUMBER *a);

--- a/tests/expectations/const_generics.compat.c
+++ b/tests/expectations/const_generics.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define SOME_NUMBER 20
+
+typedef struct StructWithConstGeneric_SOME_NUMBER StructWithConstGeneric_SOME_NUMBER;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(const StructWithConstGeneric_SOME_NUMBER *a);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/const_generics.cpp
+++ b/tests/expectations/const_generics.cpp
@@ -1,0 +1,16 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+static const uint8_t SOME_NUMBER = 20;
+
+template<typename N = void>
+struct StructWithConstGeneric;
+
+extern "C" {
+
+void root(const StructWithConstGeneric<SOME_NUMBER> *a);
+
+} // extern "C"

--- a/tests/expectations/const_generics.cpp_
+++ b/tests/expectations/const_generics.cpp_
@@ -1,0 +1,16 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+static const uint8_t SOME_NUMBER2 = 20;
+
+template<typename u8 = void>
+struct StructWithConstGeneric;
+
+extern "C" {
+
+void root(const StructWithConstGeneric<uint8_t> *a);
+
+} // extern "C"

--- a/tests/expectations/const_generics.pyx
+++ b/tests/expectations/const_generics.pyx
@@ -1,0 +1,9 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  const uint8_t SOME_NUMBER # = 20

--- a/tests/expectations/const_generics.tag.c
+++ b/tests/expectations/const_generics.tag.c
@@ -1,0 +1,10 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define SOME_NUMBER 20
+
+struct StructWithConstGeneric_SOME_NUMBER;
+
+void root(const struct StructWithConstGeneric_SOME_NUMBER *a);

--- a/tests/expectations/const_generics.tag.compat.c
+++ b/tests/expectations/const_generics.tag.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define SOME_NUMBER 20
+
+struct StructWithConstGeneric_SOME_NUMBER;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(const struct StructWithConstGeneric_SOME_NUMBER *a);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/rust/const_generics.rs
+++ b/tests/rust/const_generics.rs
@@ -1,0 +1,6 @@
+pub struct StructWithConstGeneric<const N: u8>;
+
+pub const SOME_NUMBER: u8 = 20;
+
+#[no_mangle]
+pub extern "C" fn root(a: &StructWithConstGeneric<SOME_NUMBER>) {}


### PR DESCRIPTION
It's now possible to have a const generic in a struct definition.

Example:

    pub struct StructWithConstGeneric<const N: u8>;

It only works for a very limited case. When the struct is used, you
need to supply a defined constant, you cannot use a value directly.

This works:

    const SOME_NUMBER: u8 = 123;
    #[no_mangle]
    pub unsafe extern "C" fn hello_generic(_hello_generic: *const HelloConstGeneric<SOME_NUMBER>) {}

This one doesn't work:

    #[no_mangle]
    pub unsafe extern "C" fn hello_generic(_hello_generic: *const HelloConstGeneric<123>) {}

Even with this limitation it isn't fully working yet. The C++ code doesn't compile. Can someone please tell me what the expected output for C++ should look like?
