### PR TITLE
ir: Deal with name conflicts correctly in declaration type resolution.

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -476,12 +476,17 @@ impl Item for Enum {
     }
 
     fn collect_declaration_types(&self, resolver: &mut DeclarationTypeResolver) {
-        if self.tag.is_some() && self.repr.style == ReprStyle::C {
-            resolver.add_struct(&self.path);
-        } else if self.tag.is_some() && self.repr.style != ReprStyle::C {
-            resolver.add_union(&self.path);
+        if self.tag.is_some() {
+            if self.repr.style == ReprStyle::C {
+                resolver.add_struct(&self.path);
+            } else {
+                resolver.add_union(&self.path);
+            }
         } else if self.repr.style == ReprStyle::C {
             resolver.add_enum(&self.path);
+        } else {
+            // This is important to handle conflicting names with opaque items.
+            resolver.add_none(&self.path);
         }
     }
 

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -266,7 +266,9 @@ impl Item for Struct {
     }
 
     fn collect_declaration_types(&self, resolver: &mut DeclarationTypeResolver) {
-        if !self.is_transparent {
+        if self.is_transparent {
+            resolver.add_none(&self.path);
+        } else {
             resolver.add_struct(&self.path);
         }
     }

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -138,6 +138,10 @@ impl Item for Typedef {
         self.aliased.rename_for_config(config, &self.generic_params);
     }
 
+    fn collect_declaration_types(&self, resolver: &mut DeclarationTypeResolver) {
+        resolver.add_none(&self.path);
+    }
+
     fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {
         self.aliased.resolve_declaration_types(resolver);
     }

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -318,15 +318,21 @@ impl Library {
             x.collect_declaration_types(&mut resolver);
         });
 
-        self.opaque_items.for_all_items(|x| {
-            x.collect_declaration_types(&mut resolver);
-        });
-
         self.enums.for_all_items(|x| {
             x.collect_declaration_types(&mut resolver);
         });
 
         self.unions.for_all_items(|x| {
+            x.collect_declaration_types(&mut resolver);
+        });
+
+        self.typedefs.for_all_items(|x| {
+            x.collect_declaration_types(&mut resolver);
+        });
+
+        // NOTE: Intentionally last, so that in case there's an opaque type
+        // which is conflicting with a non-opaque one, the later wins.
+        self.opaque_items.for_all_items(|x| {
             x.collect_declaration_types(&mut resolver);
         });
 

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -653,7 +653,7 @@ impl Parse {
         }
 
         let loggable_item_name = || {
-            let mut items = vec![];
+            let mut items = Vec::with_capacity(3);
             items.push(crate_name.to_owned());
             if let Some(ref self_type) = self_type {
                 items.push(self_type.to_string());

--- a/tests/expectations/decl_name_conflicting.both.c
+++ b/tests/expectations/decl_name_conflicting.both.c
@@ -1,0 +1,16 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum BindingType {
+  Buffer = 0,
+  NotBuffer = 1,
+};
+typedef uint32_t BindingType;
+
+typedef struct BindGroupLayoutEntry {
+  BindingType ty;
+} BindGroupLayoutEntry;
+
+void root(struct BindGroupLayoutEntry entry);

--- a/tests/expectations/decl_name_conflicting.both.compat.c
+++ b/tests/expectations/decl_name_conflicting.both.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum BindingType
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  Buffer = 0,
+  NotBuffer = 1,
+};
+#ifndef __cplusplus
+typedef uint32_t BindingType;
+#endif // __cplusplus
+
+typedef struct BindGroupLayoutEntry {
+  BindingType ty;
+} BindGroupLayoutEntry;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(struct BindGroupLayoutEntry entry);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/decl_name_conflicting.c
+++ b/tests/expectations/decl_name_conflicting.c
@@ -1,0 +1,16 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum BindingType {
+  Buffer = 0,
+  NotBuffer = 1,
+};
+typedef uint32_t BindingType;
+
+typedef struct {
+  BindingType ty;
+} BindGroupLayoutEntry;
+
+void root(BindGroupLayoutEntry entry);

--- a/tests/expectations/decl_name_conflicting.compat.c
+++ b/tests/expectations/decl_name_conflicting.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum BindingType
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  Buffer = 0,
+  NotBuffer = 1,
+};
+#ifndef __cplusplus
+typedef uint32_t BindingType;
+#endif // __cplusplus
+
+typedef struct {
+  BindingType ty;
+} BindGroupLayoutEntry;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(BindGroupLayoutEntry entry);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/decl_name_conflicting.cpp
+++ b/tests/expectations/decl_name_conflicting.cpp
@@ -1,0 +1,20 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+enum class BindingType : uint32_t {
+  Buffer = 0,
+  NotBuffer = 1,
+};
+
+struct BindGroupLayoutEntry {
+  BindingType ty;
+};
+
+extern "C" {
+
+void root(BindGroupLayoutEntry entry);
+
+} // extern "C"

--- a/tests/expectations/decl_name_conflicting.pyx
+++ b/tests/expectations/decl_name_conflicting.pyx
@@ -1,0 +1,17 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  cdef enum:
+    Buffer # = 0,
+    NotBuffer # = 1,
+  ctypedef uint32_t BindingType;
+
+  ctypedef struct BindGroupLayoutEntry:
+    BindingType ty;
+
+  void root(BindGroupLayoutEntry entry);

--- a/tests/expectations/decl_name_conflicting.tag.c
+++ b/tests/expectations/decl_name_conflicting.tag.c
@@ -1,0 +1,16 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum BindingType {
+  Buffer = 0,
+  NotBuffer = 1,
+};
+typedef uint32_t BindingType;
+
+struct BindGroupLayoutEntry {
+  BindingType ty;
+};
+
+void root(struct BindGroupLayoutEntry entry);

--- a/tests/expectations/decl_name_conflicting.tag.compat.c
+++ b/tests/expectations/decl_name_conflicting.tag.compat.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+enum BindingType
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  Buffer = 0,
+  NotBuffer = 1,
+};
+#ifndef __cplusplus
+typedef uint32_t BindingType;
+#endif // __cplusplus
+
+struct BindGroupLayoutEntry {
+  BindingType ty;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(struct BindGroupLayoutEntry entry);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/decl_name_conflicting.tag.pyx
+++ b/tests/expectations/decl_name_conflicting.tag.pyx
@@ -1,0 +1,17 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  cdef enum:
+    Buffer # = 0,
+    NotBuffer # = 1,
+  ctypedef uint32_t BindingType;
+
+  cdef struct BindGroupLayoutEntry:
+    BindingType ty;
+
+  void root(BindGroupLayoutEntry entry);

--- a/tests/rust/decl_name_conflicting.rs
+++ b/tests/rust/decl_name_conflicting.rs
@@ -1,0 +1,14 @@
+mod uhoh {
+    enum BindingType { Buffer, NotBuffer }
+}
+
+#[repr(u32)]
+pub enum BindingType { Buffer = 0, NotBuffer = 1 }
+
+#[repr(C)]
+pub struct BindGroupLayoutEntry {
+    pub ty: BindingType, // This is the repr(u32) enum
+}
+
+#[no_mangle]
+pub extern "C" fn root(entry: BindGroupLayoutEntry) {}


### PR DESCRIPTION
So, basically, make opaque items last, and make previous names override
them.

Fixes #649