### PR TITLE
constant: Add support for associated constant expressions.

### DIFF
--- a/tests/expectations/associated_in_body.both.c
+++ b/tests/expectations/associated_in_body.both.c
@@ -35,4 +35,25 @@ typedef struct StyleAlignFlags {
 #define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 #define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
-void root(struct StyleAlignFlags flags);
+/**
+ * An arbitrary identifier for a native (OS compositor) surface
+ */
+typedef struct StyleNativeSurfaceId {
+  uint64_t _0;
+} StyleNativeSurfaceId;
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeSurfaceId_DEBUG_OVERLAY (StyleNativeSurfaceId){ ._0 = UINT64_MAX }
+
+typedef struct StyleNativeTileId {
+  struct StyleNativeSurfaceId surface_id;
+  int32_t x;
+  int32_t y;
+} StyleNativeTileId;
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeTileId_DEBUG_OVERLAY (StyleNativeTileId){ .surface_id = StyleNativeSurfaceId_DEBUG_OVERLAY, .x = 0, .y = 0 }
+
+void root(struct StyleAlignFlags flags, struct StyleNativeTileId tile);

--- a/tests/expectations/associated_in_body.both.c
+++ b/tests/expectations/associated_in_body.both.c
@@ -27,9 +27,12 @@ typedef struct StyleAlignFlags {
  * 'end'
  */
 #define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define StyleAlignFlags_ALIAS (StyleAlignFlags){ .bits = (uint8_t)(StyleAlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
+#define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
 void root(struct StyleAlignFlags flags);

--- a/tests/expectations/associated_in_body.both.compat.c
+++ b/tests/expectations/associated_in_body.both.compat.c
@@ -35,11 +35,32 @@ typedef struct StyleAlignFlags {
 #define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 #define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
+/**
+ * An arbitrary identifier for a native (OS compositor) surface
+ */
+typedef struct StyleNativeSurfaceId {
+  uint64_t _0;
+} StyleNativeSurfaceId;
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeSurfaceId_DEBUG_OVERLAY (StyleNativeSurfaceId){ ._0 = UINT64_MAX }
+
+typedef struct StyleNativeTileId {
+  struct StyleNativeSurfaceId surface_id;
+  int32_t x;
+  int32_t y;
+} StyleNativeTileId;
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeTileId_DEBUG_OVERLAY (StyleNativeTileId){ .surface_id = StyleNativeSurfaceId_DEBUG_OVERLAY, .x = 0, .y = 0 }
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(struct StyleAlignFlags flags);
+void root(struct StyleAlignFlags flags, struct StyleNativeTileId tile);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/associated_in_body.both.compat.c
+++ b/tests/expectations/associated_in_body.both.compat.c
@@ -27,10 +27,13 @@ typedef struct StyleAlignFlags {
  * 'end'
  */
 #define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define StyleAlignFlags_ALIAS (StyleAlignFlags){ .bits = (uint8_t)(StyleAlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
+#define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/associated_in_body.c
+++ b/tests/expectations/associated_in_body.c
@@ -35,4 +35,25 @@ typedef struct {
 #define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 #define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
-void root(StyleAlignFlags flags);
+/**
+ * An arbitrary identifier for a native (OS compositor) surface
+ */
+typedef struct {
+  uint64_t _0;
+} StyleNativeSurfaceId;
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeSurfaceId_DEBUG_OVERLAY (StyleNativeSurfaceId){ ._0 = UINT64_MAX }
+
+typedef struct {
+  StyleNativeSurfaceId surface_id;
+  int32_t x;
+  int32_t y;
+} StyleNativeTileId;
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeTileId_DEBUG_OVERLAY (StyleNativeTileId){ .surface_id = StyleNativeSurfaceId_DEBUG_OVERLAY, .x = 0, .y = 0 }
+
+void root(StyleAlignFlags flags, StyleNativeTileId tile);

--- a/tests/expectations/associated_in_body.c
+++ b/tests/expectations/associated_in_body.c
@@ -27,9 +27,12 @@ typedef struct {
  * 'end'
  */
 #define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define StyleAlignFlags_ALIAS (StyleAlignFlags){ .bits = (uint8_t)(StyleAlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
+#define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
 void root(StyleAlignFlags flags);

--- a/tests/expectations/associated_in_body.compat.c
+++ b/tests/expectations/associated_in_body.compat.c
@@ -35,11 +35,32 @@ typedef struct {
 #define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 #define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
+/**
+ * An arbitrary identifier for a native (OS compositor) surface
+ */
+typedef struct {
+  uint64_t _0;
+} StyleNativeSurfaceId;
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeSurfaceId_DEBUG_OVERLAY (StyleNativeSurfaceId){ ._0 = UINT64_MAX }
+
+typedef struct {
+  StyleNativeSurfaceId surface_id;
+  int32_t x;
+  int32_t y;
+} StyleNativeTileId;
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeTileId_DEBUG_OVERLAY (StyleNativeTileId){ .surface_id = StyleNativeSurfaceId_DEBUG_OVERLAY, .x = 0, .y = 0 }
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(StyleAlignFlags flags);
+void root(StyleAlignFlags flags, StyleNativeTileId tile);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/associated_in_body.compat.c
+++ b/tests/expectations/associated_in_body.compat.c
@@ -27,10 +27,13 @@ typedef struct {
  * 'end'
  */
 #define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define StyleAlignFlags_ALIAS (StyleAlignFlags){ .bits = (uint8_t)(StyleAlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
+#define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/associated_in_body.cpp
+++ b/tests/expectations/associated_in_body.cpp
@@ -60,8 +60,25 @@ inline const StyleAlignFlags StyleAlignFlags::FLEX_START = StyleAlignFlags{ /* .
 inline const StyleAlignFlags StyleAlignFlags::MIXED = StyleAlignFlags{ /* .bits = */ (uint8_t)(((1 << 4) | (StyleAlignFlags::FLEX_START).bits) | (StyleAlignFlags::END).bits) };
 inline const StyleAlignFlags StyleAlignFlags::MIXED_SELF = StyleAlignFlags{ /* .bits = */ (uint8_t)(((1 << 5) | (StyleAlignFlags::FLEX_START).bits) | (StyleAlignFlags::END).bits) };
 
+/// An arbitrary identifier for a native (OS compositor) surface
+struct StyleNativeSurfaceId {
+  uint64_t _0;
+  static const StyleNativeSurfaceId DEBUG_OVERLAY;
+};
+/// A special id for the native surface that is used for debug / profiler overlays.
+inline const StyleNativeSurfaceId StyleNativeSurfaceId::DEBUG_OVERLAY = StyleNativeSurfaceId{ /* ._0 = */ UINT64_MAX };
+
+struct StyleNativeTileId {
+  StyleNativeSurfaceId surface_id;
+  int32_t x;
+  int32_t y;
+  static const StyleNativeTileId DEBUG_OVERLAY;
+};
+/// A special id for the native surface that is used for debug / profiler overlays.
+inline const StyleNativeTileId StyleNativeTileId::DEBUG_OVERLAY = StyleNativeTileId{ /* .surface_id = */ StyleNativeSurfaceId::DEBUG_OVERLAY, /* .x = */ 0, /* .y = */ 0 };
+
 extern "C" {
 
-void root(StyleAlignFlags flags);
+void root(StyleAlignFlags flags, StyleNativeTileId tile);
 
 } // extern "C"

--- a/tests/expectations/associated_in_body.cpp
+++ b/tests/expectations/associated_in_body.cpp
@@ -41,7 +41,10 @@ struct StyleAlignFlags {
   static const StyleAlignFlags NORMAL;
   static const StyleAlignFlags START;
   static const StyleAlignFlags END;
+  static const StyleAlignFlags ALIAS;
   static const StyleAlignFlags FLEX_START;
+  static const StyleAlignFlags MIXED;
+  static const StyleAlignFlags MIXED_SELF;
 };
 /// 'auto'
 inline const StyleAlignFlags StyleAlignFlags::AUTO = StyleAlignFlags{ /* .bits = */ (uint8_t)0 };
@@ -51,8 +54,11 @@ inline const StyleAlignFlags StyleAlignFlags::NORMAL = StyleAlignFlags{ /* .bits
 inline const StyleAlignFlags StyleAlignFlags::START = StyleAlignFlags{ /* .bits = */ (uint8_t)(1 << 1) };
 /// 'end'
 inline const StyleAlignFlags StyleAlignFlags::END = StyleAlignFlags{ /* .bits = */ (uint8_t)(1 << 2) };
+inline const StyleAlignFlags StyleAlignFlags::ALIAS = StyleAlignFlags{ /* .bits = */ (uint8_t)(StyleAlignFlags::END).bits };
 /// 'flex-start'
 inline const StyleAlignFlags StyleAlignFlags::FLEX_START = StyleAlignFlags{ /* .bits = */ (uint8_t)(1 << 3) };
+inline const StyleAlignFlags StyleAlignFlags::MIXED = StyleAlignFlags{ /* .bits = */ (uint8_t)(((1 << 4) | (StyleAlignFlags::FLEX_START).bits) | (StyleAlignFlags::END).bits) };
+inline const StyleAlignFlags StyleAlignFlags::MIXED_SELF = StyleAlignFlags{ /* .bits = */ (uint8_t)(((1 << 5) | (StyleAlignFlags::FLEX_START).bits) | (StyleAlignFlags::END).bits) };
 
 extern "C" {
 

--- a/tests/expectations/associated_in_body.pyx
+++ b/tests/expectations/associated_in_body.pyx
@@ -25,4 +25,17 @@ cdef extern from *:
   const StyleAlignFlags StyleAlignFlags_MIXED # = <StyleAlignFlags>{ <uint8_t>(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
   const StyleAlignFlags StyleAlignFlags_MIXED_SELF # = <StyleAlignFlags>{ <uint8_t>(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
-  void root(StyleAlignFlags flags);
+  # An arbitrary identifier for a native (OS compositor) surface
+  ctypedef struct StyleNativeSurfaceId:
+    uint64_t _0;
+  # A special id for the native surface that is used for debug / profiler overlays.
+  const StyleNativeSurfaceId StyleNativeSurfaceId_DEBUG_OVERLAY # = <StyleNativeSurfaceId>{ UINT64_MAX }
+
+  ctypedef struct StyleNativeTileId:
+    StyleNativeSurfaceId surface_id;
+    int32_t x;
+    int32_t y;
+  # A special id for the native surface that is used for debug / profiler overlays.
+  const StyleNativeTileId StyleNativeTileId_DEBUG_OVERLAY # = <StyleNativeTileId>{ StyleNativeSurfaceId_DEBUG_OVERLAY, 0, 0 }
+
+  void root(StyleAlignFlags flags, StyleNativeTileId tile);

--- a/tests/expectations/associated_in_body.pyx
+++ b/tests/expectations/associated_in_body.pyx
@@ -19,7 +19,10 @@ cdef extern from *:
   const StyleAlignFlags StyleAlignFlags_START # = <StyleAlignFlags>{ <uint8_t>(1 << 1) }
   # 'end'
   const StyleAlignFlags StyleAlignFlags_END # = <StyleAlignFlags>{ <uint8_t>(1 << 2) }
+  const StyleAlignFlags StyleAlignFlags_ALIAS # = <StyleAlignFlags>{ <uint8_t>(StyleAlignFlags_END).bits }
   # 'flex-start'
   const StyleAlignFlags StyleAlignFlags_FLEX_START # = <StyleAlignFlags>{ <uint8_t>(1 << 3) }
+  const StyleAlignFlags StyleAlignFlags_MIXED # = <StyleAlignFlags>{ <uint8_t>(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
+  const StyleAlignFlags StyleAlignFlags_MIXED_SELF # = <StyleAlignFlags>{ <uint8_t>(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
   void root(StyleAlignFlags flags);

--- a/tests/expectations/associated_in_body.tag.c
+++ b/tests/expectations/associated_in_body.tag.c
@@ -35,4 +35,25 @@ struct StyleAlignFlags {
 #define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 #define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
-void root(struct StyleAlignFlags flags);
+/**
+ * An arbitrary identifier for a native (OS compositor) surface
+ */
+struct StyleNativeSurfaceId {
+  uint64_t _0;
+};
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeSurfaceId_DEBUG_OVERLAY (StyleNativeSurfaceId){ ._0 = UINT64_MAX }
+
+struct StyleNativeTileId {
+  struct StyleNativeSurfaceId surface_id;
+  int32_t x;
+  int32_t y;
+};
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeTileId_DEBUG_OVERLAY (StyleNativeTileId){ .surface_id = StyleNativeSurfaceId_DEBUG_OVERLAY, .x = 0, .y = 0 }
+
+void root(struct StyleAlignFlags flags, struct StyleNativeTileId tile);

--- a/tests/expectations/associated_in_body.tag.c
+++ b/tests/expectations/associated_in_body.tag.c
@@ -27,9 +27,12 @@ struct StyleAlignFlags {
  * 'end'
  */
 #define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define StyleAlignFlags_ALIAS (StyleAlignFlags){ .bits = (uint8_t)(StyleAlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
+#define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
 void root(struct StyleAlignFlags flags);

--- a/tests/expectations/associated_in_body.tag.compat.c
+++ b/tests/expectations/associated_in_body.tag.compat.c
@@ -35,11 +35,32 @@ struct StyleAlignFlags {
 #define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 #define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
+/**
+ * An arbitrary identifier for a native (OS compositor) surface
+ */
+struct StyleNativeSurfaceId {
+  uint64_t _0;
+};
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeSurfaceId_DEBUG_OVERLAY (StyleNativeSurfaceId){ ._0 = UINT64_MAX }
+
+struct StyleNativeTileId {
+  struct StyleNativeSurfaceId surface_id;
+  int32_t x;
+  int32_t y;
+};
+/**
+ * A special id for the native surface that is used for debug / profiler overlays.
+ */
+#define StyleNativeTileId_DEBUG_OVERLAY (StyleNativeTileId){ .surface_id = StyleNativeSurfaceId_DEBUG_OVERLAY, .x = 0, .y = 0 }
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(struct StyleAlignFlags flags);
+void root(struct StyleAlignFlags flags, struct StyleNativeTileId tile);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/associated_in_body.tag.compat.c
+++ b/tests/expectations/associated_in_body.tag.compat.c
@@ -27,10 +27,13 @@ struct StyleAlignFlags {
  * 'end'
  */
 #define StyleAlignFlags_END (StyleAlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define StyleAlignFlags_ALIAS (StyleAlignFlags){ .bits = (uint8_t)(StyleAlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define StyleAlignFlags_FLEX_START (StyleAlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define StyleAlignFlags_MIXED (StyleAlignFlags){ .bits = (uint8_t)(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
+#define StyleAlignFlags_MIXED_SELF (StyleAlignFlags){ .bits = (uint8_t)(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/expectations/associated_in_body.tag.pyx
+++ b/tests/expectations/associated_in_body.tag.pyx
@@ -25,4 +25,17 @@ cdef extern from *:
   const StyleAlignFlags StyleAlignFlags_MIXED # = <StyleAlignFlags>{ <uint8_t>(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
   const StyleAlignFlags StyleAlignFlags_MIXED_SELF # = <StyleAlignFlags>{ <uint8_t>(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
-  void root(StyleAlignFlags flags);
+  # An arbitrary identifier for a native (OS compositor) surface
+  cdef struct StyleNativeSurfaceId:
+    uint64_t _0;
+  # A special id for the native surface that is used for debug / profiler overlays.
+  const StyleNativeSurfaceId StyleNativeSurfaceId_DEBUG_OVERLAY # = <StyleNativeSurfaceId>{ UINT64_MAX }
+
+  cdef struct StyleNativeTileId:
+    StyleNativeSurfaceId surface_id;
+    int32_t x;
+    int32_t y;
+  # A special id for the native surface that is used for debug / profiler overlays.
+  const StyleNativeTileId StyleNativeTileId_DEBUG_OVERLAY # = <StyleNativeTileId>{ StyleNativeSurfaceId_DEBUG_OVERLAY, 0, 0 }
+
+  void root(StyleAlignFlags flags, StyleNativeTileId tile);

--- a/tests/expectations/associated_in_body.tag.pyx
+++ b/tests/expectations/associated_in_body.tag.pyx
@@ -19,7 +19,10 @@ cdef extern from *:
   const StyleAlignFlags StyleAlignFlags_START # = <StyleAlignFlags>{ <uint8_t>(1 << 1) }
   # 'end'
   const StyleAlignFlags StyleAlignFlags_END # = <StyleAlignFlags>{ <uint8_t>(1 << 2) }
+  const StyleAlignFlags StyleAlignFlags_ALIAS # = <StyleAlignFlags>{ <uint8_t>(StyleAlignFlags_END).bits }
   # 'flex-start'
   const StyleAlignFlags StyleAlignFlags_FLEX_START # = <StyleAlignFlags>{ <uint8_t>(1 << 3) }
+  const StyleAlignFlags StyleAlignFlags_MIXED # = <StyleAlignFlags>{ <uint8_t>(((1 << 4) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
+  const StyleAlignFlags StyleAlignFlags_MIXED_SELF # = <StyleAlignFlags>{ <uint8_t>(((1 << 5) | (StyleAlignFlags_FLEX_START).bits) | (StyleAlignFlags_END).bits) }
 
   void root(StyleAlignFlags flags);

--- a/tests/expectations/bitflags.both.c
+++ b/tests/expectations/bitflags.both.c
@@ -27,10 +27,13 @@ typedef struct AlignFlags {
  * 'end'
  */
 #define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define AlignFlags_ALIAS (AlignFlags){ .bits = (uint8_t)(AlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define AlignFlags_MIXED (AlignFlags){ .bits = (uint8_t)(((1 << 4) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
+#define AlignFlags_MIXED_SELF (AlignFlags){ .bits = (uint8_t)(((1 << 5) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
 
 typedef struct DebugFlags {
   uint32_t bits;

--- a/tests/expectations/bitflags.both.compat.c
+++ b/tests/expectations/bitflags.both.compat.c
@@ -27,10 +27,13 @@ typedef struct AlignFlags {
  * 'end'
  */
 #define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define AlignFlags_ALIAS (AlignFlags){ .bits = (uint8_t)(AlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define AlignFlags_MIXED (AlignFlags){ .bits = (uint8_t)(((1 << 4) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
+#define AlignFlags_MIXED_SELF (AlignFlags){ .bits = (uint8_t)(((1 << 5) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
 
 typedef struct DebugFlags {
   uint32_t bits;

--- a/tests/expectations/bitflags.c
+++ b/tests/expectations/bitflags.c
@@ -27,10 +27,13 @@ typedef struct {
  * 'end'
  */
 #define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define AlignFlags_ALIAS (AlignFlags){ .bits = (uint8_t)(AlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define AlignFlags_MIXED (AlignFlags){ .bits = (uint8_t)(((1 << 4) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
+#define AlignFlags_MIXED_SELF (AlignFlags){ .bits = (uint8_t)(((1 << 5) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
 
 typedef struct {
   uint32_t bits;

--- a/tests/expectations/bitflags.compat.c
+++ b/tests/expectations/bitflags.compat.c
@@ -27,10 +27,13 @@ typedef struct {
  * 'end'
  */
 #define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define AlignFlags_ALIAS (AlignFlags){ .bits = (uint8_t)(AlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define AlignFlags_MIXED (AlignFlags){ .bits = (uint8_t)(((1 << 4) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
+#define AlignFlags_MIXED_SELF (AlignFlags){ .bits = (uint8_t)(((1 << 5) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
 
 typedef struct {
   uint32_t bits;

--- a/tests/expectations/bitflags.cpp
+++ b/tests/expectations/bitflags.cpp
@@ -46,8 +46,11 @@ static const AlignFlags AlignFlags_NORMAL = AlignFlags{ /* .bits = */ (uint8_t)1
 static const AlignFlags AlignFlags_START = AlignFlags{ /* .bits = */ (uint8_t)(1 << 1) };
 /// 'end'
 static const AlignFlags AlignFlags_END = AlignFlags{ /* .bits = */ (uint8_t)(1 << 2) };
+static const AlignFlags AlignFlags_ALIAS = AlignFlags{ /* .bits = */ (uint8_t)(AlignFlags_END).bits };
 /// 'flex-start'
 static const AlignFlags AlignFlags_FLEX_START = AlignFlags{ /* .bits = */ (uint8_t)(1 << 3) };
+static const AlignFlags AlignFlags_MIXED = AlignFlags{ /* .bits = */ (uint8_t)(((1 << 4) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) };
+static const AlignFlags AlignFlags_MIXED_SELF = AlignFlags{ /* .bits = */ (uint8_t)(((1 << 5) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) };
 
 struct DebugFlags {
   uint32_t bits;

--- a/tests/expectations/bitflags.pyx
+++ b/tests/expectations/bitflags.pyx
@@ -19,8 +19,11 @@ cdef extern from *:
   const AlignFlags AlignFlags_START # = <AlignFlags>{ <uint8_t>(1 << 1) }
   # 'end'
   const AlignFlags AlignFlags_END # = <AlignFlags>{ <uint8_t>(1 << 2) }
+  const AlignFlags AlignFlags_ALIAS # = <AlignFlags>{ <uint8_t>(AlignFlags_END).bits }
   # 'flex-start'
   const AlignFlags AlignFlags_FLEX_START # = <AlignFlags>{ <uint8_t>(1 << 3) }
+  const AlignFlags AlignFlags_MIXED # = <AlignFlags>{ <uint8_t>(((1 << 4) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
+  const AlignFlags AlignFlags_MIXED_SELF # = <AlignFlags>{ <uint8_t>(((1 << 5) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
 
   ctypedef struct DebugFlags:
     uint32_t bits;

--- a/tests/expectations/bitflags.tag.c
+++ b/tests/expectations/bitflags.tag.c
@@ -27,10 +27,13 @@ struct AlignFlags {
  * 'end'
  */
 #define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define AlignFlags_ALIAS (AlignFlags){ .bits = (uint8_t)(AlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define AlignFlags_MIXED (AlignFlags){ .bits = (uint8_t)(((1 << 4) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
+#define AlignFlags_MIXED_SELF (AlignFlags){ .bits = (uint8_t)(((1 << 5) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
 
 struct DebugFlags {
   uint32_t bits;

--- a/tests/expectations/bitflags.tag.compat.c
+++ b/tests/expectations/bitflags.tag.compat.c
@@ -27,10 +27,13 @@ struct AlignFlags {
  * 'end'
  */
 #define AlignFlags_END (AlignFlags){ .bits = (uint8_t)(1 << 2) }
+#define AlignFlags_ALIAS (AlignFlags){ .bits = (uint8_t)(AlignFlags_END).bits }
 /**
  * 'flex-start'
  */
 #define AlignFlags_FLEX_START (AlignFlags){ .bits = (uint8_t)(1 << 3) }
+#define AlignFlags_MIXED (AlignFlags){ .bits = (uint8_t)(((1 << 4) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
+#define AlignFlags_MIXED_SELF (AlignFlags){ .bits = (uint8_t)(((1 << 5) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
 
 struct DebugFlags {
   uint32_t bits;

--- a/tests/expectations/bitflags.tag.pyx
+++ b/tests/expectations/bitflags.tag.pyx
@@ -19,8 +19,11 @@ cdef extern from *:
   const AlignFlags AlignFlags_START # = <AlignFlags>{ <uint8_t>(1 << 1) }
   # 'end'
   const AlignFlags AlignFlags_END # = <AlignFlags>{ <uint8_t>(1 << 2) }
+  const AlignFlags AlignFlags_ALIAS # = <AlignFlags>{ <uint8_t>(AlignFlags_END).bits }
   # 'flex-start'
   const AlignFlags AlignFlags_FLEX_START # = <AlignFlags>{ <uint8_t>(1 << 3) }
+  const AlignFlags AlignFlags_MIXED # = <AlignFlags>{ <uint8_t>(((1 << 4) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
+  const AlignFlags AlignFlags_MIXED_SELF # = <AlignFlags>{ <uint8_t>(((1 << 5) | (AlignFlags_FLEX_START).bits) | (AlignFlags_END).bits) }
 
   cdef struct DebugFlags:
     uint32_t bits;

--- a/tests/rust/associated_in_body.rs
+++ b/tests/rust/associated_in_body.rs
@@ -21,5 +21,34 @@ bitflags! {
     }
 }
 
+/// An arbitrary identifier for a native (OS compositor) surface
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub struct NativeSurfaceId(pub u64);
+
+impl NativeSurfaceId {
+    /// A special id for the native surface that is used for debug / profiler overlays.
+    pub const DEBUG_OVERLAY: NativeSurfaceId = NativeSurfaceId(u64::MAX);
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct NativeTileId {
+    pub surface_id: NativeSurfaceId,
+    pub x: i32,
+    pub y: i32,
+}
+
+impl NativeTileId {
+    /// A special id for the native surface that is used for debug / profiler overlays.
+    pub const DEBUG_OVERLAY: NativeTileId = NativeTileId {
+        surface_id: NativeSurfaceId::DEBUG_OVERLAY,
+        x: 0,
+        y: 0,
+    };
+}
+
 #[no_mangle]
-pub extern "C" fn root(flags: AlignFlags) {}
+pub extern "C" fn root(flags: AlignFlags, tile: NativeTileId) {}

--- a/tests/rust/associated_in_body.rs
+++ b/tests/rust/associated_in_body.rs
@@ -2,7 +2,7 @@ bitflags! {
     /// Constants shared by multiple CSS Box Alignment properties
     ///
     /// These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
-    #[derive(MallocSizeOf, ToComputedValue)]
+    #[derive(MallocSizeOf)]
     #[repr(C)]
     pub struct AlignFlags: u8 {
         /// 'auto'
@@ -13,8 +13,11 @@ bitflags! {
         const START = 1 << 1;
         /// 'end'
         const END = 1 << 2;
+        const ALIAS = Self::END.bits;
         /// 'flex-start'
         const FLEX_START = 1 << 3;
+        const MIXED = 1 << 4 | AlignFlags::FLEX_START.bits | AlignFlags::END.bits;
+        const MIXED_SELF = 1 << 5 | AlignFlags::FLEX_START.bits | AlignFlags::END.bits;
     }
 }
 

--- a/tests/rust/bitflags.rs
+++ b/tests/rust/bitflags.rs
@@ -2,7 +2,7 @@ bitflags! {
     /// Constants shared by multiple CSS Box Alignment properties
     ///
     /// These constants match Gecko's `NS_STYLE_ALIGN_*` constants.
-    #[derive(MallocSizeOf, ToComputedValue)]
+    #[derive(MallocSizeOf)]
     #[repr(C)]
     pub struct AlignFlags: u8 {
         /// 'auto'
@@ -13,8 +13,11 @@ bitflags! {
         const START = 1 << 1;
         /// 'end'
         const END = 1 << 2;
+        const ALIAS = Self::END.bits;
         /// 'flex-start'
         const FLEX_START = 1 << 3;
+        const MIXED = 1 << 4 | AlignFlags::FLEX_START.bits | AlignFlags::END.bits;
+        const MIXED_SELF = 1 << 5 | AlignFlags::FLEX_START.bits | AlignFlags::END.bits;
     }
 }
 


### PR DESCRIPTION
These are useful for bitflags.