### PR TITLE
Update --pretty=expanded to -Zunpretty=expanded

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -399,7 +399,7 @@ trailer = "/* Text to put at the end of the generated file */"
 # default: doesn't emit an include guard
 include_guard = "mozilla_wr_bindings_h"
 
-# Whether to add a `#pragma once` guard 
+# Whether to add a `#pragma once` guard
 # default: doesn't emit a `#pragma once`
 pragma_once = true
 
@@ -937,7 +937,7 @@ include = ["webrender", "webrender_traits"]
 # default: []
 exclude = ["libc"]
 
-# Whether to use a new temporary target directory when running `rustc --pretty=expanded`.
+# Whether to use a new temporary target directory when running `rustc -Zunpretty=expanded`.
 # This may be required for some build processes.
 #
 # default: false
@@ -982,7 +982,7 @@ features = ["cbindgen"]
 [ptr]
 # An optional string to decorate all pointers that are
 # required to be non null. Nullability is inferred from the Rust type: `&T`,
-# `&mut T` and `NonNull<T>` all require a valid pointer value. 
+# `&mut T` and `NonNull<T>` all require a valid pointer value.
 non_null_attribute = "_Nonnull"
 
 # Options specific to Cython bindings.

--- a/src/bindgen/cargo/cargo_expand.rs
+++ b/src/bindgen/cargo/cargo_expand.rs
@@ -92,7 +92,10 @@ pub fn expand(
 
     cmd.arg("rustc");
     cmd.arg("--lib");
-    cmd.arg("--profile=check");
+    // When build with the release profile we can't choose the `check` profile.
+    if profile != Profile::Release {
+        cmd.arg("--profile=check");
+    }
     cmd.arg("--manifest-path");
     cmd.arg(manifest_path);
     if let Some(features) = expand_features {

--- a/src/bindgen/cargo/cargo_expand.rs
+++ b/src/bindgen/cargo/cargo_expand.rs
@@ -15,13 +15,13 @@ extern crate tempfile;
 use self::tempfile::Builder;
 
 #[derive(Debug)]
-/// Possible errors that can occur during `rustc --pretty=expanded`.
+/// Possible errors that can occur during `rustc -Zunpretty=expanded`.
 pub enum Error {
     /// Error during creation of temporary directory
     Io(io::Error),
     /// Output of `cargo metadata` was not valid utf8
     Utf8(Utf8Error),
-    /// Error during execution of `cargo rustc --pretty=expanded`
+    /// Error during execution of `cargo rustc -Zunpretty=expanded`
     Compile(String),
 }
 
@@ -127,9 +127,7 @@ pub fn expand(
     cmd.arg(&package);
     cmd.arg("--verbose");
     cmd.arg("--");
-    cmd.arg("-Z");
-    cmd.arg("unstable-options");
-    cmd.arg("--pretty=expanded");
+    cmd.arg("-Zunpretty=expanded");
     info!("Command: {:?}", cmd);
     let output = cmd.output()?;
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -717,13 +717,13 @@ impl FromStr for Profile {
 
 deserialize_enum_str!(Profile);
 
-/// Settings to apply when running `rustc --pretty=expanded`
+/// Settings to apply when running `rustc -Zunpretty=expanded`
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 #[serde(default)]
 pub struct ParseExpandConfig {
-    /// The names of crates to parse with `rustc --pretty=expanded`
+    /// The names of crates to parse with `rustc -Zunpretty=expanded`
     pub crates: Vec<String>,
     /// Whether to enable all the features when expanding.
     pub all_features: bool,
@@ -806,10 +806,10 @@ pub struct ParseConfig {
     pub include: Option<Vec<String>>,
     /// The names of crates to not parse
     pub exclude: Vec<String>,
-    /// The configuration options for `rustc --pretty=expanded`
+    /// The configuration options for `rustc -Zunpretty=expanded`
     #[serde(deserialize_with = "retrocomp_parse_expand_config_deserialize")]
     pub expand: ParseExpandConfig,
-    /// Whether to use a new temporary target directory when running `rustc --pretty=expanded`.
+    /// Whether to use a new temporary target directory when running `rustc -Zunpretty=expanded`.
     /// This may be required for some build processes.
     pub clean: bool,
     /// List of crate names which generate consts, statics, and fns. By default

--- a/src/bindgen/error.rs
+++ b/src/bindgen/error.rs
@@ -40,7 +40,7 @@ impl fmt::Display for Error {
             }
             Error::CargoExpand(ref crate_name, ref error) => write!(
                 f,
-                "Parsing crate `{}`: couldn't run `cargo rustc --pretty=expanded`: {:?}",
+                "Parsing crate `{}`: couldn't run `cargo rustc -Zunpretty=expanded`: {:?}",
                 crate_name, error
             ),
             Error::ParseSyntaxError {


### PR DESCRIPTION
`--pretty` is gone as of https://github.com/rust-lang/rust/pull/83491