### PR TITLE
parser: force proc macro fallback

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -206,6 +206,7 @@ impl<'a> Parser<'a> {
                         self.config.parse.expand.profile,
                     )
                     .map_err(|x| Error::CargoExpand(pkg.name.clone(), x))?;
+                proc_macro2::fallback::force();
                 let i = syn::parse_file(&s).map_err(|x| Error::ParseSyntaxError {
                     crate_name: pkg.name.clone(),
                     src_path: "".to_owned(),
@@ -243,6 +244,7 @@ impl<'a> Parser<'a> {
                         src_path: mod_path.to_str().unwrap().to_owned(),
                     })?;
 
+                proc_macro2::fallback::force();
                 let i = syn::parse_file(&s).map_err(|x| Error::ParseSyntaxError {
                     crate_name: pkg.name.clone(),
                     src_path: mod_path.to_string_lossy().into(),

--- a/tests/basic_cbindgen_wrapper/.gitignore
+++ b/tests/basic_cbindgen_wrapper/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/tests/basic_cbindgen_wrapper/Cargo.toml
+++ b/tests/basic_cbindgen_wrapper/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "panic_abort"
+version = "0.1.0"
+edition = "2018"
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"
+
+[dependencies]
+cbindgen = { path = "../.." }

--- a/tests/basic_cbindgen_wrapper/src/main.rs
+++ b/tests/basic_cbindgen_wrapper/src/main.rs
@@ -1,0 +1,23 @@
+use std::{env, process};
+
+fn exit_with_usage(exe_name: impl AsRef<str>) -> ! {
+    eprintln!("Usage: {} MANIFEST_PATH PKG_NAME", exe_name.as_ref());
+    process::exit(1);
+}
+
+/// A cbindgen wrapper whose return status can be leveraged by tests. Of note is that it is built
+/// with `panic = "abort"` with respect to https://github.com/alexcrichton/proc-macro2/pull/220.
+pub fn main() {
+    let opts = env::args().collect::<Vec<String>>();
+    if opts.len() < 3 {
+        exit_with_usage(&opts[0]);
+    }
+    let crate_dir = &opts[1];
+    let pkg_name = &opts[2];
+
+    cbindgen::Builder::new()
+        .with_crate(crate_dir)
+        .with_parse_expand(&vec![pkg_name])
+        .generate()
+        .expect("Unable to generate bindings");
+}

--- a/tests/panic_abort_strategy.rs
+++ b/tests/panic_abort_strategy.rs
@@ -1,0 +1,31 @@
+use std::{env, path::PathBuf, process::Command};
+
+#[test]
+fn test_panic_abort_strategy() {
+    // Validates cbindgen's incorporation of https://github.com/alexcrichton/proc-macro2/issues/218.
+    //
+    // Run a binary whose profile specifies `panic = "abort"` and where the binary proceeds to
+    // call into cbindgen's generation functionality. Prior to the incorporation of the above this
+    // would result in the binary aborting.
+    let cargo = env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
+    let mut cmd = Command::new(cargo);
+
+    let tests_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("tests");
+    let wrapper_manifest_path = tests_dir.join("basic_cbindgen_wrapper").join("Cargo.toml");
+    let arg_manifest_dir = tests_dir.join("rust").join("expand_dep");
+
+    cmd.arg("run");
+    cmd.arg("--manifest-path");
+    cmd.arg(wrapper_manifest_path.as_path().to_str().unwrap());
+    cmd.arg("--");
+    cmd.arg(arg_manifest_dir.as_path().to_str().unwrap());
+    cmd.arg("expand-dep");
+
+    let output = cmd.output().expect("Failed to run cargo command");
+
+    assert!(
+        output.status.success(),
+        "Cargo run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
Incorporate https://github.com/alexcrichton/proc-macro2/pull/220 to fix the case where a binary which is built with `panic = "abort"` aborts when calling into cbindgen functionality.

Addresses https://github.com/eqrion/cbindgen/issues/569.

While there is a test included that covers both additions I haven't made any changes to documentation.  If there is desire to have these changes land in some form I'd just be looking for guidance on what doc changes would be appropriate, if any, in addition to any feedback on the overall direction of this change.  Thanks!