### PR TITLE
Respect remove_underscores config when prefixing name to enum

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -540,9 +540,11 @@ impl Item for Enum {
             };
 
             for variant in &mut self.variants {
-                variant.export_name = format!("{}{}{}", self.export_name, separator, variant.export_name);
+                variant.export_name =
+                    format!("{}{}{}", self.export_name, separator, variant.export_name);
                 if let VariantBody::Body { ref mut body, .. } = variant.body {
-                    body.export_name = format!("{}{}{}", self.export_name, separator, body.export_name());
+                    body.export_name =
+                        format!("{}{}{}", self.export_name, separator, body.export_name());
                 }
             }
         }

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -533,10 +533,16 @@ impl Item for Enum {
         if config.enumeration.prefix_with_name
             || self.annotations.bool("prefix-with-name").unwrap_or(false)
         {
+            let separator = if config.export.mangle.remove_underscores {
+                ""
+            } else {
+                "_"
+            };
+
             for variant in &mut self.variants {
-                variant.export_name = format!("{}_{}", self.export_name, variant.export_name);
+                variant.export_name = format!("{}{}{}", self.export_name, separator, variant.export_name);
                 if let VariantBody::Body { ref mut body, .. } = variant.body {
-                    body.export_name = format!("{}_{}", self.export_name, body.export_name());
+                    body.export_name = format!("{}{}{}", self.export_name, separator, body.export_name());
                 }
             }
         }


### PR DESCRIPTION
This closes #705 

I am not able to run the tests here on my Mac using clang. 

However, I've confirmed this fixes the issue for our project. 

Here some some of the suggested changes for test cases:

```

diff --git a/tests/expectations/mangle.c b/tests/expectations/mangle.c
index 4da7082..d58bc58 100644
--- a/tests/expectations/mangle.c
+++ b/tests/expectations/mangle.c
@@ -10,3 +10,8 @@ typedef struct {
 typedef FooU8 Boo;
 
 void root(Boo x);
+
+typedef enum Bar {
+  BarSome,
+  BarThing,
+} Bar;
diff --git a/tests/expectations/mangle.tag.pyx b/tests/expectations/mangle.tag.pyx
index d362ca8..8542651 100644
--- a/tests/expectations/mangle.tag.pyx
+++ b/tests/expectations/mangle.tag.pyx
@@ -12,3 +12,7 @@ cdef extern from *:
   ctypedef FooU8 Boo;
 
   void root(Boo x);
+
+  ctypedef enum Bar:
+    BarSome,
+    BarThing;
diff --git a/tests/rust/mangle.rs b/tests/rust/mangle.rs
index b4aa46d..ef0124c 100644
--- a/tests/rust/mangle.rs
+++ b/tests/rust/mangle.rs
@@ -9,3 +9,9 @@ pub type Boo = Foo<u8>;
 pub extern "C" fn root(
     x: Boo,
 ) { }
+
+
+pub enum Bar {
+    Some,
+    Thing,
+}
```