### PR TITLE
Skip profiles test in package.

### DIFF
--- a/.github/workflows/cbindgen.yml
+++ b/.github/workflows/cbindgen.yml
@@ -78,10 +78,14 @@ jobs:
       run: |
         cargo test --verbose
 
-    - name: Cargo update minimal-versions
+    - name: Test package
+      env:
+        CBINDGEN_TEST_VERIFY: 1
       run: |
-        cargo update -Zminimal-versions
+        cargo package --verbose
+        (cd target/package/cbindgen-$(cargo run -- --version | cut -d ' ' -f 2) && cargo test --verbose)
 
     - name: Test minimal-versions
       run: |
+        cargo update -Zminimal-versions
         cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["bindings", "ffi", "code-generation"]
 categories = ["external-ffi-bindings", "development-tools::ffi"]
 repository = "https://github.com/eqrion/cbindgen/"
 edition = "2018"
+exclude = [
+  "tests/profile.rs", # Test relies in a sub-crate, see https://github.com/rust-lang/cargo/issues/9017
+]
 
 [badges]
 travis-ci = { repository = "eqrion/cbindgen" }


### PR DESCRIPTION
As it relies in a sub-crate, see rust-lang/cargo#9017.