### PR TITLE
parser: Fix handling of #[path] attributes inside inline submodules.

### DIFF
--- a/tests/expectations/mod_2015.both.c
+++ b/tests/expectations/mod_2015.both.c
@@ -10,3 +10,5 @@ typedef struct ExportMe {
 } ExportMe;
 
 void export_me(struct ExportMe *val);
+
+void from_really_nested_mod(void);

--- a/tests/expectations/mod_2015.both.compat.c
+++ b/tests/expectations/mod_2015.both.compat.c
@@ -15,6 +15,8 @@ extern "C" {
 
 void export_me(struct ExportMe *val);
 
+void from_really_nested_mod(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/mod_2015.c
+++ b/tests/expectations/mod_2015.c
@@ -10,3 +10,5 @@ typedef struct {
 } ExportMe;
 
 void export_me(ExportMe *val);
+
+void from_really_nested_mod(void);

--- a/tests/expectations/mod_2015.compat.c
+++ b/tests/expectations/mod_2015.compat.c
@@ -15,6 +15,8 @@ extern "C" {
 
 void export_me(ExportMe *val);
 
+void from_really_nested_mod(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/mod_2015.cpp
+++ b/tests/expectations/mod_2015.cpp
@@ -14,4 +14,6 @@ extern "C" {
 
 void export_me(ExportMe *val);
 
+void from_really_nested_mod();
+
 } // extern "C"

--- a/tests/expectations/mod_2015.pyx
+++ b/tests/expectations/mod_2015.pyx
@@ -12,3 +12,5 @@ cdef extern from *:
     uint64_t val;
 
   void export_me(ExportMe *val);
+
+  void from_really_nested_mod();

--- a/tests/expectations/mod_2015.tag.c
+++ b/tests/expectations/mod_2015.tag.c
@@ -10,3 +10,5 @@ struct ExportMe {
 };
 
 void export_me(struct ExportMe *val);
+
+void from_really_nested_mod(void);

--- a/tests/expectations/mod_2015.tag.compat.c
+++ b/tests/expectations/mod_2015.tag.compat.c
@@ -15,6 +15,8 @@ extern "C" {
 
 void export_me(struct ExportMe *val);
 
+void from_really_nested_mod(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/mod_2015.tag.pyx
+++ b/tests/expectations/mod_2015.tag.pyx
@@ -12,3 +12,5 @@ cdef extern from *:
     uint64_t val;
 
   void export_me(ExportMe *val);
+
+  void from_really_nested_mod();

--- a/tests/expectations/mod_2018.both.c
+++ b/tests/expectations/mod_2018.both.c
@@ -16,3 +16,5 @@ typedef struct ExportMe2 {
 void export_me(struct ExportMe *val);
 
 void export_me_2(struct ExportMe2*);
+
+void from_really_nested_mod(void);

--- a/tests/expectations/mod_2018.both.compat.c
+++ b/tests/expectations/mod_2018.both.compat.c
@@ -21,6 +21,8 @@ void export_me(struct ExportMe *val);
 
 void export_me_2(struct ExportMe2*);
 
+void from_really_nested_mod(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/mod_2018.c
+++ b/tests/expectations/mod_2018.c
@@ -16,3 +16,5 @@ typedef struct {
 void export_me(ExportMe *val);
 
 void export_me_2(ExportMe2*);
+
+void from_really_nested_mod(void);

--- a/tests/expectations/mod_2018.compat.c
+++ b/tests/expectations/mod_2018.compat.c
@@ -21,6 +21,8 @@ void export_me(ExportMe *val);
 
 void export_me_2(ExportMe2*);
 
+void from_really_nested_mod(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/mod_2018.cpp
+++ b/tests/expectations/mod_2018.cpp
@@ -20,4 +20,6 @@ void export_me(ExportMe *val);
 
 void export_me_2(ExportMe2*);
 
+void from_really_nested_mod();
+
 } // extern "C"

--- a/tests/expectations/mod_2018.pyx
+++ b/tests/expectations/mod_2018.pyx
@@ -17,3 +17,5 @@ cdef extern from *:
   void export_me(ExportMe *val);
 
   void export_me_2(ExportMe2*);
+
+  void from_really_nested_mod();

--- a/tests/expectations/mod_2018.tag.c
+++ b/tests/expectations/mod_2018.tag.c
@@ -16,3 +16,5 @@ struct ExportMe2 {
 void export_me(struct ExportMe *val);
 
 void export_me_2(struct ExportMe2*);
+
+void from_really_nested_mod(void);

--- a/tests/expectations/mod_2018.tag.compat.c
+++ b/tests/expectations/mod_2018.tag.compat.c
@@ -21,6 +21,8 @@ void export_me(struct ExportMe *val);
 
 void export_me_2(struct ExportMe2*);
 
+void from_really_nested_mod(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/mod_2018.tag.pyx
+++ b/tests/expectations/mod_2018.tag.pyx
@@ -17,3 +17,5 @@ cdef extern from *:
   void export_me(ExportMe *val);
 
   void export_me_2(ExportMe2*);
+
+  void from_really_nested_mod();

--- a/tests/rust/mod_2015/src/nested/mod.rs
+++ b/tests/rust/mod_2015/src/nested/mod.rs
@@ -1,1 +1,6 @@
 pub mod other;
+
+mod other3 {
+    #[path = "other4.rs"]
+    mod other4;
+}

--- a/tests/rust/mod_2015/src/nested/other3/other4.rs
+++ b/tests/rust/mod_2015/src/nested/other3/other4.rs
@@ -1,0 +1,2 @@
+#[no_mangle]
+pub unsafe extern "C" fn from_really_nested_mod() { }

--- a/tests/rust/mod_2018/src/nested.rs
+++ b/tests/rust/mod_2018/src/nested.rs
@@ -2,3 +2,8 @@ pub mod other;
 
 #[path = "other2.rs"]
 pub mod other2;
+
+pub mod other3 {
+    #[path = "other4.rs"]
+    pub mod other4;
+}

--- a/tests/rust/mod_2018/src/nested/other3/other4.rs
+++ b/tests/rust/mod_2018/src/nested/other3/other4.rs
@@ -1,0 +1,2 @@
+#[no_mangle]
+pub unsafe extern "C" fn from_really_nested_mod() { }


### PR DESCRIPTION
As seen in hashbrown:

    #[cfg(feature = "raw")]
    /// Experimental and unsafe `RawTable` API. This module is only available if the
    /// `raw` feature is enabled.
    pub mod raw {
        // The RawTable API is still experimental and is not properly documented yet.
        #[allow(missing_docs)]
        #[path = "mod.rs"]
        mod inner;
        pub use inner::*;

        #[cfg(feature = "rayon")]
        pub mod rayon {
            pub use crate::external_trait_impls::rayon::raw::*;
        }
    }