### PR TITLE
Simplify Pin<T> to T

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -161,6 +161,8 @@ cbindgen contains the following hardcoded mappings (again completely ignoring na
 * PhantomData => *evaporates*, can only appear as the field of a type
 * PhantomPinned => *evaporates*, can only appear as the field of a type  
 * () => *evaporates*, can only appear as the field of a type
+* MaybeUninit<T>, ManuallyDrop<T>, and Pin<T> => T
+
 
 
 

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -630,7 +630,7 @@ impl Type {
                 is_ref: false,
             }),
             "Cell" => Some(generic.into_owned()),
-            "ManuallyDrop" | "MaybeUninit" if config.language != Language::Cxx => {
+            "ManuallyDrop" | "MaybeUninit" | "Pin" if config.language != Language::Cxx => {
                 Some(generic.into_owned())
             }
             _ => None,

--- a/tests/expectations/pin.both.c
+++ b/tests/expectations/pin.both.c
@@ -1,0 +1,27 @@
+#if 0
+''' '
+#endif
+
+#ifdef __cplusplus
+template <typename T>
+using Pin = T;
+template <typename T>
+using Box = T*;
+#endif
+
+#if 0
+' '''
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct PinTest {
+  int32_t *pinned_box;
+  int32_t *pinned_ref;
+} PinTest;
+
+void root(int32_t *s, struct PinTest p);

--- a/tests/expectations/pin.both.compat.c
+++ b/tests/expectations/pin.both.compat.c
@@ -1,0 +1,35 @@
+#if 0
+''' '
+#endif
+
+#ifdef __cplusplus
+template <typename T>
+using Pin = T;
+template <typename T>
+using Box = T*;
+#endif
+
+#if 0
+' '''
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct PinTest {
+  int32_t *pinned_box;
+  int32_t *pinned_ref;
+} PinTest;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(int32_t *s, struct PinTest p);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/pin.c
+++ b/tests/expectations/pin.c
@@ -1,0 +1,27 @@
+#if 0
+''' '
+#endif
+
+#ifdef __cplusplus
+template <typename T>
+using Pin = T;
+template <typename T>
+using Box = T*;
+#endif
+
+#if 0
+' '''
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t *pinned_box;
+  int32_t *pinned_ref;
+} PinTest;
+
+void root(int32_t *s, PinTest p);

--- a/tests/expectations/pin.compat.c
+++ b/tests/expectations/pin.compat.c
@@ -1,0 +1,35 @@
+#if 0
+''' '
+#endif
+
+#ifdef __cplusplus
+template <typename T>
+using Pin = T;
+template <typename T>
+using Box = T*;
+#endif
+
+#if 0
+' '''
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t *pinned_box;
+  int32_t *pinned_ref;
+} PinTest;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(int32_t *s, PinTest p);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/pin.cpp
+++ b/tests/expectations/pin.cpp
@@ -1,0 +1,32 @@
+#if 0
+''' '
+#endif
+
+#ifdef __cplusplus
+template <typename T>
+using Pin = T;
+template <typename T>
+using Box = T*;
+#endif
+
+#if 0
+' '''
+#endif
+
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+struct PinTest {
+  Pin<Box<int32_t>> pinned_box;
+  Pin<int32_t*> pinned_ref;
+};
+
+extern "C" {
+
+void root(Pin<int32_t*> s, PinTest p);
+
+} // extern "C"

--- a/tests/expectations/pin.pyx
+++ b/tests/expectations/pin.pyx
@@ -1,0 +1,29 @@
+#if 0
+''' '
+#endif
+
+#ifdef __cplusplus
+template <typename T>
+using Pin = T;
+template <typename T>
+using Box = T*;
+#endif
+
+#if 0
+' '''
+#endif
+
+
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  ctypedef struct PinTest:
+    int32_t *pinned_box;
+    int32_t *pinned_ref;
+
+  void root(int32_t *s, PinTest p);

--- a/tests/expectations/pin.tag.c
+++ b/tests/expectations/pin.tag.c
@@ -1,0 +1,27 @@
+#if 0
+''' '
+#endif
+
+#ifdef __cplusplus
+template <typename T>
+using Pin = T;
+template <typename T>
+using Box = T*;
+#endif
+
+#if 0
+' '''
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct PinTest {
+  int32_t *pinned_box;
+  int32_t *pinned_ref;
+};
+
+void root(int32_t *s, struct PinTest p);

--- a/tests/expectations/pin.tag.compat.c
+++ b/tests/expectations/pin.tag.compat.c
@@ -1,0 +1,35 @@
+#if 0
+''' '
+#endif
+
+#ifdef __cplusplus
+template <typename T>
+using Pin = T;
+template <typename T>
+using Box = T*;
+#endif
+
+#if 0
+' '''
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct PinTest {
+  int32_t *pinned_box;
+  int32_t *pinned_ref;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(int32_t *s, struct PinTest p);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/pin.tag.pyx
+++ b/tests/expectations/pin.tag.pyx
@@ -1,0 +1,29 @@
+#if 0
+''' '
+#endif
+
+#ifdef __cplusplus
+template <typename T>
+using Pin = T;
+template <typename T>
+using Box = T*;
+#endif
+
+#if 0
+' '''
+#endif
+
+
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  cdef struct PinTest:
+    int32_t *pinned_box;
+    int32_t *pinned_ref;
+
+  void root(int32_t *s, PinTest p);

--- a/tests/rust/pin.rs
+++ b/tests/rust/pin.rs
@@ -1,0 +1,8 @@
+#[repr(C)]
+struct PinTest {
+    pinned_box: Pin<Box<i32>>,
+    pinned_ref: Pin<&mut i32>
+}
+
+#[no_mangle]
+pub extern "C" fn root(s: Pin<&mut i32>, p: PinTest) {}

--- a/tests/rust/pin.toml
+++ b/tests/rust/pin.toml
@@ -1,0 +1,21 @@
+header = """
+#if 0
+''' '
+#endif
+
+#ifdef __cplusplus
+template <typename T>
+using Pin = T;
+template <typename T>
+using Box = T*;
+#endif
+
+#if 0
+' '''
+#endif
+"""
+[export]
+exclude = [
+    "Pin",
+    "Box"
+]


### PR DESCRIPTION
cbindgen already simplifies `MaybeUninit<T>` and `ManuallyDrop<T>` to `T`. This adds `Pin<T>` as well.