### PR TITLE
ir: simplify_standard_types should be recursive.

### DIFF
--- a/tests/expectations/simplify_option_ptr.both.c
+++ b/tests/expectations/simplify_option_ptr.both.c
@@ -7,24 +7,23 @@ typedef struct Opaque Opaque;
 
 typedef struct Option_____Opaque Option_____Opaque;
 
-typedef struct Option_______c_void Option_______c_void;
-
 typedef struct Foo {
   const struct Opaque *x;
   struct Opaque *y;
   void (*z)(void);
-  struct Option_______c_void *zz;
+  void (**zz)(void);
 } Foo;
 
 typedef union Bar {
   const struct Opaque *x;
   struct Opaque *y;
   void (*z)(void);
-  struct Option_______c_void *zz;
+  void (**zz)(void);
 } Bar;
 
 void root(const struct Opaque *a,
           struct Opaque *b,
           struct Foo c,
           union Bar d,
-          struct Option_____Opaque *e);
+          struct Option_____Opaque *e,
+          void (*f)(const struct Opaque*));

--- a/tests/expectations/simplify_option_ptr.both.compat.c
+++ b/tests/expectations/simplify_option_ptr.both.compat.c
@@ -7,20 +7,18 @@ typedef struct Opaque Opaque;
 
 typedef struct Option_____Opaque Option_____Opaque;
 
-typedef struct Option_______c_void Option_______c_void;
-
 typedef struct Foo {
   const struct Opaque *x;
   struct Opaque *y;
   void (*z)(void);
-  struct Option_______c_void *zz;
+  void (**zz)(void);
 } Foo;
 
 typedef union Bar {
   const struct Opaque *x;
   struct Opaque *y;
   void (*z)(void);
-  struct Option_______c_void *zz;
+  void (**zz)(void);
 } Bar;
 
 #ifdef __cplusplus
@@ -31,7 +29,8 @@ void root(const struct Opaque *a,
           struct Opaque *b,
           struct Foo c,
           union Bar d,
-          struct Option_____Opaque *e);
+          struct Option_____Opaque *e,
+          void (*f)(const struct Opaque*));
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/simplify_option_ptr.c
+++ b/tests/expectations/simplify_option_ptr.c
@@ -7,20 +7,18 @@ typedef struct Opaque Opaque;
 
 typedef struct Option_____Opaque Option_____Opaque;
 
-typedef struct Option_______c_void Option_______c_void;
-
 typedef struct {
   const Opaque *x;
   Opaque *y;
   void (*z)(void);
-  Option_______c_void *zz;
+  void (**zz)(void);
 } Foo;
 
 typedef union {
   const Opaque *x;
   Opaque *y;
   void (*z)(void);
-  Option_______c_void *zz;
+  void (**zz)(void);
 } Bar;
 
-void root(const Opaque *a, Opaque *b, Foo c, Bar d, Option_____Opaque *e);
+void root(const Opaque *a, Opaque *b, Foo c, Bar d, Option_____Opaque *e, void (*f)(const Opaque*));

--- a/tests/expectations/simplify_option_ptr.compat.c
+++ b/tests/expectations/simplify_option_ptr.compat.c
@@ -7,27 +7,25 @@ typedef struct Opaque Opaque;
 
 typedef struct Option_____Opaque Option_____Opaque;
 
-typedef struct Option_______c_void Option_______c_void;
-
 typedef struct {
   const Opaque *x;
   Opaque *y;
   void (*z)(void);
-  Option_______c_void *zz;
+  void (**zz)(void);
 } Foo;
 
 typedef union {
   const Opaque *x;
   Opaque *y;
   void (*z)(void);
-  Option_______c_void *zz;
+  void (**zz)(void);
 } Bar;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(const Opaque *a, Opaque *b, Foo c, Bar d, Option_____Opaque *e);
+void root(const Opaque *a, Opaque *b, Foo c, Bar d, Option_____Opaque *e, void (*f)(const Opaque*));
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/simplify_option_ptr.cpp
+++ b/tests/expectations/simplify_option_ptr.cpp
@@ -13,18 +13,18 @@ struct Foo {
   const Opaque *x;
   Opaque *y;
   void (*z)();
-  Option<void(*)()> *zz;
+  void (**zz)();
 };
 
 union Bar {
   const Opaque *x;
   Opaque *y;
   void (*z)();
-  Option<void(*)()> *zz;
+  void (**zz)();
 };
 
 extern "C" {
 
-void root(const Opaque *a, Opaque *b, Foo c, Bar d, Option<Opaque*> *e);
+void root(const Opaque *a, Opaque *b, Foo c, Bar d, Option<Opaque*> *e, void (*f)(const Opaque*));
 
 } // extern "C"

