### PR TITLE
Add NS_ENUM support, for Swift

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -380,17 +380,27 @@ applies to the generated tags for tagged enums with data in them.
 
 [appledoc]: https://developer.apple.com/documentation/swift/objective-c_and_c_code_customization/grouping_related_objective-c_constants
 
-That way, you can import e.g. `#[repr(i32)] pub enum A { Abc, Def }` in Swift and
-use it as `.abc` as you would with a Swift enum.
+Normally, the ergonomics of C enums in Swift is very poor; you can't use the
+variants directly and pass them to function accepting the typedef name, because
+Swift sees the variants each as just raw integers and the typedef name as a
+newtype. So you essentially have to redefine the enum in Swift, get its
+`.rawValue` and convert it to the C enum type, and convert back in the other
+direction.
+
+With `NS_ENUM`/`CF_ENUM`, you can import e.g. `#[repr(i32)] pub enum A { Abc,
+Def }` in Swift and use it as `A.abc` as you would with a Swift enum. 
 
 ### Example configuration for Swift bindings
 
 ```toml
+language = "C"
 sys_includes = ["CoreFoundation/CoreFoundation.h"]
 [fn]
 swift_name_macro = "CF_SWIFT_NAME"
 [enum]
 swift_enum_macro = "CF_ENUM"
+rename_variants = "SnakeCase" # make the variants .abc/.def instead of .Abc/.Def
+prefix_with_name = true       # optional, but doesn't affect Swift names, only C
 ```
 
 ## cbindgen.toml

--- a/docs.md
+++ b/docs.md
@@ -360,13 +360,38 @@ arg: *mut T --> T arg[]
 
 ## Generating Swift Bindings
 
+### Function names
+
 In addition to parsing function names in C/C++ header files, the Swift compiler can make use of the `swift_name` attribute on functions to generate more idiomatic names for imported functions and methods.
 
 This attribute is commonly used in Objective-C/C/C++ via the `NS_SWIFT_NAME` and `CF_SWIFT_NAME` macros.
 
 Given configuration in the cbindgen.toml, `cbindgen` can generate these attributes for you by guessing an appropriate method signature based on the existing function name (and type, if it is a method in an `impl` block).
 
-This is controlled by the `swift_name_macro` option in the cbindgen.toml.
+This is controlled by the `swift_name_macro` option in the `[fn]` section of cbindgen.toml.
+
+### Directly using enums
+
+Enums that have a `#[repr(<size>)]` representation can be imported and used
+directly in Swift code, if you supply a `swift_enum_macro` in the `[enum]`
+section of cbindgen.toml. This option lets you use the [`NS_ENUM`/`CF_ENUM`
+macros][appledoc] from Apple's Foundation/CoreFoundation headers. It also
+applies to the generated tags for tagged enums with data in them.
+
+[appledoc]: https://developer.apple.com/documentation/swift/objective-c_and_c_code_customization/grouping_related_objective-c_constants
+
+That way, you can import e.g. `#[repr(i32)] pub enum A { Abc, Def }` in Swift and
+use it as `.abc` as you would with a Swift enum.
+
+### Example configuration for Swift bindings
+
+```toml
+sys_includes = ["CoreFoundation/CoreFoundation.h"]
+[fn]
+swift_name_macro = "CF_SWIFT_NAME"
+[enum]
+swift_enum_macro = "CF_ENUM"
+```
 
 ## cbindgen.toml
 
@@ -882,6 +907,14 @@ derive_tagged_enum_copy_assignment = false
 #
 # default: false
 private_default_tagged_enum_constructor = false
+
+# An optional macro to use when generating enum typedefs, which must take two arguments
+# along the lines of `NS_ENUM` (`NS_ENUM(NSInteger, MyEnumTypedefName)`).
+#
+# Only relevant when targeting C; also disables the `cpp_compat` effect on enum definitions.
+#
+# default: no macro is used for typedefs
+swift_enum_macro = "CF_ENUM"
 
 
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -573,6 +573,14 @@ pub struct EnumConfig {
     /// Whether to generate empty, private default-constructors for tagged
     /// enums.
     pub private_default_tagged_enum_constructor: bool,
+    /// An optional macro to use when generating enum typedefs, which must take two arguments
+    /// along the lines of `NS_ENUM` (`NS_ENUM(NSInteger, MyEnumTypedefName)`).
+    /// See the [Apple documentation][appledoc] for details.
+    ///
+    /// Only relevant when targeting C; also disables the `cpp_compat` effect on enum definitions.
+    ///
+    /// [appledoc]: https://developer.apple.com/documentation/swift/objective-c_and_c_code_customization/grouping_related_objective-c_constants
+    pub swift_enum_macro: Option<String>,
 }
 
 impl Default for EnumConfig {
@@ -592,6 +600,7 @@ impl Default for EnumConfig {
             derive_ostream: false,
             enum_class: true,
             private_default_tagged_enum_constructor: false,
+            swift_enum_macro: None,
         }
     }
 }
@@ -659,6 +668,12 @@ impl EnumConfig {
             return x;
         }
         self.private_default_tagged_enum_constructor
