### PR TITLE
Fix new clippy lint clippy::wrong-self-convention

### DIFF
--- a/src/bindgen/rename.rs
+++ b/src/bindgen/rename.rs
@@ -16,8 +16,8 @@ pub enum IdentifierType<'a> {
 }
 
 impl<'a> IdentifierType<'a> {
-    fn to_str(&'a self) -> &'static str {
-        match *self {
+    fn to_str(self) -> &'static str {
+        match self {
             IdentifierType::StructMember => "m",
             IdentifierType::EnumVariant { .. } => "",
             IdentifierType::FunctionArg => "a",


### PR DESCRIPTION
This should be backwards-compatible in practice since `IdentifierType`
is `Copy`. In theory it's not though, as someone _might_ be passing that
function by name to something that requires that exact signature.