### PR TITLE
Update syn dependency to at least 1.0.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ quote = "1"
 heck = "0.4"
 
 [dependencies.syn]
-version = "1.0.3"
+version = "1.0.88"
 default-features = false
 features = ["clone-impls", "extra-traits", "full", "parsing", "printing"]
 


### PR DESCRIPTION
While the Cargo.lock has 1.0.89, the current minimal version in Cargo.toml
is 1.0.3, which cannot parse modern Rust code. This leads to some
downstreams (*cough* Debian) inadvertently building cbindgen against
older versions of syn and the resulting cbindgen, even if it is the last
version, not being able to parse recent Rust code.

Bumping the version in Cargo.toml alleviates this to some extent. A
quick scan of the syn logs suggests 1.0.88 is the last version where
parsing support relevant to stable Rust syntax was added.