+    }
+    pub(crate) fn swift_enum_macro(&self, annotations: &AnnotationSet) -> Option<String> {
+        if let Some(x) = annotations.atom("swift-enum-macro") {
+            return x;
+        }
+        self.swift_enum_macro.clone()
     }
 }
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -776,12 +776,12 @@ impl Enum {
                         write!(out, "enum {}", tag_name);
                         if config.cpp_compatible_c() {
                             out.new_line();
-                            out.write("#if defined(__cplusplus) || __has_feature(objc_fixed_enum)");
+                            out.write("#ifdef __cplusplus");
                             out.new_line();
                             write!(out, "  : {}", prim);
                             out.new_line();
                             out.write(
-                                "#endif // defined(__cplusplus) || __has_feature(objc_fixed_enum)",
+                                "#endif // __cplusplus",
                             );
                             out.new_line();
                         }
@@ -849,7 +849,7 @@ impl Enum {
             if self.typedef_inline_enum_macro(config).is_none() {
                 if config.cpp_compatible_c() {
                     out.new_line_if_not_start();
-                    out.write("#if !(defined(__cplusplus) || __has_feature(objc_fixed_enum))");
+                    out.write("#ifndef __cplusplus");
                 }
 
                 if config.language != Language::Cxx {
@@ -859,9 +859,7 @@ impl Enum {
 
                 if config.cpp_compatible_c() {
                     out.new_line_if_not_start();
-                    out.write(
-                        "#endif // !(defined(__cplusplus) || __has_feature(objc_fixed_enum))",
-                    );
+                    out.write("#endif // __cplusplus");
                 }
             }
         }

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -306,6 +306,24 @@ impl PrimitiveType {
     fn can_cmp_eq(&self) -> bool {
         true
     }
+
+    pub(crate) fn can_be_enum_fixed_type(&self) -> bool {
+        match self {
+            // integer types yes
+            PrimitiveType::Bool
+            | PrimitiveType::Char
+            | PrimitiveType::Char32
+            | PrimitiveType::PtrDiffT
+            | PrimitiveType::Integer { .. }
+            | PrimitiveType::SChar
+            | PrimitiveType::UChar => true,
+            // the rest, no
+            PrimitiveType::Void
+            | PrimitiveType::Double
+            | PrimitiveType::Float
+            | PrimitiveType::VaList => false,
+        }
+    }
 }
 
 // The `U` part of `[T; U]`

--- a/tests/expectations/swift_enum.both.c
+++ b/tests/expectations/swift_enum.both.c
@@ -1,0 +1,184 @@
+#import <CoreFoundation/CoreFoundation.h>
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef CF_ENUM(uint64_t, A) {
+  a1 = 0,
+  a2 = 2,
+  a3,
+  a4 = 5,
+};
+
+typedef CF_ENUM(uint32_t, B) {
+  b1 = 0,
+  b2 = 2,
+  b3,
+  b4 = 5,
+};
+
+typedef CF_ENUM(uint16_t, C) {
+  c1 = 0,
+  c2 = 2,
+  c3,
+  c4 = 5,
+};
+
+typedef CF_ENUM(uint8_t, D) {
+  d1 = 0,
+  d2 = 2,
+  d3,
+  d4 = 5,
+};
+
+typedef CF_ENUM(uintptr_t, E) {
+  e1 = 0,
+  e2 = 2,
+  e3,
+  e4 = 5,
+};
+
+typedef CF_ENUM(intptr_t, F) {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
+};
+
+typedef enum L {
+  l1,
+  l2,
+  l3,
+  l4,
+} L;
+
+typedef CF_ENUM(int8_t, M) {
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
+};
+
+typedef enum N {
+  n1,
+  n2,
+  n3,
+  n4,
+} N;
+
+typedef CF_ENUM(int8_t, O) {
+  o1,
+  o2,
+  o3,
+  o4,
+};
+
+typedef struct J J;
+
+typedef struct K K;
+
+typedef struct Opaque Opaque;
+
+typedef CF_ENUM(uint8_t, G_Tag) {
+  Foo,
+  Bar,
+  Baz,
+};
+
+typedef struct Bar_Body {
+  G_Tag tag;
+  uint8_t x;
+  int16_t y;
+} Bar_Body;
+
+typedef union G {
+  G_Tag tag;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
+  Bar_Body bar;
+} G;
+
+typedef enum H_Tag {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+} H_Tag;
+
+typedef struct H_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} H_Bar_Body;
+
+typedef struct H {
+  H_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    H_Bar_Body bar;
+  };
+} H;
+
+typedef CF_ENUM(uint8_t, ExI_Tag) {
+  ExI_Foo,
+  ExI_Bar,
+  ExI_Baz,
+};
+
+typedef struct ExI_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} ExI_Bar_Body;
+
+typedef struct ExI {
+  ExI_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    ExI_Bar_Body bar;
+  };
+} ExI;
+
+typedef CF_ENUM(uint8_t, P_Tag) {
+  P0,
+  P1,
+};
+
+typedef struct P1_Body {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+} P1_Body;
+
+typedef struct P {
+  P_Tag tag;
+  union {
+    struct {
+      uint8_t p0;
+    };
+    P1_Body p1;
+  };
+} P;
+
+void root(struct Opaque *opaque,
+          A a,
+          B b,
+          C c,
+          D d,
+          E e,
+          F f,
+          union G g,
+          struct H h,
+          struct ExI i,
+          struct J j,
+          struct K k,
+          enum L l,
+          M m,
+          enum N n,
+          O o,
+          struct P p);

