### PR TITLE
RFC: Map RawFd to Int

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -158,6 +158,7 @@ cbindgen contains the following hardcoded mappings (again completely ignoring na
 * f32 => float
 * f64 => double
 * VaList => va_list
+* RawFd => int
 * PhantomData => *evaporates*, can only appear as the field of a type
 * PhantomPinned => *evaporates*, can only appear as the field of a type  
 * () => *evaporates*, can only appear as the field of a type

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -77,6 +77,7 @@ impl PrimitiveType {
                     "c_ulong" => (IntKind::Long, false),
                     "c_ulonglong" => (IntKind::LongLong, false),
                     "size_t" => (IntKind::SizeT, false),
+                    "RawFd" => (IntKind::Int, true),
 
                     "isize" | "intptr_t" => (IntKind::Size, true),
                     "usize" | "uintptr_t" => (IntKind::Size, false),


### PR DESCRIPTION
On all Unix systems, RawFd is defined as c_int.

