### PR TITLE
Only fetch dependencies for current platform by default

### DIFF
--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -341,6 +341,7 @@ impl Builder {
                 binding_lib_name.as_deref(),
                 self.config.parse.parse_deps,
                 self.config.parse.clean,
+                self.config.fetch_all_dependencies,
                 /* existing_metadata = */ None,
             )?;
 

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -241,8 +241,8 @@ impl Builder {
     }
 
     #[allow(unused)]
-    pub fn with_all_dependencies(mut self, fetch_all_dependencies: bool) -> Builder {
-        self.config.fetch_all_dependencies = fetch_all_dependencies;
+    pub fn with_only_host_dependencies(mut self, only_host_dependencies: bool) -> Builder {
+        self.config.only_host_dependencies = only_host_dependencies;
         self
     }
 
@@ -347,7 +347,7 @@ impl Builder {
                 binding_lib_name.as_deref(),
                 self.config.parse.parse_deps,
                 self.config.parse.clean,
-                self.config.fetch_all_dependencies,
+                self.config.only_host_dependencies,
                 /* existing_metadata = */ None,
             )?;
 

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -241,8 +241,8 @@ impl Builder {
     }
 
     #[allow(unused)]
-    pub fn with_only_host_dependencies(mut self, only_host_dependencies: bool) -> Builder {
-        self.config.only_host_dependencies = only_host_dependencies;
+    pub fn with_only_target_dependencies(mut self, only_target_dependencies: bool) -> Builder {
+        self.config.only_target_dependencies = only_target_dependencies;
         self
     }
 
@@ -347,7 +347,7 @@ impl Builder {
                 binding_lib_name.as_deref(),
                 self.config.parse.parse_deps,
                 self.config.parse.clean,
-                self.config.only_host_dependencies,
+                self.config.only_target_dependencies,
                 /* existing_metadata = */ None,
             )?;
 

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -241,6 +241,12 @@ impl Builder {
     }
 
     #[allow(unused)]
+    pub fn with_all_dependencies(mut self, fetch_all_dependencies: bool) -> Builder {
+        self.config.fetch_all_dependencies = fetch_all_dependencies;
+        self
+    }
+
+    #[allow(unused)]
     pub fn with_documentation(mut self, documentation: bool) -> Builder {
         self.config.documentation = documentation;
         self

--- a/src/bindgen/cargo/cargo.rs
+++ b/src/bindgen/cargo/cargo.rs
@@ -40,12 +40,12 @@ impl Cargo {
         binding_crate_name: Option<&str>,
         use_cargo_lock: bool,
         clean: bool,
-        only_host_dependencies: bool,
+        only_target_dependencies: bool,
         existing_metadata_file: Option<&Path>,
     ) -> Result<Cargo, Error> {
         let toml_path = crate_dir.join("Cargo.toml");
         let metadata =
-            cargo_metadata::metadata(&toml_path, existing_metadata_file, only_host_dependencies)
+            cargo_metadata::metadata(&toml_path, existing_metadata_file, only_target_dependencies)
                 .map_err(|x| Error::CargoMetadata(toml_path.to_str().unwrap().to_owned(), x))?;
         let lock_path = lock_file
             .map(PathBuf::from)

--- a/src/bindgen/cargo/cargo.rs
+++ b/src/bindgen/cargo/cargo.rs
@@ -40,11 +40,13 @@ impl Cargo {
         binding_crate_name: Option<&str>,
         use_cargo_lock: bool,
         clean: bool,
+        fetch_all_platforms: bool,
         existing_metadata_file: Option<&Path>,
     ) -> Result<Cargo, Error> {
         let toml_path = crate_dir.join("Cargo.toml");
-        let metadata = cargo_metadata::metadata(&toml_path, existing_metadata_file)
-            .map_err(|x| Error::CargoMetadata(toml_path.to_str().unwrap().to_owned(), x))?;
+        let metadata =
+            cargo_metadata::metadata(&toml_path, existing_metadata_file, fetch_all_platforms)
+                .map_err(|x| Error::CargoMetadata(toml_path.to_str().unwrap().to_owned(), x))?;
         let lock_path = lock_file
             .map(PathBuf::from)
             .unwrap_or_else(|| Path::new(&metadata.workspace_root).join("Cargo.lock"));

--- a/src/bindgen/cargo/cargo.rs
+++ b/src/bindgen/cargo/cargo.rs
@@ -40,12 +40,12 @@ impl Cargo {
         binding_crate_name: Option<&str>,
         use_cargo_lock: bool,
         clean: bool,
-        fetch_all_platforms: bool,
+        only_host_dependencies: bool,
         existing_metadata_file: Option<&Path>,
     ) -> Result<Cargo, Error> {
         let toml_path = crate_dir.join("Cargo.toml");
         let metadata =
-            cargo_metadata::metadata(&toml_path, existing_metadata_file, fetch_all_platforms)
+            cargo_metadata::metadata(&toml_path, existing_metadata_file, only_host_dependencies)
                 .map_err(|x| Error::CargoMetadata(toml_path.to_str().unwrap().to_owned(), x))?;
         let lock_path = lock_file
             .map(PathBuf::from)

--- a/src/bindgen/cargo/cargo_metadata.rs
+++ b/src/bindgen/cargo/cargo_metadata.rs
@@ -195,7 +195,8 @@ pub fn metadata(
                 // If `rustc` fails to run, we just fall back to not passing --filter-platforms.
                 //
                 // NOTE: We set the current directory in case of rustup shenanigans.
-                let rustc = Command::new("rustc")
+                let rustc = env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));
+                let rustc = Command::new(rustc)
                     .current_dir(manifest_path.parent().unwrap())
                     .arg("-vV")
                     .output();

--- a/src/bindgen/cargo/cargo_metadata.rs
+++ b/src/bindgen/cargo/cargo_metadata.rs
@@ -204,7 +204,14 @@ pub fn metadata(
                 if let Ok(out) = rustc {
                     if let Ok(stdout) = std::str::from_utf8(&out.stdout) {
                         let field = "host: ";
-                        let value = stdout.lines().find_map(|l| l.strip_prefix(field));
+                        let value = stdout.lines().find_map(|l| {
+                            // XXX l.strip_prefix(field) re-implemented to preserve MSRV
+                            if l.starts_with(field) {
+                                Some(&l[field.len()..])
+                            } else {
+                                None
+                            }
+                        });
                         if let Some(value) = value {
                             target = Some(value.to_string());
                         }

--- a/src/bindgen/cargo/cargo_metadata.rs
+++ b/src/bindgen/cargo/cargo_metadata.rs
@@ -180,7 +180,7 @@ impl Eq for Dependency {}
 pub fn metadata(
     manifest_path: &Path,
     existing_metadata_file: Option<&Path>,
-    only_host: bool,
+    only_target: bool,
 ) -> Result<Metadata, Error> {
     let output;
     let metadata = match existing_metadata_file {
@@ -188,8 +188,13 @@ pub fn metadata(
         None => {
             let mut target = None;
 
-            if only_host {
-                // cargo metadata defaults to giving information for _all_ targets.
+            if only_target {
+                target = std::env::var_os("TARGET");
+            }
+
+            if only_target && target.is_none() {
+                // We must be running as a standalone script, not under cargo.
+                // Let's use the host platform instead.
                 // We figure out the host platform through rustc and use that.
                 // We unfortunatelly cannot go through cargo, since cargo rustc _also_ builds.
                 // If `rustc` fails to run, we just fall back to not passing --filter-platforms.
@@ -213,7 +218,7 @@ pub fn metadata(
                             }
                         });
                         if let Some(value) = value {
-                            target = Some(value.to_string());
+                            target = Some(value.into());
                         }
                     }
                 }

--- a/src/bindgen/cargo/cargo_metadata.rs
+++ b/src/bindgen/cargo/cargo_metadata.rs
@@ -185,11 +185,42 @@ pub fn metadata(
     let metadata = match existing_metadata_file {
         Some(path) => Cow::Owned(std::fs::read_to_string(path)?),
         None => {
+            // cargo metadata defaults to giving information for _all_ targets.
+            // We figure out the host platform through rustc and use that.
+            // We unfortunatelly cannot go through cargo, since cargo rustc _also_ builds.
+            // If `rustc` fails to run, we just fall back to not passing --filter-platforms.
+            //
+            // NOTE: We set the current directory in case of rustup shenanigans.
+            let rustc = Command::new("rustc")
+                .current_dir(manifest_path.parent().unwrap())
+                .arg("-vV")
+                .output();
+            log::debug!("Discovering host platform by {:?}", rustc);
+            let mut target = None;
+            if let Ok(out) = rustc {
+                if let Ok(stdout) = std::str::from_utf8(&out.stdout) {
+                    let field = "host: ";
+                    let value = stdout.lines().find_map(|l| l.strip_prefix(field));
+                    if let Some(value) = value {
+                        target = Some(value.to_string());
+                    }
+                }
+            }
+            if target.is_none() {
+                log::warn!(
+                    "Failed to discover host platform for cargo metadata; \
+                    will fetch dependencies for all platforms."
+                );
+            }
+
             let cargo = env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
             let mut cmd = Command::new(cargo);
             cmd.arg("metadata");
             cmd.arg("--all-features");
             cmd.arg("--format-version").arg("1");
+            if let Some(target) = target {
+                cmd.arg("--filter-platform").arg(target);
+            }
             cmd.arg("--manifest-path");
             cmd.arg(manifest_path);
             output = cmd.output()?;

--- a/src/bindgen/cargo/cargo_metadata.rs
+++ b/src/bindgen/cargo/cargo_metadata.rs
@@ -180,7 +180,7 @@ impl Eq for Dependency {}
 pub fn metadata(
     manifest_path: &Path,
     existing_metadata_file: Option<&Path>,
-    all_platforms: bool,
+    only_host: bool,
 ) -> Result<Metadata, Error> {
     let output;
     let metadata = match existing_metadata_file {
@@ -188,7 +188,7 @@ pub fn metadata(
         None => {
             let mut target = None;
 
-            if !all_platforms {
+            if only_host {
                 // cargo metadata defaults to giving information for _all_ targets.
                 // We figure out the host platform through rustc and use that.
                 // We unfortunatelly cannot go through cargo, since cargo rustc _also_ builds.

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -938,6 +938,38 @@ pub struct Config {
     /// Configuration options for pointers
     #[serde(rename = "ptr")]
     pub pointer: PtrConfig,
+    /// Download sources for dependencies on all platforms.
+    ///
+    /// By default, cbindgen will only fetch sources for dependencies that match the current target
+    /// platform. This means that if a type is defined in terms of a type from a dependency on
+    /// another target (probably behind a `#[cfg]`), cbindgen will be unable to generate the
+    /// appropriate binding as it cannot see the nested type's definition. By setting this option
+    /// to `true`, all dependencies will be downloaded, regardless of platform (the default prior
+    /// to cbindgen 0.19).
+    ///
+    /// As an example, consider this Cargo.toml:
+    ///
+    /// ```toml
+    /// [target.'cfg(windows)'.dependencies]
+    /// windows = "0.7"
+    /// ```
+    ///
+    /// with this declaration in one of the `.rs` files that cbindgen is asked to generate bindings
+    /// for:
+    ///
+    /// ```rust,ignore
+    /// #[cfg(windows)]
+    /// pub struct Error(windows::ErrorCode);
+    /// ```
+    ///
+    /// If this option is `false` and this code is run under cbindgen on a non-Windows platform,
+    /// the `windows` dependency will not be downloaded, and cbindgen will fail to generate a
+    /// binding for the `Error` type since it doesn't know the definition of the inner type.
+    ///
+    /// If this option is `true`, the `windows` dependency will be fetched no matter what platform
+    /// cbindgen is run on. This may increase runtime as more assets must be downloaded, but will
+    /// allow cbindgen to generate the bindings for `Error` even on a non-Windows platform.
+    pub fetch_all_dependencies: bool,
     /// Configuration options specific to Cython.
     pub cython: CythonConfig,
 }
@@ -979,6 +1011,7 @@ impl Default for Config {
             documentation: true,
             documentation_style: DocumentationStyle::Auto,
             pointer: PtrConfig::default(),
+            fetch_all_dependencies: false,
             cython: CythonConfig::default(),
         }
     }

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -938,14 +938,13 @@ pub struct Config {
     /// Configuration options for pointers
     #[serde(rename = "ptr")]
     pub pointer: PtrConfig,
-    /// Download sources for dependencies on all platforms.
+    /// Download sources for dependencies only for the host platform.
     ///
-    /// By default, cbindgen will only fetch sources for dependencies that match the current target
-    /// platform. This means that if a type is defined in terms of a type from a dependency on
-    /// another target (probably behind a `#[cfg]`), cbindgen will be unable to generate the
-    /// appropriate binding as it cannot see the nested type's definition. By setting this option
-    /// to `true`, all dependencies will be downloaded, regardless of platform (the default prior
-    /// to cbindgen 0.19).
+    /// By default, cbindgen will fetch sources for dependencies on all platforms, so that if a
+    /// type is defined in terms of a type from a dependency on another target (probably behind a
+    /// `#[cfg]`), cbindgen will be able to generate the appropriate binding as it can see the
+    /// nested type's definition. However, this makes calling cbindgen slower, as it may have to
+    /// download a number of additional dependencies.
     ///
     /// As an example, consider this Cargo.toml:
     ///
@@ -962,14 +961,14 @@ pub struct Config {
     /// pub struct Error(windows::ErrorCode);
     /// ```
     ///
-    /// If this option is `false` and this code is run under cbindgen on a non-Windows platform,
-    /// the `windows` dependency will not be downloaded, and cbindgen will fail to generate a
-    /// binding for the `Error` type since it doesn't know the definition of the inner type.
+    /// With the default value (`false`), cbindgen will download the `windows` dependency even on
+    /// non-Windows platforms, and thus be able to generate the binding for `Error` (behind a
+    /// `#define`).
     ///
-    /// If this option is `true`, the `windows` dependency will be fetched no matter what platform
-    /// cbindgen is run on. This may increase runtime as more assets must be downloaded, but will
-    /// allow cbindgen to generate the bindings for `Error` even on a non-Windows platform.
-    pub fetch_all_dependencies: bool,
+    /// If this value is instead to `true`, cbindgen will _not_ download the `windows` dependency
+    /// if run on a non-Windows platform, but will also fail to generate a Windows binding for
+    /// `Error` as it does not know the definition for `ErrorCode`.
+    pub only_host_dependencies: bool,
     /// Configuration options specific to Cython.
     pub cython: CythonConfig,
 }
@@ -1011,7 +1010,7 @@ impl Default for Config {
             documentation: true,
             documentation_style: DocumentationStyle::Auto,
             pointer: PtrConfig::default(),
-            fetch_all_dependencies: false,
+            only_host_dependencies: false,
             cython: CythonConfig::default(),
         }
     }

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -938,9 +938,9 @@ pub struct Config {
     /// Configuration options for pointers
     #[serde(rename = "ptr")]
     pub pointer: PtrConfig,
-    /// Download sources for dependencies only for the host platform.
+    /// Only download sources for dependencies needed for the target platform.
     ///
-    /// By default, cbindgen will fetch sources for dependencies on all platforms, so that if a
+    /// By default, cbindgen will fetch sources for dependencies used on any platform so that if a
     /// type is defined in terms of a type from a dependency on another target (probably behind a
     /// `#[cfg]`), cbindgen will be able to generate the appropriate binding as it can see the
     /// nested type's definition. However, this makes calling cbindgen slower, as it may have to
@@ -961,14 +961,14 @@ pub struct Config {
     /// pub struct Error(windows::ErrorCode);
     /// ```
     ///
-    /// With the default value (`false`), cbindgen will download the `windows` dependency even on
-    /// non-Windows platforms, and thus be able to generate the binding for `Error` (behind a
-    /// `#define`).
+    /// With the default value (`false`), cbindgen will download the `windows` dependency even when
+    /// not compiling for Windows, and will thus be able to generate the binding for `Error`
+    /// (behind a `#define`).
     ///
     /// If this value is instead to `true`, cbindgen will _not_ download the `windows` dependency
-    /// if run on a non-Windows platform, but will also fail to generate a Windows binding for
+    /// if it's not compiling for Windows, but will also fail to generate a Windows binding for
     /// `Error` as it does not know the definition for `ErrorCode`.
-    pub only_host_dependencies: bool,
+    pub only_target_dependencies: bool,
     /// Configuration options specific to Cython.
     pub cython: CythonConfig,
 }
@@ -1010,7 +1010,7 @@ impl Default for Config {
             documentation: true,
             documentation_style: DocumentationStyle::Auto,
             pointer: PtrConfig::default(),
-            only_host_dependencies: false,
+            only_target_dependencies: false,
             cython: CythonConfig::default(),
         }
     }

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -154,7 +154,9 @@ impl<'a> Parser<'a> {
                 None => {
                     // This should be an error, but is common enough to just elicit a warning
                     warn!(
-                        "Parsing crate `{}`: can't find lib.rs with `cargo metadata`.",
+                        "Parsing crate `{}`: can't find lib.rs with `cargo metadata`. \
+                        The crate may be available only on a particular platform, \
+                        so consider setting `fetch_all_dependencies` in your cbindgen configuration.",
                         pkg.name
                     );
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,8 @@ fn apply_config_overrides<'a>(config: &mut Config, matches: &ArgMatches<'a>) {
         config.cpp_compat = true;
     }
 
-    if matches.is_present("only-host-dependencies") {
-        config.only_host_dependencies = true;
+    if matches.is_present("only-target-dependencies") {
+        config.only_target_dependencies = true;
     }
 
     if let Some(style) = matches.value_of("style") {
@@ -102,7 +102,7 @@ fn load_bindings<'a>(input: &Path, matches: &ArgMatches<'a>) -> Result<Bindings,
         matches.value_of("crate"),
         true,
         matches.is_present("clean"),
-        matches.is_present("only-host-dependencies"),
+        matches.is_present("only-target-dependencies"),
         matches.value_of("metadata").map(Path::new),
     )?;
 
@@ -165,9 +165,10 @@ fn main() {
                 .help("Whether to add C++ compatibility to generated C bindings")
         )
         .arg(
-            Arg::with_name("only-host-dependencies")
-                .long("only-host-dependencies")
-                .help("Only fetch dependencies for the host platform")
+            Arg::with_name("only-target-dependencies")
+                .long("only-target-dependencies")
+                .help("Only fetch dependencies needed by the target platform. \
+                    The target platform defaults to the host platform; set TARGET to override.")
         )
         .arg(
             Arg::with_name("style")

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,10 @@ fn apply_config_overrides<'a>(config: &mut Config, matches: &ArgMatches<'a>) {
         config.cpp_compat = true;
     }
 
+    if matches.is_present("fetch-all-dependencies") {
+        config.fetch_all_dependencies = true;
+    }
+
     if let Some(style) = matches.value_of("style") {
         config.style = match style {
             "Both" => Style::Both,
@@ -98,6 +102,7 @@ fn load_bindings<'a>(input: &Path, matches: &ArgMatches<'a>) -> Result<Bindings,
         matches.value_of("crate"),
         true,
         matches.is_present("clean"),
+        matches.is_present("fetch-all-dependencies"),
         matches.value_of("metadata").map(Path::new),
     )?;
 
@@ -158,6 +163,11 @@ fn main() {
             Arg::with_name("cpp-compat")
                 .long("cpp-compat")
                 .help("Whether to add C++ compatibility to generated C bindings")
+        )
+        .arg(
+            Arg::with_name("fetch-all-dependencies")
+                .long("fetch-all-dependencies")
+                .help("Whether to fetch all dependencies, including those for other target platforms")
         )
         .arg(
             Arg::with_name("style")

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,8 @@ fn apply_config_overrides<'a>(config: &mut Config, matches: &ArgMatches<'a>) {
         config.cpp_compat = true;
     }
 
-    if matches.is_present("fetch-all-dependencies") {
-        config.fetch_all_dependencies = true;
+    if matches.is_present("only-host-dependencies") {
+        config.only_host_dependencies = true;
     }
 
     if let Some(style) = matches.value_of("style") {
@@ -102,7 +102,7 @@ fn load_bindings<'a>(input: &Path, matches: &ArgMatches<'a>) -> Result<Bindings,
         matches.value_of("crate"),
         true,
         matches.is_present("clean"),
-        matches.is_present("fetch-all-dependencies"),
+        matches.is_present("only-host-dependencies"),
         matches.value_of("metadata").map(Path::new),
     )?;
 
@@ -165,9 +165,9 @@ fn main() {
                 .help("Whether to add C++ compatibility to generated C bindings")
         )
         .arg(
-            Arg::with_name("fetch-all-dependencies")
-                .long("fetch-all-dependencies")
-                .help("Whether to fetch all dependencies, including those for other target platforms")
+            Arg::with_name("only-host-dependencies")
+                .long("only-host-dependencies")
+                .help("Only fetch dependencies for the host platform")
         )
         .arg(
             Arg::with_name("style")


### PR DESCRIPTION
cbindgen invokes `cargo metadata` to find the sources of dependencies so
that it can generate bindings for types that originate in those
dependencies. However, `cargo metadata` defaults to fetching
dependencies for _all_ platforms unless it is specifically invoked with
the `--filter-platforms` argument.

This PR makes cbindgen pass that argument to `cargo metadata` using the
host platform, which will significantly reduce the time of the first
call in cases where the dependency tree includes many target-specific
dependencies.

Fixes #675.