### PR TITLE
Reintroduce clippy checks

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,2 @@
+# Specify the minimum supported Rust version
+msrv = "1.40.0"

--- a/.github/workflows/cbindgen.yml
+++ b/.github/workflows/cbindgen.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  rustfmt:
+  rustfmt-clippy:
 
     runs-on: ubuntu-latest
 
@@ -29,6 +29,13 @@ jobs:
       with:
         command: fmt
         args: -- --check
+
+    - name: Install clippy
+      uses: dtolnay/rust-toolchain@clippy
+
+    - name: Run clippy
+      run: |
+        cargo clippy --workspace -- -D warnings
 
     - name: Install minimum supported Rust version
       uses: actions-rs/toolchain@v1

--- a/src/bindgen/cargo/cargo_expand.rs
+++ b/src/bindgen/cargo/cargo_expand.rs
@@ -58,6 +58,7 @@ impl error::Error for Error {
 
 /// Use rustc to expand and pretty print the crate into a single file,
 /// removing any macros in the process.
+#[allow(clippy::too_many_arguments)]
 pub fn expand(
     manifest_path: &Path,
     crate_name: &str,

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -1141,7 +1141,7 @@ impl Enum {
                             write!(out, "{} ", attrs);
                         }
                     }};
-                };
+                }
 
                 write_attrs!("constructor");
                 write!(out, "static {} {}(", self.export_name, variant.export_name);
@@ -1297,7 +1297,7 @@ impl Enum {
                     write!(out, "{} ", attrs);
                 }
             }};
-        };
+        }
 
         if self.can_derive_eq() && config.structure.derive_eq(&self.annotations) {
             out.new_line();

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -61,7 +61,7 @@ impl Function {
                     never_return = true;
                     Type::Primitive(PrimitiveType::Void)
                 } else {
-                    Type::load(ty)?.unwrap_or_else(|| Type::Primitive(PrimitiveType::Void))
+                    Type::load(ty)?.unwrap_or(Type::Primitive(PrimitiveType::Void))
                 }
             }
         };
@@ -328,7 +328,7 @@ impl Source for Function {
             out.write(";");
 
             condition.write_after(config, out);
-        };
+        }
 
         let option_1 = out.measure(|out| write_1(self, config, out));
 

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -645,7 +645,7 @@ impl Source for Struct {
                     out.write(";");
                     out.close_brace(false);
                 }};
-            };
+            }
 
             if config.structure.derive_eq(&self.annotations) && self.can_derive_eq() {
                 emit_op!("eq", "==", "&&");


### PR DESCRIPTION
Now it is possible to set the minimal `Rust` version in the `.clippy.toml` file, so lints newer than `MSRV` are disabled.

Thanks in advance for your review! :)