### PR TITLE
Fix for syn::Type::Reference. Properly represent a C pointer '*' or r…

### DIFF
--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -379,7 +379,7 @@ impl Type {
                     ty: Box::new(converted),
                     is_const,
                     is_nullable: false,
-                    is_ref: false,
+                    is_ref: true, // Must be true when Type is reference
                 }
             }
             syn::Type::Ptr(ref pointer) => {


### PR DESCRIPTION
…eference '&'

Example of issue:

Rust code:
```
#[no_mangle]
pub extern "C" fn key_to_hex(raw_hex: &mut [c_char; GXT_KEY_LEN_HEX], raw_key: &[u8; GXT_KEY_LEN])
```

Incorrect C Code:
```
void key_to_hex(char (*rawHex)[GXT_KEY_LEN_HEX],
                              const uint8_t (&rawKey)[GXT_KEY_LEN]);
```

Correct C Code: 
```
key_to_hex(char (&rawHex)[GXT_KEY_LEN_HEX],
                              const uint8_t (&rawKey)[GXT_KEY_LEN]);
```

Although this is not yet a complete fix but it is a step forward.
Next, is to change a sized C Array without any pointer or reference. 
