### PR TITLE
Fixes2 - fix array types for C

### DIFF
--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -385,9 +385,9 @@ impl SynFnArgHelpers for syn::FnArg {
                     Some(x) => x,
                     None => return Ok(None),
                 };
-                if let Type::Array(..) = ty {
-                    return Err("Array as function arguments are not supported".to_owned());
-                }
+                // if let Type::Array(..) = ty {
+                //     return Err("Array as function arguments are not supported".to_owned());
+                // }
                 Ok(Some(FunctionArgument {
                     name,
                     ty,

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -379,7 +379,7 @@ impl Type {
                     ty: Box::new(converted),
                     is_const,
                     is_nullable: false,
-                    is_ref: false,
+                    is_ref: true, // Must be true when Type is reference
                 }
             }
             syn::Type::Ptr(ref pointer) => {

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -375,11 +375,16 @@ impl Type {
 
                 // TODO(emilio): we could make these use is_ref: true.
                 let is_const = reference.mutability.is_none();
-                Type::Ptr {
-                    ty: Box::new(converted),
-                    is_const,
-                    is_nullable: false,
-                    is_ref: true, // Must be true when Type is reference
+                match &converted {
+                    Type::Array(_x, _y) => {
+                        converted
+                    },
+                    _ => Type::Ptr {
+                        ty: Box::new(converted),
+                        is_const,
+                        is_nullable: false,
+                        is_ref: true, // Must be true when Type is reference
+                    }
                 }
             }
             syn::Type::Ptr(ref pointer) => {


### PR DESCRIPTION
Now Array types are passed properly.

Example: 
```Rust
pub extern "C" fn key_to_hex(raw_hex: &mut [c_char; GXT_KEY_LEN_HEX], raw_key: &[u8; GXT_KEY_LEN])
```

```C
void key_to_hex(char rawHex[GXT_KEY_LEN_HEX], uint8_t rawKey[GXT_KEY_LEN]);
```
