### PR TITLE
Cython: Omit per-variant tags in unions generated for Rust enums

### DIFF
--- a/tests/expectations/annotation.pyx
+++ b/tests/expectations/annotation.pyx
@@ -31,7 +31,6 @@ cdef extern from *:
 
   ctypedef union F:
     F_Tag tag;
-    F_Tag foo_tag;
     int16_t foo;
     Bar_Body bar;
 

--- a/tests/expectations/annotation.tag.pyx
+++ b/tests/expectations/annotation.tag.pyx
@@ -31,7 +31,6 @@ cdef extern from *:
 
   cdef union F:
     F_Tag tag;
-    F_Tag foo_tag;
     int16_t foo;
     Bar_Body bar;
 

--- a/tests/expectations/asserted_cast.pyx
+++ b/tests/expectations/asserted_cast.pyx
@@ -56,7 +56,6 @@ cdef extern from *:
 
   ctypedef union K:
     K_Tag tag;
-    K_Tag foo_tag;
     int16_t foo;
     K_Bar_Body bar;
 

--- a/tests/expectations/asserted_cast.tag.pyx
+++ b/tests/expectations/asserted_cast.tag.pyx
@@ -56,7 +56,6 @@ cdef extern from *:
 
   cdef union K:
     K_Tag tag;
-    K_Tag foo_tag;
     int16_t foo;
     K_Bar_Body bar;
 

--- a/tests/expectations/derive_ostream.pyx
+++ b/tests/expectations/derive_ostream.pyx
@@ -36,7 +36,6 @@ cdef extern from *:
 
   ctypedef union F:
     F_Tag tag;
-    F_Tag foo_tag;
     int16_t foo;
     Bar_Body bar;
 

--- a/tests/expectations/derive_ostream.tag.pyx
+++ b/tests/expectations/derive_ostream.tag.pyx
@@ -36,7 +36,6 @@ cdef extern from *:
 
   cdef union F:
     F_Tag tag;
-    F_Tag foo_tag;
     int16_t foo;
     Bar_Body bar;
 

--- a/tests/expectations/destructor_and_copy_ctor.pyx
+++ b/tests/expectations/destructor_and_copy_ctor.pyx
@@ -81,11 +81,8 @@ cdef extern from *:
 
   ctypedef union Baz_i32:
     Baz_i32_Tag tag;
-    Baz_i32_Tag polygon21_tag;
     Polygon_i32 polygon21;
-    Baz_i32_Tag slice21_tag;
     OwnedSlice_i32 slice21;
-    Baz_i32_Tag slice22_tag;
     OwnedSlice_i32 slice22;
     Slice23_Body_i32 slice23;
     Slice24_Body_i32 slice24;
@@ -98,9 +95,7 @@ cdef extern from *:
 
   ctypedef union Taz:
     Taz_Tag tag;
-    Taz_Tag taz1_tag;
     int32_t taz1;
-    Taz_Tag taz3_tag;
     OwnedSlice_i32 taz3;
 
   cdef enum:
@@ -110,7 +105,6 @@ cdef extern from *:
 
   ctypedef union Tazz:
     Tazz_Tag tag;
-    Tazz_Tag taz2_tag;
     int32_t taz2;
 
   cdef enum:
@@ -120,7 +114,6 @@ cdef extern from *:
 
   ctypedef union Tazzz:
     Tazzz_Tag tag;
-    Tazzz_Tag taz5_tag;
     int32_t taz5;
 
   cdef enum:
@@ -130,9 +123,7 @@ cdef extern from *:
 
   ctypedef union Tazzzz:
     Tazzzz_Tag tag;
-    Tazzzz_Tag taz6_tag;
     int32_t taz6;
-    Tazzzz_Tag taz7_tag;
     uint32_t taz7;
 
   cdef enum:
@@ -142,9 +133,7 @@ cdef extern from *:
 
   ctypedef union Qux:
     Qux_Tag tag;
-    Qux_Tag qux1_tag;
     int32_t qux1;