--- a/tests/expectations/simplify_option_ptr.pyx
+++ b/tests/expectations/simplify_option_ptr.pyx
@@ -12,19 +12,21 @@ cdef extern from *:
   ctypedef struct Option_____Opaque:
     pass
 
-  ctypedef struct Option_______c_void:
-    pass
-
   ctypedef struct Foo:
     const Opaque *x;
     Opaque *y;
     void (*z)();
-    Option_______c_void *zz;
+    void (**zz)();
 
   ctypedef union Bar:
     const Opaque *x;
     Opaque *y;
     void (*z)();
-    Option_______c_void *zz;
+    void (**zz)();
 
-  void root(const Opaque *a, Opaque *b, Foo c, Bar d, Option_____Opaque *e);
+  void root(const Opaque *a,
+            Opaque *b,
+            Foo c,
+            Bar d,
+            Option_____Opaque *e,
+            void (*f)(const Opaque*));

--- a/tests/expectations/simplify_option_ptr.tag.c
+++ b/tests/expectations/simplify_option_ptr.tag.c
@@ -7,24 +7,23 @@ struct Opaque;
 
 struct Option_____Opaque;
 
-struct Option_______c_void;
-
 struct Foo {
   const struct Opaque *x;
   struct Opaque *y;
   void (*z)(void);
-  struct Option_______c_void *zz;
+  void (**zz)(void);
 };
 
 union Bar {
   const struct Opaque *x;
   struct Opaque *y;
   void (*z)(void);
-  struct Option_______c_void *zz;
+  void (**zz)(void);
 };
 
 void root(const struct Opaque *a,
           struct Opaque *b,
           struct Foo c,
           union Bar d,
-          struct Option_____Opaque *e);
+          struct Option_____Opaque *e,
+          void (*f)(const struct Opaque*));

--- a/tests/expectations/simplify_option_ptr.tag.compat.c
+++ b/tests/expectations/simplify_option_ptr.tag.compat.c
@@ -7,20 +7,18 @@ struct Opaque;
 
 struct Option_____Opaque;
 
-struct Option_______c_void;
-
 struct Foo {
   const struct Opaque *x;
   struct Opaque *y;
   void (*z)(void);
-  struct Option_______c_void *zz;
+  void (**zz)(void);
 };
 
 union Bar {
   const struct Opaque *x;
   struct Opaque *y;
   void (*z)(void);
-  struct Option_______c_void *zz;
+  void (**zz)(void);
 };
 
 #ifdef __cplusplus
@@ -31,7 +29,8 @@ void root(const struct Opaque *a,
           struct Opaque *b,
           struct Foo c,
           union Bar d,
-          struct Option_____Opaque *e);
+          struct Option_____Opaque *e,
+          void (*f)(const struct Opaque*));
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/simplify_option_ptr.tag.pyx
+++ b/tests/expectations/simplify_option_ptr.tag.pyx
@@ -12,19 +12,21 @@ cdef extern from *:
   cdef struct Option_____Opaque:
     pass
 
-  cdef struct Option_______c_void:
-    pass
-
   cdef struct Foo:
     const Opaque *x;
     Opaque *y;
     void (*z)();
-    Option_______c_void *zz;
+    void (**zz)();
 
   cdef union Bar:
     const Opaque *x;
     Opaque *y;
     void (*z)();
-    Option_______c_void *zz;
+    void (**zz)();
 
-  void root(const Opaque *a, Opaque *b, Foo c, Bar d, Option_____Opaque *e);
+  void root(const Opaque *a,
+            Opaque *b,
+            Foo c,
+            Bar d,
+            Option_____Opaque *e,
+            void (*f)(const Opaque*));

--- a/tests/rust/simplify_option_ptr.rs
+++ b/tests/rust/simplify_option_ptr.rs
@@ -24,4 +24,5 @@ pub extern "C" fn root(
     c: Foo,
     d: Bar,
     e: *mut Option<*mut Opaque>,
+    f: extern "C" fn(Option<&Opaque>),
 ) { }


### PR DESCRIPTION
Stuff like `*mut Option<&mut Foo>` should really be `*mut *mut Foo` for
example.