### PR TITLE
Add `type_replacements` option to control output of name mangling

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -609,6 +609,14 @@ rename_types = "PascalCase"
 # Whether the underscores from the mangled name should be omitted.
 remove_underscores = false
 
+# Table of replacement strings for substituting type parameters when name mangling.
+# The keys are processed type names, and the values are the replacement strings.
+# This is useful for controlling the mangled names of generic types.
+[export.mangle.type_replacements]
+"U8" = "Char"
+"VecChar" = "Bytes" # This key corresponds to a mangled Vec<u8>
+"Empty" = ""
+
 [layout]
 # A string that should come before the name of any type which has been marked
 # as `#[repr(packed)]`. For instance, "__attribute__((packed))" would be a

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -341,7 +341,8 @@ pub struct MangleConfig {
     pub rename_types: RenameRule,
     /// Remove the underscores used for name mangling.
     pub remove_underscores: bool,
-    /// Replacement names for type parameters when name mangling
+    /// Table of replacement strings for substituting type parameters when name mangling.
+    /// The keys are processed type names, and the values are the replacement strings.
     pub type_replacements: HashMap<String, String>,
 }
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -341,6 +341,8 @@ pub struct MangleConfig {
     pub rename_types: RenameRule,
     /// Remove the underscores used for name mangling.
     pub remove_underscores: bool,
+    /// Replacement names for type parameters when name mangling
+    pub type_replacements: HashMap<String, String>,
 }
 
 impl ExportConfig {

--- a/src/bindgen/ir/item.rs
+++ b/src/bindgen/ir/item.rs
@@ -95,21 +95,24 @@ impl<T: Item + Clone> ItemMap<T> {
     }
 
     pub fn try_insert(&mut self, item: T) -> bool {
-        match (item.cfg().is_some(), self.data.get_mut(item.path())) {
-            (true, Some(&mut ItemValue::Cfg(ref mut items))) => {
-                items.push(item);
-                return true;
+        self.try_insert_item(item, false)
+    }
+
+    pub fn try_insert_item(&mut self, item: T, overwrite_existing: bool) -> bool {
+        if !overwrite_existing {
+            match (item.cfg().is_some(), self.data.get_mut(item.path())) {
+                (true, Some(&mut ItemValue::Cfg(ref mut items))) => {
+                    items.push(item);
+                    return true;
+                }
+                (false, Some(&mut ItemValue::Cfg(_))) => {
+                    return false;
+                }
+                (_, Some(&mut ItemValue::Single(_))) => {
+                    return false;
+                }
+                _ => {}
             }
-            (false, Some(&mut ItemValue::Cfg(_))) => {
-                return false;
-            }
-            (true, Some(&mut ItemValue::Single(_))) => {
-                return false;
-            }
-            (false, Some(&mut ItemValue::Single(_))) => {
-                return false;
-            }
-            _ => {}
         }
 
         let path = item.path().clone();

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -396,21 +396,22 @@ impl Library {
             x.add_monomorphs(self, &mut monomorphs);
         }
 
-        // Insert the monomorphs into self
+        // Insert the monomorphs into self. Allow overwriting to enable empty type parameter
+        // replacements to work properly.
         for monomorph in monomorphs.drain_structs() {
-            self.structs.try_insert(monomorph);
+            self.structs.try_insert_item(monomorph, true);
         }
         for monomorph in monomorphs.drain_unions() {
-            self.unions.try_insert(monomorph);
+            self.unions.try_insert_item(monomorph, true);
         }
         for monomorph in monomorphs.drain_opaques() {
-            self.opaque_items.try_insert(monomorph);
+            self.opaque_items.try_insert_item(monomorph, true);
         }
         for monomorph in monomorphs.drain_typedefs() {
-            self.typedefs.try_insert(monomorph);
+            self.typedefs.try_insert_item(monomorph, true);
         }
         for monomorph in monomorphs.drain_enums() {
-            self.enums.try_insert(monomorph);
+            self.enums.try_insert_item(monomorph, true);
         }
 
         // Remove structs and opaque items that are generic

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -70,21 +70,32 @@ impl<'a> Mangler<'a> {
                 let sub_path =
                     Mangler::new(generic.export_name(), generic.generics(), last, self.config)
                         .mangle();
+                let mangled = self
+                    .config
+                    .rename_types
+                    .apply(&sub_path, IdentifierType::Type);
+                let type_str = self
+                    .config
+                    .type_replacements
+                    .get(mangled.as_ref())
+                    .map(String::as_str)
+                    .unwrap_or_else(|| mangled.as_ref());
 
-                self.output.push_str(
-                    &self
-                        .config
-                        .rename_types
-                        .apply(&sub_path, IdentifierType::Type),
-                );
+                self.output.push_str(type_str);
             }
             Type::Primitive(ref primitive) => {
-                self.output.push_str(
-                    &self
-                        .config
-                        .rename_types
-                        .apply(primitive.to_repr_rust(), IdentifierType::Type),
-                );
+                let mangled = self
+                    .config
+                    .rename_types
+                    .apply(primitive.to_repr_rust(), IdentifierType::Type);
+                let type_str = self
+                    .config
+                    .type_replacements
+                    .get(mangled.as_ref())
+                    .map(String::as_str)
+                    .unwrap_or_else(|| mangled.as_ref());
+
+                self.output.push_str(type_str);
             }
             Type::Ptr {
                 ref ty, is_const, ..
@@ -147,6 +158,7 @@ impl<'a> Mangler<'a> {
 fn generics() {
     use crate::bindgen::ir::{GenericPath, PrimitiveType};
     use crate::bindgen::rename::RenameRule::{self, PascalCase};
+    use std::collections::HashMap;
 
     fn float() -> Type {
         Type::Primitive(PrimitiveType::Float)
@@ -196,6 +208,7 @@ fn generics() {
             &MangleConfig {
                 remove_underscores: true,
                 rename_types: RenameRule::None,
+                type_replacements: HashMap::new(),
             }
         ),
         Path::new("FooBar")
@@ -209,6 +222,7 @@ fn generics() {
             &MangleConfig {
                 remove_underscores: true,
                 rename_types: PascalCase,
+                type_replacements: HashMap::new(),
             },
         ),
         Path::new("FooBarF32")
@@ -222,6 +236,7 @@ fn generics() {
             &MangleConfig {
                 remove_underscores: true,
                 rename_types: PascalCase,
+                type_replacements: HashMap::new(),
             },
         ),
         Path::new("FooBarCChar")
@@ -268,6 +283,7 @@ fn generics() {
             &MangleConfig {
                 remove_underscores: true,
                 rename_types: PascalCase,
+                type_replacements: HashMap::new(),
             },
         ),
         Path::new("FooBarTE")
@@ -284,6 +300,7 @@ fn generics() {
             &MangleConfig {
                 remove_underscores: true,
                 rename_types: PascalCase,
+                type_replacements: HashMap::new(),
             },
         ),
         Path::new("FooBarTBarE")

--- a/tests/expectations/mangle.both.c
+++ b/tests/expectations/mangle.both.c
@@ -14,4 +14,17 @@ typedef struct FooU8 {
 
 typedef struct FooU8 Boo;
 
-void root(Boo x, enum Bar y);
+typedef enum Dog_Tag {
+  DogWoof,
+} Dog_Tag;
+
+typedef struct Dog {
+  Dog_Tag tag;
+  union {
+    struct {
+      struct FooU8 woof;
+    };
+  };
+} Dog;
+
+void root(Boo x, enum Bar y, struct Dog z);

--- a/tests/expectations/mangle.both.compat.c
+++ b/tests/expectations/mangle.both.compat.c
@@ -14,11 +14,24 @@ typedef struct FooU8 {
 
 typedef struct FooU8 Boo;
 
+typedef enum Dog_Tag {
+  DogWoof,
+} Dog_Tag;
+
+typedef struct Dog {
+  Dog_Tag tag;
+  union {
+    struct {
+      struct FooU8 woof;
+    };
+  };
+} Dog;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(Boo x, enum Bar y);
+void root(Boo x, enum Bar y, struct Dog z);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/mangle.c
+++ b/tests/expectations/mangle.c
@@ -14,4 +14,17 @@ typedef struct {
 
 typedef FooU8 Boo;
 
-void root(Boo x, Bar y);
+typedef enum {
+  DogWoof,
+} Dog_Tag;
+
+typedef struct {
+  Dog_Tag tag;
+  union {
+    struct {
+      FooU8 woof;
+    };
+  };
+} Dog;
+
+void root(Boo x, Bar y, Dog z);

--- a/tests/expectations/mangle.compat.c
+++ b/tests/expectations/mangle.compat.c
@@ -14,11 +14,24 @@ typedef struct {
 
 typedef FooU8 Boo;
 
+typedef enum {
+  DogWoof,
+} Dog_Tag;
+
+typedef struct {
+  Dog_Tag tag;
+  union {
+    struct {
+      FooU8 woof;
+    };
+  };
+} Dog;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(Boo x, Bar y);
+void root(Boo x, Bar y, Dog z);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/mangle.cpp
+++ b/tests/expectations/mangle.cpp
@@ -16,8 +16,24 @@ struct Foo {
 
 using Boo = Foo<uint8_t>;
 
+template<typename T>
+struct Dog {
+  enum class Tag {
+    DogWoof,
+  };
+
+  struct DogWoof_Body {
+    T _0;
+  };
+
+  Tag tag;
+  union {
+    DogWoof_Body woof;
+  };
+};
+
 extern "C" {
 
-void root(Boo x, Bar y);
+void root(Boo x, Bar y, Dog<Foo<uint8_t>> z);
 
 } // extern "C"

--- a/tests/expectations/mangle.pyx
+++ b/tests/expectations/mangle.pyx
@@ -15,4 +15,11 @@ cdef extern from *:
 
   ctypedef FooU8 Boo;
 
-  void root(Boo x, Bar y);
+  ctypedef enum Dog_Tag:
+    DogWoof,
+
+  ctypedef struct Dog:
+    Dog_Tag tag;
+    FooU8 woof;
+
+  void root(Boo x, Bar y, Dog z);

--- a/tests/expectations/mangle.tag.c
+++ b/tests/expectations/mangle.tag.c
@@ -14,4 +14,17 @@ struct FooU8 {
 
 typedef struct FooU8 Boo;
 
-void root(Boo x, enum Bar y);
+enum Dog_Tag {
+  DogWoof,
+};
+
+struct Dog {
+  enum Dog_Tag tag;
+  union {
+    struct {
+      struct FooU8 woof;
+    };
+  };
+};
+
+void root(Boo x, enum Bar y, struct Dog z);

--- a/tests/expectations/mangle.tag.compat.c
+++ b/tests/expectations/mangle.tag.compat.c
@@ -14,11 +14,24 @@ struct FooU8 {
 
 typedef struct FooU8 Boo;
 
+enum Dog_Tag {
+  DogWoof,
+};
+
+struct Dog {
+  enum Dog_Tag tag;
+  union {
+    struct {
+      struct FooU8 woof;
+    };
+  };
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(Boo x, enum Bar y);
+void root(Boo x, enum Bar y, struct Dog z);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/mangle.tag.pyx
+++ b/tests/expectations/mangle.tag.pyx
@@ -15,4 +15,11 @@ cdef extern from *:
 
   ctypedef FooU8 Boo;
 
-  void root(Boo x, Bar y);
+  cdef enum Dog_Tag:
+    DogWoof,
+
+  cdef struct Dog:
+    Dog_Tag tag;
+    FooU8 woof;
+
+  void root(Boo x, Bar y, Dog z);

--- a/tests/rust/mangle.rs
+++ b/tests/rust/mangle.rs
@@ -12,8 +12,11 @@ pub enum Bar {
     Thing,
 }
 
+/// cbindgen:prefix-with-name=true
+#[repr(C)]
+pub enum Dog<T> {
+    Woof(T),
+}
+
 #[no_mangle]
-pub extern "C" fn root(
-    x: Boo,
-    y: Bar,
-) { }
+pub extern "C" fn root(x: Boo, y: Bar, z: Dog<Foo<u8>>) {}

--- a/tests/rust/mangle.toml
+++ b/tests/rust/mangle.toml
@@ -1,3 +1,6 @@
 [export.mangle]
 remove_underscores = true
 rename_types = "PascalCase"
+
+[export.mangle.type_replacements]
+"FooU8" = ""


### PR DESCRIPTION
This PR introduces the `mangle.type_replacements` option, allowing users to replace type parameter names with their own strings when name mangling. This enables users to customize and control the output of the name mangling process.