### PR TITLE
Add support for generic struct parametrized by unit type

### DIFF
--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -491,9 +491,11 @@ impl Type {
             }
             syn::Type::Tuple(ref tuple) => {
                 if tuple.elems.is_empty() {
-                    return Ok(None);
+                    // The generic type is the Rust unit type, use C void to represent it.
+                    Type::Primitive(PrimitiveType::Void)
+                } else {
+                    return Err("Tuples are not supported types.".to_owned());
                 }
-                return Err("Tuples are not supported types.".to_owned());
             }
             _ => return Err(format!("Unsupported type: {:?}", ty)),
         };

--- a/tests/expectations/struct_generic_unit.both.c
+++ b/tests/expectations/struct_generic_unit.both.c
@@ -1,0 +1,10 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct MyStruct_c_void {
+  uint32_t int_field;
+} MyStruct_c_void;
+
+struct MyStruct_c_void my_test(void);

--- a/tests/expectations/struct_generic_unit.both.compat.c
+++ b/tests/expectations/struct_generic_unit.both.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct MyStruct_c_void {
+  uint32_t int_field;
+} MyStruct_c_void;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+struct MyStruct_c_void my_test(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/struct_generic_unit.c
+++ b/tests/expectations/struct_generic_unit.c
@@ -1,0 +1,10 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  uint32_t int_field;
+} MyStruct_c_void;
+
+MyStruct_c_void my_test(void);

--- a/tests/expectations/struct_generic_unit.compat.c
+++ b/tests/expectations/struct_generic_unit.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  uint32_t int_field;
+} MyStruct_c_void;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+MyStruct_c_void my_test(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/struct_generic_unit.cpp
+++ b/tests/expectations/struct_generic_unit.cpp
@@ -1,0 +1,17 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+template<typename T>
+struct MyStruct {
+  uint32_t int_field;
+  T generic_field;
+};
+
+extern "C" {
+
+MyStruct<void> my_test();
+
+} // extern "C"

--- a/tests/expectations/struct_generic_unit.pyx
+++ b/tests/expectations/struct_generic_unit.pyx
@@ -1,0 +1,12 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  ctypedef struct MyStruct_c_void:
+    uint32_t int_field;
+
+  MyStruct_c_void my_test();

--- a/tests/expectations/struct_generic_unit.tag.c
+++ b/tests/expectations/struct_generic_unit.tag.c
@@ -1,0 +1,10 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct MyStruct_c_void {
+  uint32_t int_field;
+};
+
+struct MyStruct_c_void my_test(void);

--- a/tests/expectations/struct_generic_unit.tag.compat.c
+++ b/tests/expectations/struct_generic_unit.tag.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct MyStruct_c_void {
+  uint32_t int_field;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+struct MyStruct_c_void my_test(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/struct_generic_unit.tag.pyx
+++ b/tests/expectations/struct_generic_unit.tag.pyx
@@ -1,0 +1,12 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  cdef struct MyStruct_c_void:
+    uint32_t int_field;
+
+  MyStruct_c_void my_test();

--- a/tests/rust/struct_generic_unit.rs
+++ b/tests/rust/struct_generic_unit.rs
@@ -1,0 +1,13 @@
+#[repr(C)]
+pub struct MyStruct<T> {
+    int_field: u32,
+    generic_field: T,
+}
+
+#[no_mangle]
+pub extern "C" fn my_test() -> MyStruct<()> {
+    MyStruct {
+        int_field: 0,
+        generic_field: ()
+    }
+}


### PR DESCRIPTION
It is no possible to paraemtrize a generic struct by the unit type.
The resulting struct will have the suffix `_c_void`.

This Rust code:

```
pub struct MyStruct<T> {
    int_field: u32,
    generic_field: T,
}

pub extern "C" fn my_test() -> MyStruct<()> {
    MyStruct {
        int_field: 0,
        generic_field: ()
    }
}
```

Will result in this struct in C:

```
typedef struct {
  uint32_t int_field;
} MyStruct_c_void;
```

Fixes #659.