### PR TITLE
feat: Add the `none` documentation style

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -484,6 +484,7 @@ tab_width = 3
 # How the generated documentation should be commented.
 #
 # possible values:
+# * "none": documentation is not generated
 # * "c": /* like this */
 # * "c99": // like this
 # * "c++": /// like this

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -165,6 +165,7 @@ deserialize_enum_str!(Layout);
 /// How the comments containing documentation should be styled.
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub enum DocumentationStyle {
+    None,
     C,
     C99,
     Doxy,
@@ -177,6 +178,7 @@ impl FromStr for DocumentationStyle {
 
     fn from_str(s: &str) -> Result<DocumentationStyle, Self::Err> {
         match s.to_lowercase().as_ref() {
+            "none" => Ok(DocumentationStyle::None),
             "c" => Ok(DocumentationStyle::C),
             "c99" => Ok(DocumentationStyle::C99),
             "cxx" => Ok(DocumentationStyle::Cxx),

--- a/src/bindgen/ir/documentation.rs
+++ b/src/bindgen/ir/documentation.rs
@@ -39,7 +39,10 @@ impl Documentation {
 
 impl Source for Documentation {
     fn write<F: Write>(&self, config: &Config, out: &mut SourceWriter<F>) {
-        if self.doc_comment.is_empty() || !config.documentation {
+        if self.doc_comment.is_empty()
+            || !config.documentation
+            || config.documentation_style == DocumentationStyle::None
+        {
             return;
         }
 
@@ -82,7 +85,7 @@ impl Source for Documentation {
                 DocumentationStyle::Doxy => out.write(" *"),
                 DocumentationStyle::C99 => out.write("//"),
                 DocumentationStyle::Cxx => out.write("///"),
-                DocumentationStyle::Auto => unreachable!(), // Auto case should always be covered
+                DocumentationStyle::Auto | DocumentationStyle::None => unreachable!(), // `Auto` and `None` cases should always be covered
             }
 
             write!(out, "{}", line);


### PR DESCRIPTION
This new documentation style skips the generation of the documentation.

I'm not sure how to test it. Any clue?