### PR TITLE
ir: Tweak monomorphization to instantiate recursively after inserting to the replacements map.

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -633,9 +633,7 @@ impl Item for Enum {
             self.documentation.clone(),
         );
 
-        monomorph.add_monomorphs(library, out);
-
-        out.insert_enum(self, monomorph, generic_values.to_owned());
+        out.insert_enum(library, self, monomorph, generic_values.to_owned());
     }
 
     fn add_dependencies(&self, library: &Library, out: &mut Dependencies) {

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -387,11 +387,7 @@ impl Item for Struct {
             .collect::<Vec<_>>();
 
         let monomorph = self.specialize(generic_values, &mappings, library.get_config());
-
-        // Instantiate any monomorphs for any generic paths we may have just created.
-        monomorph.add_monomorphs(library, out);
-
-        out.insert_struct(self, monomorph, generic_values.to_owned());
+        out.insert_struct(library, self, monomorph, generic_values.to_owned());
     }
 }
 

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -191,10 +191,7 @@ impl Item for Typedef {
             self.documentation.clone(),
         );
 
-        // Instantiate any monomorphs for any generic paths we may have just created.
-        monomorph.add_monomorphs(library, out);
-
-        out.insert_typedef(self, monomorph, generic_values.to_owned());
+        out.insert_typedef(library, self, monomorph, generic_values.to_owned());
     }
 }
 

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -270,10 +270,7 @@ impl Item for Union {
             self.documentation.clone(),
         );
 
-        // Instantiate any monomorphs for any generic paths we may have just created.
-        monomorph.add_monomorphs(library, out);
-
-        out.insert_union(self, monomorph, generic_values.to_owned());
+        out.insert_union(library, self, monomorph, generic_values.to_owned());
     }
 }
 

--- a/src/bindgen/monomorph.rs
+++ b/src/bindgen/monomorph.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::mem;
 
 use crate::bindgen::ir::{Enum, GenericPath, OpaqueItem, Path, Struct, Type, Typedef, Union};
+use crate::bindgen::library::Library;
 
 #[derive(Default, Clone, Debug)]
 pub struct Monomorphs {
@@ -22,7 +23,13 @@ impl Monomorphs {
         self.replacements.contains_key(path)
     }
 
-    pub fn insert_struct(&mut self, generic: &Struct, monomorph: Struct, parameters: Vec<Type>) {
+    pub fn insert_struct(
+        &mut self,
+        library: &Library,
+        generic: &Struct,
+        monomorph: Struct,
+        parameters: Vec<Type>,
+    ) {
         let replacement_path = GenericPath::new(generic.path.clone(), parameters);
 
         debug_assert!(generic.generic_params.len() > 0);
@@ -30,10 +37,19 @@ impl Monomorphs {
 
         self.replacements
             .insert(replacement_path, monomorph.path.clone());
+
+        monomorph.add_monomorphs(library, self);
+
         self.structs.push(monomorph);
     }
 
-    pub fn insert_enum(&mut self, generic: &Enum, monomorph: Enum, parameters: Vec<Type>) {
+    pub fn insert_enum(
+        &mut self,
+        library: &Library,
+        generic: &Enum,
+        monomorph: Enum,
+        parameters: Vec<Type>,
+    ) {
         let replacement_path = GenericPath::new(generic.path.clone(), parameters);
 
         debug_assert!(generic.generic_params.len() > 0);
@@ -41,10 +57,19 @@ impl Monomorphs {
 
         self.replacements
             .insert(replacement_path, monomorph.path.clone());
+
+        monomorph.add_monomorphs(library, self);
+
         self.enums.push(monomorph);
     }
 
-    pub fn insert_union(&mut self, generic: &Union, monomorph: Union, parameters: Vec<Type>) {
+    pub fn insert_union(
+        &mut self,
+        library: &Library,
+        generic: &Union,
+        monomorph: Union,
+        parameters: Vec<Type>,
+    ) {
         let replacement_path = GenericPath::new(generic.path.clone(), parameters);
 
         debug_assert!(generic.generic_params.len() > 0);
@@ -52,6 +77,9 @@ impl Monomorphs {
 
         self.replacements
             .insert(replacement_path, monomorph.path.clone());
+
+        monomorph.add_monomorphs(library, self);
+
         self.unions.push(monomorph);
     }
 
@@ -71,7 +99,13 @@ impl Monomorphs {
         self.opaques.push(monomorph);
     }
 
-    pub fn insert_typedef(&mut self, generic: &Typedef, monomorph: Typedef, parameters: Vec<Type>) {
+    pub fn insert_typedef(
+        &mut self,
+        library: &Library,
+        generic: &Typedef,
+        monomorph: Typedef,
+        parameters: Vec<Type>,
+    ) {
         let replacement_path = GenericPath::new(generic.path.clone(), parameters);
 
         debug_assert!(generic.generic_params.len() > 0);
@@ -79,6 +113,9 @@ impl Monomorphs {
 
         self.replacements
             .insert(replacement_path, monomorph.path.clone());
+
+        monomorph.add_monomorphs(library, self);
+
         self.typedefs.push(monomorph);
     }
 

--- a/tests/expectations/infinite-recursion-typedef-monomorph.compat.c
+++ b/tests/expectations/infinite-recursion-typedef-monomorph.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/infinite-recursion-typedef-monomorph.cpp
+++ b/tests/expectations/infinite-recursion-typedef-monomorph.cpp
@@ -1,0 +1,5 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>

--- a/tests/expectations/infinite-recursion-typedef-monomorph.pyx
+++ b/tests/expectations/infinite-recursion-typedef-monomorph.pyx
@@ -1,0 +1,8 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+  pass

--- a/tests/expectations/infinite_recursion_typedef_monomorph.compat.c
+++ b/tests/expectations/infinite_recursion_typedef_monomorph.compat.c
@@ -1,0 +1,4 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>

--- a/tests/expectations/infinite_recursion_typedef_monomorph.cpp
+++ b/tests/expectations/infinite_recursion_typedef_monomorph.cpp
@@ -1,0 +1,5 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>

--- a/tests/expectations/infinite_recursion_typedef_monomorph.pyx
+++ b/tests/expectations/infinite_recursion_typedef_monomorph.pyx
@@ -1,0 +1,8 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+  pass

--- a/tests/rust/infinite_recursion_typedef_monomorph.rs
+++ b/tests/rust/infinite_recursion_typedef_monomorph.rs
@@ -1,0 +1,2 @@
+pub type TryVec<T> = fallible_collections::TryVec<T>;
+pub type TryString = fallible_collections::TryVec<u8>;


### PR DESCRIPTION
That way the check to prevent double-instantiation also works to prevent
infinite recursion.