--- a/tests/expectations/swift_enum.both.compat.c
+++ b/tests/expectations/swift_enum.both.compat.c
@@ -1,0 +1,192 @@
+#import <CoreFoundation/CoreFoundation.h>
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef CF_ENUM(uint64_t, A) {
+  a1 = 0,
+  a2 = 2,
+  a3,
+  a4 = 5,
+};
+
+typedef CF_ENUM(uint32_t, B) {
+  b1 = 0,
+  b2 = 2,
+  b3,
+  b4 = 5,
+};
+
+typedef CF_ENUM(uint16_t, C) {
+  c1 = 0,
+  c2 = 2,
+  c3,
+  c4 = 5,
+};
+
+typedef CF_ENUM(uint8_t, D) {
+  d1 = 0,
+  d2 = 2,
+  d3,
+  d4 = 5,
+};
+
+typedef CF_ENUM(uintptr_t, E) {
+  e1 = 0,
+  e2 = 2,
+  e3,
+  e4 = 5,
+};
+
+typedef CF_ENUM(intptr_t, F) {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
+};
+
+typedef enum L {
+  l1,
+  l2,
+  l3,
+  l4,
+} L;
+
+typedef CF_ENUM(int8_t, M) {
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
+};
+
+typedef enum N {
+  n1,
+  n2,
+  n3,
+  n4,
+} N;
+
+typedef CF_ENUM(int8_t, O) {
+  o1,
+  o2,
+  o3,
+  o4,
+};
+
+typedef struct J J;
+
+typedef struct K K;
+
+typedef struct Opaque Opaque;
+
+typedef CF_ENUM(uint8_t, G_Tag) {
+  Foo,
+  Bar,
+  Baz,
+};
+
+typedef struct Bar_Body {
+  G_Tag tag;
+  uint8_t x;
+  int16_t y;
+} Bar_Body;
+
+typedef union G {
+  G_Tag tag;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
+  Bar_Body bar;
+} G;
+
+typedef enum H_Tag {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+} H_Tag;
+
+typedef struct H_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} H_Bar_Body;
+
+typedef struct H {
+  H_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    H_Bar_Body bar;
+  };
+} H;
+
+typedef CF_ENUM(uint8_t, ExI_Tag) {
+  ExI_Foo,
+  ExI_Bar,
+  ExI_Baz,
+};
+
+typedef struct ExI_Bar_Body {
+  uint8_t x;
+  int16_t y;
+} ExI_Bar_Body;
+
+typedef struct ExI {
+  ExI_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    ExI_Bar_Body bar;
+  };
+} ExI;
+
+typedef CF_ENUM(uint8_t, P_Tag) {
+  P0,
+  P1,
+};
+
+typedef struct P1_Body {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+} P1_Body;
+
+typedef struct P {
+  P_Tag tag;
+  union {
+    struct {
+      uint8_t p0;
+    };
+    P1_Body p1;
+  };
+} P;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(struct Opaque *opaque,
+          A a,
+          B b,
+          C c,
+          D d,
+          E e,
+          F f,
+          union G g,
+          struct H h,
+          struct ExI i,
+          struct J j,
+          struct K k,
+          enum L l,
+          M m,
+          enum N n,
+          O o,
+          struct P p);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/swift_enum.c
+++ b/tests/expectations/swift_enum.c
@@ -1,0 +1,184 @@
+#import <CoreFoundation/CoreFoundation.h>
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef CF_ENUM(uint64_t, A) {
+  a1 = 0,
+  a2 = 2,
+  a3,
+  a4 = 5,
+};
+
+typedef CF_ENUM(uint32_t, B) {
+  b1 = 0,
+  b2 = 2,
+  b3,
+  b4 = 5,
+};
+
+typedef CF_ENUM(uint16_t, C) {
+  c1 = 0,
+  c2 = 2,
+  c3,
+  c4 = 5,
+};
+
+typedef CF_ENUM(uint8_t, D) {
+  d1 = 0,
+  d2 = 2,
+  d3,
+  d4 = 5,
+};
+
+typedef CF_ENUM(uintptr_t, E) {
+  e1 = 0,
+  e2 = 2,
+  e3,
+  e4 = 5,
+};
+
+typedef CF_ENUM(intptr_t, F) {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
+};
+
+typedef enum {
+  l1,
+  l2,
+  l3,
+  l4,
+} L;
+
+typedef CF_ENUM(int8_t, M) {
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
+};
+
+typedef enum {
+  n1,
+  n2,
+  n3,
+  n4,
+} N;
+
+typedef CF_ENUM(int8_t, O) {
+  o1,
+  o2,
+  o3,
+  o4,
+};
+
+typedef struct J J;
+
+typedef struct K K;
+
+typedef struct Opaque Opaque;
+
+typedef CF_ENUM(uint8_t, G_Tag) {
+  Foo,
+  Bar,
+  Baz,
+};
+
+typedef struct {
+  G_Tag tag;
+  uint8_t x;
+  int16_t y;
+} Bar_Body;
+
+typedef union {
+  G_Tag tag;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
+  Bar_Body bar;
+} G;
+
+typedef enum {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+} H_Tag;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} H_Bar_Body;
+
+typedef struct {
+  H_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    H_Bar_Body bar;
+  };
+} H;
+
+typedef CF_ENUM(uint8_t, ExI_Tag) {
+  ExI_Foo,
+  ExI_Bar,
+  ExI_Baz,
+};
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} ExI_Bar_Body;
+
+typedef struct {
+  ExI_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    ExI_Bar_Body bar;
+  };
+} ExI;
+
+typedef CF_ENUM(uint8_t, P_Tag) {
+  P0,
+  P1,
+};
+
+typedef struct {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+} P1_Body;
+
+typedef struct {
+  P_Tag tag;
+  union {
+    struct {
+      uint8_t p0;
+    };
+    P1_Body p1;
+  };
+} P;
+
+void root(Opaque *opaque,
+          A a,
+          B b,
+          C c,
+          D d,
+          E e,
+          F f,
+          G g,
+          H h,
+          ExI i,
+          J j,
+          K k,
+          L l,
+          M m,
+          N n,
+          O o,
+          P p);

