### PR TITLE
ir: Simplify types in generics.

### DIFF
--- a/src/bindgen/ir/generic_path.rs
+++ b/src/bindgen/ir/generic_path.rs
@@ -94,9 +94,7 @@ impl GenericPath {
         if self.path.replace_self_with(self_ty) {
             self.export_name = self_ty.name().to_owned();
         }
-        for ty in &mut self.generics {
-            ty.replace_self_with(self_ty);
-        }
+        // Caller deals with generics.
     }
 
     pub fn path(&self) -> &Path {
@@ -105,6 +103,10 @@ impl GenericPath {
 
     pub fn generics(&self) -> &[Type] {
         &self.generics
+    }
+
+    pub fn generics_mut(&mut self) -> &mut [Type] {
+        &mut self.generics
     }
 
     pub fn ctype(&self) -> Option<&DeclarationType> {

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -654,7 +654,12 @@ impl Type {
     fn visit_types(&mut self, mut visitor: impl FnMut(&mut Type)) {
         match *self {
             Type::Array(ref mut ty, ..) | Type::Ptr { ref mut ty, .. } => visitor(ty),
-            Type::Path(..) | Type::Primitive(..) => {}
+            Type::Path(ref mut path) => {
+                for generic in path.generics_mut() {
+                    visitor(generic);
+                }
+            }
+            Type::Primitive(..) => {}
             Type::FuncPtr {
                 ref mut ret,
                 ref mut args,

--- a/tests/expectations/box.both.c
+++ b/tests/expectations/box.both.c
@@ -17,9 +17,9 @@ using Box = T*;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_Box_i32 NotReprC_Box_i32;
+typedef struct NotReprC_____i32 NotReprC_____i32;
 
-typedef struct NotReprC_Box_i32 Foo;
+typedef struct NotReprC_____i32 Foo;
 
 typedef struct MyStruct {
   int32_t *number;

--- a/tests/expectations/box.both.compat.c
+++ b/tests/expectations/box.both.compat.c
@@ -17,9 +17,9 @@ using Box = T*;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_Box_i32 NotReprC_Box_i32;
+typedef struct NotReprC_____i32 NotReprC_____i32;
 
-typedef struct NotReprC_Box_i32 Foo;
+typedef struct NotReprC_____i32 Foo;
 
 typedef struct MyStruct {
   int32_t *number;

--- a/tests/expectations/box.c
+++ b/tests/expectations/box.c
@@ -17,9 +17,9 @@ using Box = T*;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_Box_i32 NotReprC_Box_i32;
+typedef struct NotReprC_____i32 NotReprC_____i32;
 
-typedef NotReprC_Box_i32 Foo;
+typedef NotReprC_____i32 Foo;
 
 typedef struct {
   int32_t *number;

--- a/tests/expectations/box.compat.c
+++ b/tests/expectations/box.compat.c
@@ -17,9 +17,9 @@ using Box = T*;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_Box_i32 NotReprC_Box_i32;
+typedef struct NotReprC_____i32 NotReprC_____i32;
 
-typedef NotReprC_Box_i32 Foo;
+typedef NotReprC_____i32 Foo;
 
 typedef struct {
   int32_t *number;

--- a/tests/expectations/box.pyx
+++ b/tests/expectations/box.pyx
@@ -20,10 +20,10 @@ cdef extern from *:
 
 cdef extern from *:
 
-  ctypedef struct NotReprC_Box_i32:
+  ctypedef struct NotReprC_____i32:
     pass
 
-  ctypedef NotReprC_Box_i32 Foo;
+  ctypedef NotReprC_____i32 Foo;
 
   ctypedef struct MyStruct:
     int32_t *number;

--- a/tests/expectations/box.tag.c
+++ b/tests/expectations/box.tag.c
@@ -17,9 +17,9 @@ using Box = T*;
 #include <stdint.h>
 #include <stdlib.h>
 
-struct NotReprC_Box_i32;
+struct NotReprC_____i32;
 
-typedef struct NotReprC_Box_i32 Foo;
+typedef struct NotReprC_____i32 Foo;
 
 struct MyStruct {
   int32_t *number;

--- a/tests/expectations/box.tag.compat.c
+++ b/tests/expectations/box.tag.compat.c
@@ -17,9 +17,9 @@ using Box = T*;
 #include <stdint.h>
 #include <stdlib.h>
 
-struct NotReprC_Box_i32;
+struct NotReprC_____i32;
 
-typedef struct NotReprC_Box_i32 Foo;
+typedef struct NotReprC_____i32 Foo;
 
 struct MyStruct {
   int32_t *number;

--- a/tests/expectations/box.tag.pyx
+++ b/tests/expectations/box.tag.pyx
@@ -20,10 +20,10 @@ cdef extern from *:
 
 cdef extern from *:
 
-  cdef struct NotReprC_Box_i32:
+  cdef struct NotReprC_____i32:
     pass
 
-  ctypedef NotReprC_Box_i32 Foo;
+  ctypedef NotReprC_____i32 Foo;
 
   cdef struct MyStruct:
     int32_t *number;

--- a/tests/expectations/manuallydrop.both.c
+++ b/tests/expectations/manuallydrop.both.c
@@ -17,9 +17,9 @@ using ManuallyDrop = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_ManuallyDrop_Point NotReprC_ManuallyDrop_Point;
+typedef struct NotReprC_Point NotReprC_Point;
 
-typedef struct NotReprC_ManuallyDrop_Point Foo;
+typedef struct NotReprC_Point Foo;
 
 typedef struct Point {
   int32_t x;

--- a/tests/expectations/manuallydrop.both.compat.c
+++ b/tests/expectations/manuallydrop.both.compat.c
@@ -17,9 +17,9 @@ using ManuallyDrop = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_ManuallyDrop_Point NotReprC_ManuallyDrop_Point;
+typedef struct NotReprC_Point NotReprC_Point;
 
-typedef struct NotReprC_ManuallyDrop_Point Foo;
+typedef struct NotReprC_Point Foo;
 
 typedef struct Point {
   int32_t x;

--- a/tests/expectations/manuallydrop.c
+++ b/tests/expectations/manuallydrop.c
@@ -17,9 +17,9 @@ using ManuallyDrop = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_ManuallyDrop_Point NotReprC_ManuallyDrop_Point;
+typedef struct NotReprC_Point NotReprC_Point;
 
-typedef NotReprC_ManuallyDrop_Point Foo;
+typedef NotReprC_Point Foo;
 
 typedef struct {
   int32_t x;

--- a/tests/expectations/manuallydrop.compat.c
+++ b/tests/expectations/manuallydrop.compat.c
@@ -17,9 +17,9 @@ using ManuallyDrop = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_ManuallyDrop_Point NotReprC_ManuallyDrop_Point;
+typedef struct NotReprC_Point NotReprC_Point;
 
-typedef NotReprC_ManuallyDrop_Point Foo;
+typedef NotReprC_Point Foo;
 
 typedef struct {
   int32_t x;

--- a/tests/expectations/manuallydrop.pyx
+++ b/tests/expectations/manuallydrop.pyx
@@ -20,10 +20,10 @@ cdef extern from *:
 
 cdef extern from *:
 
-  ctypedef struct NotReprC_ManuallyDrop_Point:
+  ctypedef struct NotReprC_Point:
     pass
 
-  ctypedef NotReprC_ManuallyDrop_Point Foo;
+  ctypedef NotReprC_Point Foo;
 
   ctypedef struct Point:
     int32_t x;

--- a/tests/expectations/manuallydrop.tag.c
+++ b/tests/expectations/manuallydrop.tag.c
@@ -17,9 +17,9 @@ using ManuallyDrop = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-struct NotReprC_ManuallyDrop_Point;
+struct NotReprC_Point;
 
-typedef struct NotReprC_ManuallyDrop_Point Foo;
+typedef struct NotReprC_Point Foo;
 
 struct Point {
   int32_t x;

--- a/tests/expectations/manuallydrop.tag.compat.c
+++ b/tests/expectations/manuallydrop.tag.compat.c
@@ -17,9 +17,9 @@ using ManuallyDrop = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-struct NotReprC_ManuallyDrop_Point;
+struct NotReprC_Point;
 
-typedef struct NotReprC_ManuallyDrop_Point Foo;
+typedef struct NotReprC_Point Foo;
 
 struct Point {
   int32_t x;

--- a/tests/expectations/manuallydrop.tag.pyx
+++ b/tests/expectations/manuallydrop.tag.pyx
@@ -20,10 +20,10 @@ cdef extern from *:
 
 cdef extern from *:
 
-  cdef struct NotReprC_ManuallyDrop_Point:
+  cdef struct NotReprC_Point:
     pass
 
-  ctypedef NotReprC_ManuallyDrop_Point Foo;
+  ctypedef NotReprC_Point Foo;
 
   cdef struct Point:
     int32_t x;

--- a/tests/expectations/maybeuninit.both.c
+++ b/tests/expectations/maybeuninit.both.c
@@ -17,9 +17,9 @@ using MaybeUninit = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_MaybeUninit______i32 NotReprC_MaybeUninit______i32;
+typedef struct NotReprC______i32 NotReprC______i32;
 
-typedef struct NotReprC_MaybeUninit______i32 Foo;
+typedef struct NotReprC______i32 Foo;
 
 typedef struct MyStruct {
   const int32_t *number;

--- a/tests/expectations/maybeuninit.both.compat.c
+++ b/tests/expectations/maybeuninit.both.compat.c
@@ -17,9 +17,9 @@ using MaybeUninit = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_MaybeUninit______i32 NotReprC_MaybeUninit______i32;
+typedef struct NotReprC______i32 NotReprC______i32;
 
-typedef struct NotReprC_MaybeUninit______i32 Foo;
+typedef struct NotReprC______i32 Foo;
 
 typedef struct MyStruct {
   const int32_t *number;

--- a/tests/expectations/maybeuninit.c
+++ b/tests/expectations/maybeuninit.c
@@ -17,9 +17,9 @@ using MaybeUninit = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_MaybeUninit______i32 NotReprC_MaybeUninit______i32;
+typedef struct NotReprC______i32 NotReprC______i32;
 
-typedef NotReprC_MaybeUninit______i32 Foo;
+typedef NotReprC______i32 Foo;
 
 typedef struct {
   const int32_t *number;

--- a/tests/expectations/maybeuninit.compat.c
+++ b/tests/expectations/maybeuninit.compat.c
@@ -17,9 +17,9 @@ using MaybeUninit = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct NotReprC_MaybeUninit______i32 NotReprC_MaybeUninit______i32;
+typedef struct NotReprC______i32 NotReprC______i32;
 
-typedef NotReprC_MaybeUninit______i32 Foo;
+typedef NotReprC______i32 Foo;
 
 typedef struct {
   const int32_t *number;

--- a/tests/expectations/maybeuninit.pyx
+++ b/tests/expectations/maybeuninit.pyx
@@ -20,10 +20,10 @@ cdef extern from *:
 
 cdef extern from *:
 
-  ctypedef struct NotReprC_MaybeUninit______i32:
+  ctypedef struct NotReprC______i32:
     pass
 
-  ctypedef NotReprC_MaybeUninit______i32 Foo;
+  ctypedef NotReprC______i32 Foo;
 
   ctypedef struct MyStruct:
     const int32_t *number;

--- a/tests/expectations/maybeuninit.tag.c
+++ b/tests/expectations/maybeuninit.tag.c
@@ -17,9 +17,9 @@ using MaybeUninit = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-struct NotReprC_MaybeUninit______i32;
+struct NotReprC______i32;
 
-typedef struct NotReprC_MaybeUninit______i32 Foo;
+typedef struct NotReprC______i32 Foo;
 
 struct MyStruct {
   const int32_t *number;

--- a/tests/expectations/maybeuninit.tag.compat.c
+++ b/tests/expectations/maybeuninit.tag.compat.c
@@ -17,9 +17,9 @@ using MaybeUninit = T;
 #include <stdint.h>
 #include <stdlib.h>
 
-struct NotReprC_MaybeUninit______i32;
+struct NotReprC______i32;
 
-typedef struct NotReprC_MaybeUninit______i32 Foo;
+typedef struct NotReprC______i32 Foo;
 
 struct MyStruct {
   const int32_t *number;

--- a/tests/expectations/maybeuninit.tag.pyx
+++ b/tests/expectations/maybeuninit.tag.pyx
@@ -20,10 +20,10 @@ cdef extern from *:
 
 cdef extern from *:
 
-  cdef struct NotReprC_MaybeUninit______i32:
+  cdef struct NotReprC______i32:
     pass
 
-  ctypedef NotReprC_MaybeUninit______i32 Foo;
+  ctypedef NotReprC______i32 Foo;
 
   cdef struct MyStruct:
     const int32_t *number;

--- a/tests/expectations/nonzero.both.c
+++ b/tests/expectations/nonzero.both.c
@@ -16,7 +16,7 @@ struct NonZeroI64;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct Option_Option_NonZeroI64 Option_Option_NonZeroI64;
+typedef struct Option_i64 Option_i64;
 
 typedef struct NonZeroTest {
   uint8_t a;
@@ -28,7 +28,7 @@ typedef struct NonZeroTest {
   int32_t g;
   int64_t h;
   int64_t i;
-  const struct Option_Option_NonZeroI64 *j;
+  const struct Option_i64 *j;
 } NonZeroTest;
 
 void root(struct NonZeroTest test,
@@ -41,4 +41,4 @@ void root(struct NonZeroTest test,
           int32_t g,
           int64_t h,
           int64_t i,
-          const struct Option_Option_NonZeroI64 *j);
+          const struct Option_i64 *j);

--- a/tests/expectations/nonzero.both.compat.c
+++ b/tests/expectations/nonzero.both.compat.c
@@ -16,7 +16,7 @@ struct NonZeroI64;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct Option_Option_NonZeroI64 Option_Option_NonZeroI64;
+typedef struct Option_i64 Option_i64;
 
 typedef struct NonZeroTest {
   uint8_t a;
@@ -28,7 +28,7 @@ typedef struct NonZeroTest {
   int32_t g;
   int64_t h;
   int64_t i;
-  const struct Option_Option_NonZeroI64 *j;
+  const struct Option_i64 *j;
 } NonZeroTest;
 
 #ifdef __cplusplus
@@ -45,7 +45,7 @@ void root(struct NonZeroTest test,
           int32_t g,
           int64_t h,
           int64_t i,
-          const struct Option_Option_NonZeroI64 *j);
+          const struct Option_i64 *j);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/nonzero.c
+++ b/tests/expectations/nonzero.c
@@ -16,7 +16,7 @@ struct NonZeroI64;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct Option_Option_NonZeroI64 Option_Option_NonZeroI64;
+typedef struct Option_i64 Option_i64;
 
 typedef struct {
   uint8_t a;
@@ -28,7 +28,7 @@ typedef struct {
   int32_t g;
   int64_t h;
   int64_t i;
-  const Option_Option_NonZeroI64 *j;
+  const Option_i64 *j;
 } NonZeroTest;
 
 void root(NonZeroTest test,
@@ -41,4 +41,4 @@ void root(NonZeroTest test,
           int32_t g,
           int64_t h,
           int64_t i,
-          const Option_Option_NonZeroI64 *j);
+          const Option_i64 *j);

--- a/tests/expectations/nonzero.compat.c
+++ b/tests/expectations/nonzero.compat.c
@@ -16,7 +16,7 @@ struct NonZeroI64;
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef struct Option_Option_NonZeroI64 Option_Option_NonZeroI64;
+typedef struct Option_i64 Option_i64;
 
 typedef struct {
   uint8_t a;
@@ -28,7 +28,7 @@ typedef struct {
   int32_t g;
   int64_t h;
   int64_t i;
-  const Option_Option_NonZeroI64 *j;
+  const Option_i64 *j;
 } NonZeroTest;
 
 #ifdef __cplusplus
@@ -45,7 +45,7 @@ void root(NonZeroTest test,
           int32_t g,
           int64_t h,
           int64_t i,
-          const Option_Option_NonZeroI64 *j);
+          const Option_i64 *j);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/nonzero.cpp
+++ b/tests/expectations/nonzero.cpp
@@ -30,7 +30,7 @@ struct NonZeroTest {
   int32_t g;
   int64_t h;
   int64_t i;
-  const Option<Option<NonZeroI64>> *j;
+  const Option<int64_t> *j;
 };
 
 extern "C" {
@@ -45,6 +45,6 @@ void root(NonZeroTest test,
           int32_t g,
           int64_t h,
           int64_t i,
-          const Option<Option<NonZeroI64>> *j);
+          const Option<int64_t> *j);
 
 } // extern "C"

--- a/tests/expectations/nonzero.pyx
+++ b/tests/expectations/nonzero.pyx
@@ -19,7 +19,7 @@ cdef extern from *:
 
 cdef extern from *:
 
-  ctypedef struct Option_Option_NonZeroI64:
+  ctypedef struct Option_i64:
     pass
 
   ctypedef struct NonZeroTest:
@@ -32,7 +32,7 @@ cdef extern from *:
     int32_t g;
     int64_t h;
     int64_t i;
-    const Option_Option_NonZeroI64 *j;
+    const Option_i64 *j;
 
   void root(NonZeroTest test,
             uint8_t a,
@@ -44,4 +44,4 @@ cdef extern from *:
             int32_t g,
             int64_t h,
             int64_t i,
-            const Option_Option_NonZeroI64 *j);
+            const Option_i64 *j);

--- a/tests/expectations/nonzero.tag.c
+++ b/tests/expectations/nonzero.tag.c
@@ -16,7 +16,7 @@ struct NonZeroI64;
 #include <stdint.h>
 #include <stdlib.h>
 
-struct Option_Option_NonZeroI64;
+struct Option_i64;
 
 struct NonZeroTest {
   uint8_t a;
@@ -28,7 +28,7 @@ struct NonZeroTest {
   int32_t g;
   int64_t h;
   int64_t i;
-  const struct Option_Option_NonZeroI64 *j;
+  const struct Option_i64 *j;
 };
 
 void root(struct NonZeroTest test,
@@ -41,4 +41,4 @@ void root(struct NonZeroTest test,
           int32_t g,
           int64_t h,
           int64_t i,
-          const struct Option_Option_NonZeroI64 *j);
+          const struct Option_i64 *j);

--- a/tests/expectations/nonzero.tag.compat.c
+++ b/tests/expectations/nonzero.tag.compat.c
@@ -16,7 +16,7 @@ struct NonZeroI64;
 #include <stdint.h>
 #include <stdlib.h>
 
-struct Option_Option_NonZeroI64;
+struct Option_i64;
 
 struct NonZeroTest {
   uint8_t a;
@@ -28,7 +28,7 @@ struct NonZeroTest {
   int32_t g;
   int64_t h;
   int64_t i;
-  const struct Option_Option_NonZeroI64 *j;
+  const struct Option_i64 *j;
 };
 
 #ifdef __cplusplus
@@ -45,7 +45,7 @@ void root(struct NonZeroTest test,
           int32_t g,
           int64_t h,
           int64_t i,
-          const struct Option_Option_NonZeroI64 *j);
+          const struct Option_i64 *j);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/nonzero.tag.pyx
+++ b/tests/expectations/nonzero.tag.pyx
@@ -19,7 +19,7 @@ cdef extern from *:
 
 cdef extern from *:
 
-  cdef struct Option_Option_NonZeroI64:
+  cdef struct Option_i64:
     pass
 
   cdef struct NonZeroTest:
@@ -32,7 +32,7 @@ cdef extern from *:
     int32_t g;
     int64_t h;
     int64_t i;
-    const Option_Option_NonZeroI64 *j;
+    const Option_i64 *j;
 
   void root(NonZeroTest test,
             uint8_t a,
@@ -44,4 +44,4 @@ cdef extern from *:
             int32_t g,
             int64_t h,
             int64_t i,
-            const Option_Option_NonZeroI64 *j);
+            const Option_i64 *j);


### PR DESCRIPTION
This was an oversight in 1903686f9eb09f587885d579f3e14c990e799938
because the code I grabbed to visit the generics was dealing with them
somewhere else.