-    Qux_Tag qux2_tag;
     uint32_t qux2;
 
   void root(const Foo_u32 *a,

--- a/tests/expectations/destructor_and_copy_ctor.tag.pyx
+++ b/tests/expectations/destructor_and_copy_ctor.tag.pyx
@@ -81,11 +81,8 @@ cdef extern from *:
 
   cdef union Baz_i32:
     Baz_i32_Tag tag;
-    Baz_i32_Tag polygon21_tag;
     Polygon_i32 polygon21;
-    Baz_i32_Tag slice21_tag;
     OwnedSlice_i32 slice21;
-    Baz_i32_Tag slice22_tag;
     OwnedSlice_i32 slice22;
     Slice23_Body_i32 slice23;
     Slice24_Body_i32 slice24;
@@ -98,9 +95,7 @@ cdef extern from *:
 
   cdef union Taz:
     Taz_Tag tag;
-    Taz_Tag taz1_tag;
     int32_t taz1;
-    Taz_Tag taz3_tag;
     OwnedSlice_i32 taz3;
 
   cdef enum:
@@ -110,7 +105,6 @@ cdef extern from *:
 
   cdef union Tazz:
     Tazz_Tag tag;
-    Tazz_Tag taz2_tag;
     int32_t taz2;
 
   cdef enum:
@@ -120,7 +114,6 @@ cdef extern from *:
 
   cdef union Tazzz:
     Tazzz_Tag tag;
-    Tazzz_Tag taz5_tag;
     int32_t taz5;
 
   cdef enum:
@@ -130,9 +123,7 @@ cdef extern from *:
 
   cdef union Tazzzz:
     Tazzzz_Tag tag;
-    Tazzzz_Tag taz6_tag;
     int32_t taz6;
-    Tazzzz_Tag taz7_tag;
     uint32_t taz7;
 
   cdef enum:
@@ -142,9 +133,7 @@ cdef extern from *:
 
   cdef union Qux:
     Qux_Tag tag;
-    Qux_Tag qux1_tag;
     int32_t qux1;
-    Qux_Tag qux2_tag;
     uint32_t qux2;
 
   void root(const Foo_u32 *a,

--- a/tests/expectations/enum.pyx
+++ b/tests/expectations/enum.pyx
@@ -95,7 +95,6 @@ cdef extern from *:
 
   ctypedef union G:
     G_Tag tag;
-    G_Tag foo_tag;
     int16_t foo;
     Bar_Body bar;
 

--- a/tests/expectations/enum.tag.pyx
+++ b/tests/expectations/enum.tag.pyx
@@ -95,7 +95,6 @@ cdef extern from *:
 
   cdef union G:
     G_Tag tag;
-    G_Tag foo_tag;
     int16_t foo;
     Bar_Body bar;
 

--- a/tests/expectations/enum_self.pyx
+++ b/tests/expectations/enum_self.pyx
@@ -17,9 +17,7 @@ cdef extern from *:
 
   ctypedef union Bar:
     Bar_Tag tag;
-    Bar_Tag min_tag;
     Foo_Bar min;
-    Bar_Tag max_tag;
     Foo_Bar max;
 
   void root(Bar b);

--- a/tests/expectations/enum_self.tag.pyx
+++ b/tests/expectations/enum_self.tag.pyx
@@ -17,9 +17,7 @@ cdef extern from *:
 
   cdef union Bar:
     Bar_Tag tag;
-    Bar_Tag min_tag;
     Foo_Bar min;
-    Bar_Tag max_tag;
     Foo_Bar max;
 
   void root(Bar b);

--- a/tests/expectations/prefix.pyx
+++ b/tests/expectations/prefix.pyx
@@ -24,7 +24,6 @@ cdef extern from *:
 
   ctypedef union PREFIX_AbsoluteFontWeight:
     PREFIX_AbsoluteFontWeight_Tag tag;
-    PREFIX_AbsoluteFontWeight_Tag weight_tag;
     float weight;
 
   void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/prefix.tag.pyx
+++ b/tests/expectations/prefix.tag.pyx
@@ -24,7 +24,6 @@ cdef extern from *:
 
   cdef union PREFIX_AbsoluteFontWeight:
     PREFIX_AbsoluteFontWeight_Tag tag;
-    PREFIX_AbsoluteFontWeight_Tag weight_tag;
     float weight;
 
   void root(PREFIX_NamedLenArray x, PREFIX_ValuedLenArray y, PREFIX_AbsoluteFontWeight z);

--- a/tests/expectations/transform_op.pyx
+++ b/tests/expectations/transform_op.pyx
@@ -30,9 +30,7 @@ cdef extern from *:
   ctypedef union StyleFoo_i32:
     StyleFoo_i32_Tag tag;
     StyleFoo_Body_i32 foo;
-    StyleFoo_i32_Tag bar_tag;
     int32_t bar;
-    StyleFoo_i32_Tag baz_tag;
     StylePoint_i32 baz;
 
   ctypedef enum StyleBar_i32_Tag:
@@ -83,9 +81,7 @@ cdef extern from *:
 
   ctypedef union StyleBaz:
     StyleBaz_Tag tag;
-    StyleBaz_Tag baz1_tag;
     StyleBar_u32 baz1;
-    StyleBaz_Tag baz2_tag;
     StylePoint_i32 baz2;
 
   cdef enum:

--- a/tests/expectations/transform_op.tag.pyx
+++ b/tests/expectations/transform_op.tag.pyx
@@ -30,9 +30,7 @@ cdef extern from *:
   cdef union StyleFoo_i32:
     StyleFoo_i32_Tag tag;
     StyleFoo_Body_i32 foo;
-    StyleFoo_i32_Tag bar_tag;
     int32_t bar;
-    StyleFoo_i32_Tag baz_tag;
     StylePoint_i32 baz;
 
   cdef enum StyleBar_i32_Tag:
@@ -83,9 +81,7 @@ cdef extern from *:
 
   cdef union StyleBaz:
     StyleBaz_Tag tag;
-    StyleBaz_Tag baz1_tag;
     StyleBar_u32 baz1;
-    StyleBaz_Tag baz2_tag;
     StylePoint_i32 baz2;
 
   cdef enum:


### PR DESCRIPTION
The common `tag` should already be enough, all other tags are identical to it.
In Cython case they only create noise because the declarations only introduce names and do not determine layouts.