--- a/tests/expectations/swift_enum.compat.c
+++ b/tests/expectations/swift_enum.compat.c
@@ -1,0 +1,192 @@
+#import <CoreFoundation/CoreFoundation.h>
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef CF_ENUM(uint64_t, A) {
+  a1 = 0,
+  a2 = 2,
+  a3,
+  a4 = 5,
+};
+
+typedef CF_ENUM(uint32_t, B) {
+  b1 = 0,
+  b2 = 2,
+  b3,
+  b4 = 5,
+};
+
+typedef CF_ENUM(uint16_t, C) {
+  c1 = 0,
+  c2 = 2,
+  c3,
+  c4 = 5,
+};
+
+typedef CF_ENUM(uint8_t, D) {
+  d1 = 0,
+  d2 = 2,
+  d3,
+  d4 = 5,
+};
+
+typedef CF_ENUM(uintptr_t, E) {
+  e1 = 0,
+  e2 = 2,
+  e3,
+  e4 = 5,
+};
+
+typedef CF_ENUM(intptr_t, F) {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
+};
+
+typedef enum {
+  l1,
+  l2,
+  l3,
+  l4,
+} L;
+
+typedef CF_ENUM(int8_t, M) {
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
+};
+
+typedef enum {
+  n1,
+  n2,
+  n3,
+  n4,
+} N;
+
+typedef CF_ENUM(int8_t, O) {
+  o1,
+  o2,
+  o3,
+  o4,
+};
+
+typedef struct J J;
+
+typedef struct K K;
+
+typedef struct Opaque Opaque;
+
+typedef CF_ENUM(uint8_t, G_Tag) {
+  Foo,
+  Bar,
+  Baz,
+};
+
+typedef struct {
+  G_Tag tag;
+  uint8_t x;
+  int16_t y;
+} Bar_Body;
+
+typedef union {
+  G_Tag tag;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
+  Bar_Body bar;
+} G;
+
+typedef enum {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+} H_Tag;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} H_Bar_Body;
+
+typedef struct {
+  H_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    H_Bar_Body bar;
+  };
+} H;
+
+typedef CF_ENUM(uint8_t, ExI_Tag) {
+  ExI_Foo,
+  ExI_Bar,
+  ExI_Baz,
+};
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} ExI_Bar_Body;
+
+typedef struct {
+  ExI_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    ExI_Bar_Body bar;
+  };
+} ExI;
+
+typedef CF_ENUM(uint8_t, P_Tag) {
+  P0,
+  P1,
+};
+
+typedef struct {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+} P1_Body;
+
+typedef struct {
+  P_Tag tag;
+  union {
+    struct {
+      uint8_t p0;
+    };
+    P1_Body p1;
+  };
+} P;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(Opaque *opaque,
+          A a,
+          B b,
+          C c,
+          D d,
+          E e,
+          F f,
+          G g,
+          H h,
+          ExI i,
+          J j,
+          K k,
+          L l,
+          M m,
+          N n,
+          O o,
+          P p);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/swift_enum.cpp
+++ b/tests/expectations/swift_enum.cpp
@@ -1,0 +1,199 @@
+#import <CoreFoundation/CoreFoundation.h>
+
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+enum class A : uint64_t {
+  a1 = 0,
+  a2 = 2,
+  a3,
+  a4 = 5,
+};
+
+enum class B : uint32_t {
+  b1 = 0,
+  b2 = 2,
+  b3,
+  b4 = 5,
+};
+
+enum class C : uint16_t {
+  c1 = 0,
+  c2 = 2,
+  c3,
+  c4 = 5,
+};
+
+enum class D : uint8_t {
+  d1 = 0,
+  d2 = 2,
+  d3,
+  d4 = 5,
+};
+
+enum class E : uintptr_t {
+  e1 = 0,
+  e2 = 2,
+  e3,
+  e4 = 5,
+};
+
+enum class F : intptr_t {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
+};
+
+enum class L {
+  l1,
+  l2,
+  l3,
+  l4,
+};
+
+enum class M : int8_t {
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
+};
+
+enum N {
+  n1,
+  n2,
+  n3,
+  n4,
+};
+
+enum O : int8_t {
+  o1,
+  o2,
+  o3,
+  o4,
+};
+
+struct J;
+
+struct K;
+
+struct Opaque;
+
+union G {
+  enum class Tag : uint8_t {
+    Foo,
+    Bar,
+    Baz,
+  };
+
+  struct Foo_Body {
+    Tag tag;
+    int16_t _0;
+  };
+
+  struct Bar_Body {
+    Tag tag;
+    uint8_t x;
+    int16_t y;
+  };
+
+  struct {
+    Tag tag;
+  };
+  Foo_Body foo;
+  Bar_Body bar;
+};
+
+struct H {
+  enum class Tag {
+    H_Foo,
+    H_Bar,
+    H_Baz,
+  };
+
+  struct H_Foo_Body {
+    int16_t _0;
+  };
+
+  struct H_Bar_Body {
+    uint8_t x;
+    int16_t y;
+  };
+
+  Tag tag;
+  union {
+    H_Foo_Body foo;
+    H_Bar_Body bar;
+  };
+};
+
+struct ExI {
+  enum class Tag : uint8_t {
+    ExI_Foo,
+    ExI_Bar,
+    ExI_Baz,
+  };
+
+  struct ExI_Foo_Body {
+    int16_t _0;
+  };
+
+  struct ExI_Bar_Body {
+    uint8_t x;
+    int16_t y;
+  };
+
+  Tag tag;
+  union {
+    ExI_Foo_Body foo;
+    ExI_Bar_Body bar;
+  };
+};
+
+struct P {
+  enum class Tag : uint8_t {
+    P0,
+    P1,
+  };
+
+  struct P0_Body {
+    uint8_t _0;
+  };
+
+  struct P1_Body {
+    uint8_t _0;
+    uint8_t _1;
+    uint8_t _2;
+  };
+
+  Tag tag;
+  union {
+    P0_Body p0;
+    P1_Body p1;
+  };
+};
+
+extern "C" {
+
+void root(Opaque *opaque,
+          A a,
+          B b,
+          C c,
+          D d,
+          E e,
+          F f,
+          G g,
+          H h,
+          ExI i,
+          J j,
+          K k,
+          L l,
+          M m,
+          N n,
+          O o,
+          P p);
+
+} // extern "C"

