### PR TITLE
Ignore PhantomPinned

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -159,6 +159,7 @@ cbindgen contains the following hardcoded mappings (again completely ignoring na
 * f64 => double
 * VaList => va_list
 * PhantomData => *evaporates*, can only appear as the field of a type
+* PhantomPinned => *evaporates*, can only appear as the field of a type  
 * () => *evaporates*, can only appear as the field of a type
 
 

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -398,7 +398,8 @@ impl Type {
             syn::Type::Path(ref path) => {
                 let generic_path = GenericPath::load(&path.path)?;
 
-                if generic_path.name() == "PhantomData" {
+                if generic_path.name() == "PhantomData" ||
+                    generic_path.name() == "PhantomPinned" {
                     return Ok(None);
                 }
 

--- a/tests/rust/struct.rs
+++ b/tests/rust/struct.rs
@@ -17,6 +17,7 @@ struct NormalWithZST {
     y: f32,
     z: (),
     w: PhantomData<i32>,
+    v: PhantomPinned,
 }
 
 /// cbindgen:rename-all=GeckoCase


### PR DESCRIPTION
cbindgen already ignores `PhantomData`.  It should ignore `PhantomPinned` for the same reasons.