### PR TITLE
Support rename rule for union body members

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -559,6 +559,10 @@ impl StructConfig {
 pub struct EnumConfig {
     /// The rename rule to apply to the name of enum variants
     pub rename_variants: RenameRule,
+    /// The rename rule to apply to the names of the union fields in C/C++
+    /// generated from the Rust enum. Applied before rename_variants
+    /// rename rule. Defaults to SnakeCase.
+    pub rename_variant_name_fields: RenameRule,
     /// Whether to add a `Sentinel` value at the end of every enum
     /// This is useful in Gecko for IPC serialization
     pub add_sentinel: bool,
@@ -600,6 +604,7 @@ impl Default for EnumConfig {
     fn default() -> EnumConfig {
         EnumConfig {
             rename_variants: RenameRule::None,
+            rename_variant_name_fields: RenameRule::SnakeCase,
             add_sentinel: false,
             prefix_with_name: false,
             derive_helper_methods: false,

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -149,11 +149,16 @@ impl EnumVariant {
         if let Some(b) = enum_annotations.bool("derive-ostream") {
             annotations.add_default("derive-ostream", AnnotationValue::Bool(b));
         }
+
+        let body_rule = enum_annotations
+            .parse_atom::<RenameRule>("rename-variant-name-fields")
+            .unwrap_or(config.enumeration.rename_variant_name_fields);
+            
         let body = match variant.fields {
             syn::Fields::Unit => VariantBody::Empty(annotations),
             syn::Fields::Named(ref fields) => {
                 let path = Path::new(format!("{}_Body", variant.ident));
-                let name = RenameRule::SnakeCase
+                let name = body_rule
                     .apply(
                         &variant.ident.unraw().to_string(),
                         IdentifierType::StructMember,
@@ -179,7 +184,7 @@ impl EnumVariant {
             }
             syn::Fields::Unnamed(ref fields) => {
                 let path = Path::new(format!("{}_Body", variant.ident));
-                let name = RenameRule::SnakeCase
+                let name = body_rule
                     .apply(
                         &variant.ident.unraw().to_string(),
                         IdentifierType::StructMember,

--- a/tests/expectations/enum.both.c
+++ b/tests/expectations/enum.both.c
@@ -204,6 +204,27 @@ typedef struct Q {
   };
 } Q;
 
+typedef enum R_Tag {
+  IRFoo,
+  IRBar,
+  IRBaz,
+} R_Tag;
+
+typedef struct IRBar_Body {
+  uint8_t x;
+  int16_t y;
+} IRBar_Body;
+
+typedef struct R {
+  R_Tag tag;
+  union {
+    struct {
+      int16_t IRFoo;
+    };
+    IRBar_Body IRBar;
+  };
+} R;
+
 void root(struct Opaque *opaque,
           A a,
           B b,
@@ -221,7 +242,8 @@ void root(struct Opaque *opaque,
           enum N n,
           O o,
           struct P p,
-          struct Q q);
+          struct Q q,
+          struct R r);
 
 #if 0
 ''' '

--- a/tests/expectations/enum.both.compat.c
+++ b/tests/expectations/enum.both.compat.c
@@ -270,6 +270,27 @@ typedef struct Q {
   };
 } Q;
 
+typedef enum R_Tag {
+  IRFoo,
+  IRBar,
+  IRBaz,
+} R_Tag;
+
+typedef struct IRBar_Body {
+  uint8_t x;
+  int16_t y;
+} IRBar_Body;
+
+typedef struct R {
+  R_Tag tag;
+  union {
+    struct {
+      int16_t IRFoo;
+    };
+    IRBar_Body IRBar;
+  };
+} R;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -291,7 +312,8 @@ void root(struct Opaque *opaque,
           enum N n,
           O o,
           struct P p,
-          struct Q q);
+          struct Q q,
+          struct R r);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/enum.c
+++ b/tests/expectations/enum.c
@@ -204,6 +204,27 @@ typedef struct {
   };
 } Q;
 
+typedef enum {
+  IRFoo,
+  IRBar,
+  IRBaz,
+} R_Tag;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} IRBar_Body;
+
+typedef struct {
+  R_Tag tag;
+  union {
+    struct {
+      int16_t IRFoo;
+    };
+    IRBar_Body IRBar;
+  };
+} R;
+
 void root(Opaque *opaque,
           A a,
           B b,
@@ -221,7 +242,8 @@ void root(Opaque *opaque,
           N n,
           O o,
           P p,
-          Q q);
+          Q q,
+          R r);
 
 #if 0
 ''' '

--- a/tests/expectations/enum.compat.c
+++ b/tests/expectations/enum.compat.c
@@ -270,6 +270,27 @@ typedef struct {
   };
 } Q;
 
+typedef enum {
+  IRFoo,
+  IRBar,
+  IRBaz,
+} R_Tag;
+
+typedef struct {
+  uint8_t x;
+  int16_t y;
+} IRBar_Body;
+
+typedef struct {
+  R_Tag tag;
+  union {
+    struct {
+      int16_t IRFoo;
+    };
+    IRBar_Body IRBar;
+  };
+} R;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -291,7 +312,8 @@ void root(Opaque *opaque,
           N n,
           O o,
           P p,
-          Q q);
+          Q q,
+          R r);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/enum.cpp
+++ b/tests/expectations/enum.cpp
@@ -208,6 +208,29 @@ struct Q {
   };
 };
 
+struct R {
+  enum class Tag {
+    IRFoo,
+    IRBar,
+    IRBaz,
+  };
+
+  struct IRFoo_Body {
+    int16_t _0;
+  };
+
+  struct IRBar_Body {
+    uint8_t x;
+    int16_t y;
+  };
+
+  Tag tag;
+  union {
+    IRFoo_Body IRFoo;
+    IRBar_Body IRBar;
+  };
+};
+
 extern "C" {
 
 void root(Opaque *opaque,
@@ -227,7 +250,8 @@ void root(Opaque *opaque,
           N n,
           O o,
           P p,
-          Q q);
+          Q q,
+          R r);
 
 } // extern "C"
 

--- a/tests/expectations/enum.pyx
+++ b/tests/expectations/enum.pyx
@@ -165,6 +165,20 @@ cdef extern from *:
     uint32_t *ok;
     uint32_t err;
 
+  ctypedef enum R_Tag:
+    IRFoo,
+    IRBar,
+    IRBaz,
+
+  ctypedef struct IRBar_Body:
+    uint8_t x;
+    int16_t y;
+
+  ctypedef struct R:
+    R_Tag tag;
+    int16_t IRFoo;
+    IRBar_Body IRBar;
+
   void root(Opaque *opaque,
             A a,
             B b,
@@ -182,7 +196,8 @@ cdef extern from *:
             N n,
             O o,
             P p,
-            Q q);
+            Q q,
+            R r);
 
 #if 0
 ''' '

--- a/tests/expectations/enum.tag.c
+++ b/tests/expectations/enum.tag.c
@@ -204,6 +204,27 @@ struct Q {
   };
 };
 
+enum R_Tag {
+  IRFoo,
+  IRBar,
+  IRBaz,
+};
+
+struct IRBar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct R {
+  enum R_Tag tag;
+  union {
+    struct {
+      int16_t IRFoo;
+    };
+    struct IRBar_Body IRBar;
+  };
+};
+
 void root(struct Opaque *opaque,
           A a,
           B b,
@@ -221,7 +242,8 @@ void root(struct Opaque *opaque,
           enum N n,
           O o,
           struct P p,
-          struct Q q);
+          struct Q q,
+          struct R r);
 
 #if 0
 ''' '

--- a/tests/expectations/enum.tag.compat.c
+++ b/tests/expectations/enum.tag.compat.c
@@ -270,6 +270,27 @@ struct Q {
   };
 };
 
+enum R_Tag {
+  IRFoo,
+  IRBar,
+  IRBaz,
+};
+
+struct IRBar_Body {
+  uint8_t x;
+  int16_t y;
+};
+
+struct R {
+  enum R_Tag tag;
+  union {
+    struct {
+      int16_t IRFoo;
+    };
+    struct IRBar_Body IRBar;
+  };
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -291,7 +312,8 @@ void root(struct Opaque *opaque,
           enum N n,
           O o,
           struct P p,
-          struct Q q);
+          struct Q q,
+          struct R r);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/enum.tag.pyx
+++ b/tests/expectations/enum.tag.pyx
@@ -165,6 +165,20 @@ cdef extern from *:
     uint32_t *ok;
     uint32_t err;
 
+  cdef enum R_Tag:
+    IRFoo,
+    IRBar,
+    IRBaz,
+
+  cdef struct IRBar_Body:
+    uint8_t x;
+    int16_t y;
+
+  cdef struct R:
+    R_Tag tag;
+    int16_t IRFoo;
+    IRBar_Body IRBar;
+
   void root(Opaque *opaque,
             A a,
             B b,
@@ -182,7 +196,8 @@ cdef extern from *:
             N n,
             O o,
             P p,
-            Q q);
+            Q q,
+            R r);
 
 #if 0
 ''' '

--- a/tests/rust/enum.rs
+++ b/tests/rust/enum.rs
@@ -133,6 +133,14 @@ enum Q {
     Err(u32),
 }
 
+/// cbindgen:rename-variant-name-fields=None
+#[repr(C)]
+enum R {
+    IRFoo(i16),
+    IRBar { x: u8, y: i16 },
+    IRBaz,
+}
+
 #[no_mangle]
 pub extern "C" fn root(
     opaque: *mut Opaque,
@@ -153,5 +161,6 @@ pub extern "C" fn root(
     o: O,
     p: P,
     q: Q,
+    r: R,
 ) {
 }


### PR DESCRIPTION
I am trying to use C++ macros to generate accessors for the fields in a rust enum. Since they are converted to SnakeCase by default, its impossible to write a macro that does this using only the original enum variant name. 

Can we add an option to support different rename rules for the union body members as well?