--- a/tests/expectations/swift_enum.pyx
+++ b/tests/expectations/swift_enum.pyx
@@ -1,0 +1,165 @@
+#import <CoreFoundation/CoreFoundation.h>
+
+
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  cdef enum:
+    a1 # = 0,
+    a2 # = 2,
+    a3,
+    a4 # = 5,
+  ctypedef uint64_t A;
+
+  cdef enum:
+    b1 # = 0,
+    b2 # = 2,
+    b3,
+    b4 # = 5,
+  ctypedef uint32_t B;
+
+  cdef enum:
+    c1 # = 0,
+    c2 # = 2,
+    c3,
+    c4 # = 5,
+  ctypedef uint16_t C;
+
+  cdef enum:
+    d1 # = 0,
+    d2 # = 2,
+    d3,
+    d4 # = 5,
+  ctypedef uint8_t D;
+
+  cdef enum:
+    e1 # = 0,
+    e2 # = 2,
+    e3,
+    e4 # = 5,
+  ctypedef uintptr_t E;
+
+  cdef enum:
+    f1 # = 0,
+    f2 # = 2,
+    f3,
+    f4 # = 5,
+  ctypedef intptr_t F;
+
+  ctypedef enum L:
+    l1,
+    l2,
+    l3,
+    l4,
+
+  cdef enum:
+    m1 # = -1,
+    m2 # = 0,
+    m3 # = 1,
+  ctypedef int8_t M;
+
+  ctypedef enum N:
+    n1,
+    n2,
+    n3,
+    n4,
+
+  cdef enum:
+    o1,
+    o2,
+    o3,
+    o4,
+  ctypedef int8_t O;
+
+  ctypedef struct J:
+    pass
+
+  ctypedef struct K:
+    pass
+
+  ctypedef struct Opaque:
+    pass
+
+  cdef enum:
+    Foo,
+    Bar,
+    Baz,
+  ctypedef uint8_t G_Tag;
+
+  ctypedef struct Bar_Body:
+    G_Tag tag;
+    uint8_t x;
+    int16_t y;
+
+  ctypedef union G:
+    G_Tag tag;
+    G_Tag foo_tag;
+    int16_t foo;
+    Bar_Body bar;
+
+  ctypedef enum H_Tag:
+    H_Foo,
+    H_Bar,
+    H_Baz,
+
+  ctypedef struct H_Bar_Body:
+    uint8_t x;
+    int16_t y;
+
+  ctypedef struct H:
+    H_Tag tag;
+    int16_t foo;
+    H_Bar_Body bar;
+
+  cdef enum:
+    ExI_Foo,
+    ExI_Bar,
+    ExI_Baz,
+  ctypedef uint8_t ExI_Tag;
+
+  ctypedef struct ExI_Bar_Body:
+    uint8_t x;
+    int16_t y;
+
+  ctypedef struct ExI:
+    ExI_Tag tag;
+    int16_t foo;
+    ExI_Bar_Body bar;
+
+  cdef enum:
+    P0,
+    P1,
+  ctypedef uint8_t P_Tag;
+
+  ctypedef struct P1_Body:
+    uint8_t _0;
+    uint8_t _1;
+    uint8_t _2;
+
+  ctypedef struct P:
+    P_Tag tag;
+    uint8_t p0;
+    P1_Body p1;
+
+  void root(Opaque *opaque,
+            A a,
+            B b,
+            C c,
+            D d,
+            E e,
+            F f,
+            G g,
+            H h,
+            ExI i,
+            J j,
+            K k,
+            L l,
+            M m,
+            N n,
+            O o,
+            P p);

--- a/tests/expectations/swift_enum.tag.c
+++ b/tests/expectations/swift_enum.tag.c
@@ -1,0 +1,184 @@
+#import <CoreFoundation/CoreFoundation.h>
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef CF_ENUM(uint64_t, A) {
+  a1 = 0,
+  a2 = 2,
+  a3,
+  a4 = 5,
+};
+
+typedef CF_ENUM(uint32_t, B) {
+  b1 = 0,
+  b2 = 2,
+  b3,
+  b4 = 5,
+};
+
+typedef CF_ENUM(uint16_t, C) {
+  c1 = 0,
+  c2 = 2,
+  c3,
+  c4 = 5,
+};
+
+typedef CF_ENUM(uint8_t, D) {
+  d1 = 0,
+  d2 = 2,
+  d3,
+  d4 = 5,
+};
+
+typedef CF_ENUM(uintptr_t, E) {
+  e1 = 0,
+  e2 = 2,
+  e3,
+  e4 = 5,
+};
+
+typedef CF_ENUM(intptr_t, F) {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
+};
+
+enum L {
+  l1,
+  l2,
+  l3,
+  l4,
+};
+
+typedef CF_ENUM(int8_t, M) {
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
+};
+
+enum N {
+  n1,
+  n2,
+  n3,
+  n4,
+};
+
+typedef CF_ENUM(int8_t, O) {
+  o1,
+  o2,
+  o3,
+  o4,
+};
+
+struct J;
+
+struct K;
+
+struct Opaque;
+
+typedef CF_ENUM(uint8_t, G_Tag) {
+  Foo,
+  Bar,
+  Baz,
+};
+
+struct Bar_Body {
+  G_Tag tag;
+  uint8_t x;
+  int16_t y;
+};
+
+union G {
+  G_Tag tag;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
+  struct Bar_Body bar;
+};
+
+enum H_Tag {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+};
+
+struct H_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct H {
+  enum H_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    struct H_Bar_Body bar;
+  };
+};
+
+typedef CF_ENUM(uint8_t, ExI_Tag) {
+  ExI_Foo,
+  ExI_Bar,
+  ExI_Baz,
+};
+
+struct ExI_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct ExI {
+  ExI_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    struct ExI_Bar_Body bar;
+  };
+};
+
+typedef CF_ENUM(uint8_t, P_Tag) {
+  P0,
+  P1,
+};
+
+struct P1_Body {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+};
+
+struct P {
+  P_Tag tag;
+  union {
+    struct {
+      uint8_t p0;
+    };
+    struct P1_Body p1;
+  };
+};
+
+void root(struct Opaque *opaque,
+          A a,
+          B b,
+          C c,
+          D d,
+          E e,
+          F f,
+          union G g,
+          struct H h,
+          struct ExI i,
+          struct J j,
+          struct K k,
+          enum L l,
+          M m,
+          enum N n,
+          O o,
+          struct P p);

--- a/tests/expectations/swift_enum.tag.compat.c
+++ b/tests/expectations/swift_enum.tag.compat.c
@@ -1,0 +1,192 @@
+#import <CoreFoundation/CoreFoundation.h>
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef CF_ENUM(uint64_t, A) {
+  a1 = 0,
+  a2 = 2,
+  a3,
+  a4 = 5,
+};
+
+typedef CF_ENUM(uint32_t, B) {
+  b1 = 0,
+  b2 = 2,
+  b3,
+  b4 = 5,
+};
+
+typedef CF_ENUM(uint16_t, C) {
+  c1 = 0,
+  c2 = 2,
+  c3,
+  c4 = 5,
+};
+
+typedef CF_ENUM(uint8_t, D) {
+  d1 = 0,
+  d2 = 2,
+  d3,
+  d4 = 5,
+};
+
+typedef CF_ENUM(uintptr_t, E) {
+  e1 = 0,
+  e2 = 2,
+  e3,
+  e4 = 5,
+};
+
+typedef CF_ENUM(intptr_t, F) {
+  f1 = 0,
+  f2 = 2,
+  f3,
+  f4 = 5,
+};
+
+enum L {
+  l1,
+  l2,
+  l3,
+  l4,
+};
+
+typedef CF_ENUM(int8_t, M) {
+  m1 = -1,
+  m2 = 0,
+  m3 = 1,
+};
+
+enum N {
+  n1,
+  n2,
+  n3,
+  n4,
+};
+
+typedef CF_ENUM(int8_t, O) {
+  o1,
+  o2,
+  o3,
+  o4,
+};
+
+struct J;
+
+struct K;
+
+struct Opaque;
+
+typedef CF_ENUM(uint8_t, G_Tag) {
+  Foo,
+  Bar,
+  Baz,
+};
+
+struct Bar_Body {
+  G_Tag tag;
+  uint8_t x;
+  int16_t y;
+};
+
+union G {
+  G_Tag tag;
+  struct {
+    G_Tag foo_tag;
+    int16_t foo;
+  };
+  struct Bar_Body bar;
+};
+
+enum H_Tag {
+  H_Foo,
+  H_Bar,
+  H_Baz,
+};
+
+struct H_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct H {
+  enum H_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    struct H_Bar_Body bar;
+  };
+};
+
+typedef CF_ENUM(uint8_t, ExI_Tag) {
+  ExI_Foo,
+  ExI_Bar,
+  ExI_Baz,
+};
+
+struct ExI_Bar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct ExI {
+  ExI_Tag tag;
+  union {
+    struct {
+      int16_t foo;
+    };
+    struct ExI_Bar_Body bar;
+  };
+};
+
+typedef CF_ENUM(uint8_t, P_Tag) {
+  P0,
+  P1,
+};
+
+struct P1_Body {
+  uint8_t _0;
+  uint8_t _1;
+  uint8_t _2;
+};
+
+struct P {
+  P_Tag tag;
+  union {
+    struct {
+      uint8_t p0;
+    };
+    struct P1_Body p1;
+  };
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(struct Opaque *opaque,
+          A a,
+          B b,
+          C c,
+          D d,
+          E e,
+          F f,
+          union G g,
+          struct H h,
+          struct ExI i,
+          struct J j,
+          struct K k,
+          enum L l,
+          M m,
+          enum N n,
+          O o,
+          struct P p);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/swift_enum.tag.pyx
+++ b/tests/expectations/swift_enum.tag.pyx
@@ -1,0 +1,165 @@
+#import <CoreFoundation/CoreFoundation.h>
+
+
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  cdef enum:
+    a1 # = 0,
+    a2 # = 2,
+    a3,
+    a4 # = 5,
+  ctypedef uint64_t A;
+
+  cdef enum:
+    b1 # = 0,
+    b2 # = 2,
+    b3,
+    b4 # = 5,
+  ctypedef uint32_t B;
+
+  cdef enum:
+    c1 # = 0,
+    c2 # = 2,
+    c3,
+    c4 # = 5,
+  ctypedef uint16_t C;
+
+  cdef enum:
+    d1 # = 0,
+    d2 # = 2,
+    d3,
+    d4 # = 5,
+  ctypedef uint8_t D;
+
+  cdef enum:
+    e1 # = 0,
+    e2 # = 2,
+    e3,
+    e4 # = 5,
+  ctypedef uintptr_t E;
+
+  cdef enum:
+    f1 # = 0,
+    f2 # = 2,
+    f3,
+    f4 # = 5,
+  ctypedef intptr_t F;
+
+  cdef enum L:
+    l1,
+    l2,
+    l3,
+    l4,
+
+  cdef enum:
+    m1 # = -1,
+    m2 # = 0,
+    m3 # = 1,
+  ctypedef int8_t M;
+
+  cdef enum N:
+    n1,
+    n2,
+    n3,
+    n4,
+
+  cdef enum:
+    o1,
+    o2,
+    o3,
+    o4,
+  ctypedef int8_t O;
+
+  cdef struct J:
+    pass
+
+  cdef struct K:
+    pass
+
+  cdef struct Opaque:
+    pass
+
+  cdef enum:
+    Foo,
+    Bar,
+    Baz,
+  ctypedef uint8_t G_Tag;
+
+  cdef struct Bar_Body:
+    G_Tag tag;
+    uint8_t x;
+    int16_t y;
+
+  cdef union G:
+    G_Tag tag;
+    G_Tag foo_tag;
+    int16_t foo;
+    Bar_Body bar;
+
+  cdef enum H_Tag:
+    H_Foo,
+    H_Bar,
+    H_Baz,
+
+  cdef struct H_Bar_Body:
+    uint8_t x;
+    int16_t y;
+
+  cdef struct H:
+    H_Tag tag;
+    int16_t foo;
+    H_Bar_Body bar;
+
+  cdef enum:
+    ExI_Foo,
+    ExI_Bar,
+    ExI_Baz,
+  ctypedef uint8_t ExI_Tag;
+
+  cdef struct ExI_Bar_Body:
+    uint8_t x;
+    int16_t y;
+
+  cdef struct ExI:
+    ExI_Tag tag;
+    int16_t foo;
+    ExI_Bar_Body bar;
+
+  cdef enum:
+    P0,
+    P1,
+  ctypedef uint8_t P_Tag;
+
+  cdef struct P1_Body:
+    uint8_t _0;
+    uint8_t _1;
+    uint8_t _2;
+
+  cdef struct P:
+    P_Tag tag;
+    uint8_t p0;
+    P1_Body p1;
+
+  void root(Opaque *opaque,
+            A a,
+            B b,
+            C c,
+            D d,
+            E e,
+            F f,
+            G g,
+            H h,
+            ExI i,
+            J j,
+            K k,
+            L l,
+            M m,
+            N n,
+            O o,
+            P p);

--- a/tests/rust/swift_enum.rs
+++ b/tests/rust/swift_enum.rs
@@ -1,0 +1,152 @@
+//! same Rust source as enum.rs, but with different TOML configuration
+
+enum Opaque {
+    Foo(i32),
+    Bar,
+}
+
+#[repr(u64)]
+enum A {
+    a1 = 0,
+    a2 = 2,
+    a3,
+    a4 = 5,
+}
+
+#[repr(u32)]
+enum B {
+    b1 = 0,
+    b2 = 2,
+    b3,
+    b4 = 5,
+}
+
+#[repr(u16)]
+enum C {
+    c1 = 0,
+    c2 = 2,
+    c3,
+    c4 = 5,
+}
+
+#[repr(u8)]
+enum D {
+    d1 = 0,
+    d2 = 2,
+    d3,
+    d4 = 5,
+}
+
+#[repr(usize)]
+enum E {
+    e1 = 0,
+    e2 = 2,
+    e3,
+    e4 = 5,
+}
+
+#[repr(isize)]
+enum F {
+    f1 = 0,
+    f2 = 2,
+    f3,
+    f4 = 5,
+}
+
+#[repr(u8)]
+enum G {
+    Foo(i16),
+    Bar { x: u8, y: i16 },
+    Baz,
+}
+
+/// cbindgen:prefix-with-name
+#[repr(C)]
+enum H {
+    Foo(i16),
+    Bar { x: u8, y: i16 },
+    Baz,
+}
+
+/// cbindgen:prefix-with-name
+#[repr(C, u8)]
+enum I {
+    Foo(i16),
+    Bar { x: u8, y: i16 },
+    Baz,
+}
+
+#[repr(C, u8, u16)]
+enum J {
+    Foo(i16),
+    Bar { x: u8, y: i16 },
+    Baz,
+}
+
+#[repr(C, u8, unknown_hint)]
+enum K {
+    Foo(i16),
+    Bar { x: u8, y: i16 },
+    Baz,
+}
+
+#[repr(C)]
+enum L {
+    l1,
+    l2,
+    l3,
+    l4,
+}
+
+#[repr(i8)]
+enum M {
+    m1 = -1,
+    m2 = 0,
+    m3 = 1,
+}
+
+/// cbindgen:enum-class=false
+#[repr(C)]
+enum N {
+    n1,
+    n2,
+    n3,
+    n4,
+}
+
+/// cbindgen:enum-class=false
+#[repr(i8)]
+enum O {
+    o1,
+    o2,
+    o3,
+    o4,
+}
+
+#[repr(C, u8)]
+enum P {
+    P0(u8),
+    P1(u8, u8, u8),
+}
+
+#[no_mangle]
+pub extern "C" fn root(
+    opaque: *mut Opaque,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P,
+) {
+}

--- a/tests/rust/swift_enum.toml
+++ b/tests/rust/swift_enum.toml
@@ -1,0 +1,12 @@
+header = """
+#import <CoreFoundation/CoreFoundation.h>
+"""
+
+# NS_ENUM is defined as passing through to CF_ENUM so you can use either but
+# CF_ENUM works already whereas #import <Foundation/Foundation.h> requires a
+# change to the test suite
+[enum]
+swift_enum_macro = "CF_ENUM"
+
+[export.rename]
+"I" = "ExI"


### PR DESCRIPTION
See [NS_ENUM docs][appledocs]. See this excerpt from docs.md for motivation:

[appledocs]: https://developer.apple.com/documentation/swift/objective-c_and_c_code_customization/grouping_related_objective-c_constants

> Normally, the ergonomics of C enums in Swift is very poor; you can't use the variants directly and pass them to function accepting the typedef name, because Swift sees the variants each as just raw integers and the typedef name as a newtype. So you essentially have to redefine the enum in Swift, get its `.rawValue` and convert it to the C enum type, and convert back in the other direction.
>
> With `NS_ENUM`/`CF_ENUM`, you can import e.g. `#[repr(i32)] pub enum A { Abc,
Def }` in Swift and use it as `A.abc` as you would with a Swift enum. 

Config is like so:

```toml
sys_includes = ["CoreFoundation/CoreFoundation.h"]
[enum]
swift_enum_macro = "CF_ENUM"
```

Output is like so:

```c
typedef CF_ENUM(uint64_t, A) {
  a1 = 0,
  a2 = 2,
  a3,
  a4 = 5,
};
```

It clobbers `cpp_compat`'s effect on enums, which is normally to add a C++11 fixed type in an ifdef (`enum Name: uint32_t { ... }`). This is because CF_ENUM/NS_ENUM will already do that; the difference is it works in Objective-C as well, and maybe they do some other annotation magic to get Swift to recognise enums.
