### PR TITLE
Const generics

### DIFF
--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -5,7 +5,7 @@
 use std::io::Write;
 
 use crate::bindgen::declarationtyperesolver::DeclarationType;
-use crate::bindgen::ir::{ArrayLength, Function, Type};
+use crate::bindgen::ir::{ArrayLength, Function, GenericArgument, Type};
 use crate::bindgen::writer::{ListType, SourceWriter};
 use crate::bindgen::{Config, Language};
 
@@ -35,7 +35,7 @@ impl CDeclarator {
 struct CDecl {
     type_qualifers: String,
     type_name: String,
-    type_generic_args: Vec<Type>,
+    type_generic_args: Vec<GenericArgument>,
     declarators: Vec<CDeclarator>,
     type_ctype: Option<DeclarationType>,
 }

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -10,8 +10,9 @@ use crate::bindgen::config::{Config, Language};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, AnnotationValue, Cfg, ConditionWrite, Documentation, Field, GenericParams,
-    GenericPath, Item, ItemContainer, Literal, Path, Repr, ReprStyle, Struct, ToCondition, Type,
+    AnnotationSet, AnnotationValue, Cfg, ConditionWrite, Documentation, Field, GenericArgument,
+    GenericParams, GenericPath, Item, ItemContainer, Literal, Path, Repr, ReprStyle, Struct,
+    ToCondition, Type,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -61,8 +62,8 @@ impl VariantBody {
 
     fn specialize(
         &self,
-        generic_values: &[Type],
-        mappings: &[(&Path, &Type)],
+        generic_values: &[GenericArgument],
+        mappings: &[(&Path, &GenericArgument)],
         config: &Config,
     ) -> Self {
         match *self {
@@ -265,8 +266,8 @@ impl EnumVariant {
 
     fn specialize(
         &self,
-        generic_values: &[Type],
-        mappings: &[(&Path, &Type)],
+        generic_values: &[GenericArgument],
+        mappings: &[(&Path, &GenericArgument)],
         config: &Config,
     ) -> Self {
         Self::new(
@@ -611,7 +612,7 @@ impl Item for Enum {
 
     fn instantiate_monomorph(
         &self,
-        generic_values: &[Type],
+        generic_values: &[GenericArgument],
         library: &Library,
         out: &mut Monomorphs,
     ) {

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -383,7 +383,7 @@ impl Enum {
         }
 
         let path = Path::new(item.ident.unraw().to_string());
-        let generic_params = GenericParams::new(&item.generics);
+        let generic_params = GenericParams::load(&item.generics)?;
 
         let mut variants = Vec::new();
         let mut has_data = false;
@@ -616,24 +616,7 @@ impl Item for Enum {
         library: &Library,
         out: &mut Monomorphs,
     ) {
-        assert!(
-            self.generic_params.len() > 0,
-            "{} is not generic",
-            self.path.name()
-        );
-        assert!(
-            self.generic_params.len() == generic_values.len(),
-            "{} has {} params but is being instantiated with {} values",
-            self.path.name(),
-            self.generic_params.len(),
-            generic_values.len(),
-        );
-
-        let mappings = self
-            .generic_params
-            .iter()
-            .zip(generic_values.iter())
-            .collect::<Vec<_>>();
+        let mappings = self.generic_params.call(self.path.name(), generic_values);
 
         for variant in &self.variants {
             if let VariantBody::Body { ref body, .. } = variant.body {

--- a/src/bindgen/ir/item.rs
+++ b/src/bindgen/ir/item.rs
@@ -9,7 +9,8 @@ use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Constant, Enum, OpaqueItem, Path, Static, Struct, Type, Typedef, Union,
+    AnnotationSet, Cfg, Constant, Enum, GenericArgument, OpaqueItem, Path, Static, Struct, Typedef,
+    Union,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::monomorph::Monomorphs;
@@ -37,7 +38,12 @@ pub trait Item {
     }
     fn rename_for_config(&mut self, _config: &Config) {}
     fn add_dependencies(&self, _library: &Library, _out: &mut Dependencies) {}
-    fn instantiate_monomorph(&self, _generics: &[Type], _library: &Library, _out: &mut Monomorphs) {
+    fn instantiate_monomorph(
+        &self,
+        _generics: &[GenericArgument],
+        _library: &Library,
+        _out: &mut Monomorphs,
+    ) {
         unreachable!("Cannot instantiate {} as a generic.", self.name())
     }
 }

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -8,8 +8,8 @@ use crate::bindgen::config::{Config, Language};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericParams, Item, ItemContainer, Path,
-    ToCondition, Type,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericArgument, GenericParams, Item,
+    ItemContainer, Path, ToCondition,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -98,7 +98,7 @@ impl Item for OpaqueItem {
 
     fn instantiate_monomorph(
         &self,
-        generic_values: &[Type],
+        generic_values: &[GenericArgument],
         library: &Library,
         out: &mut Monomorphs,
     ) {

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -35,7 +35,7 @@ impl OpaqueItem {
     ) -> Result<OpaqueItem, String> {
         Ok(Self::new(
             path,
-            GenericParams::new(generics),
+            GenericParams::load(generics)?,
             Cfg::append(mod_cfg, Cfg::load(attrs)),
             AnnotationSet::load(attrs).unwrap_or_else(|_| AnnotationSet::new()),
             Documentation::load(attrs),

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -10,8 +10,9 @@ use crate::bindgen::config::{Config, Language, LayoutConfig};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, ConditionWrite, Constant, Documentation, Field, GenericParams, Item,
-    ItemContainer, Path, Repr, ReprAlign, ReprStyle, ToCondition, Type, Typedef,
+    AnnotationSet, Cfg, ConditionWrite, Constant, Documentation, Field, GenericArgument,
+    GenericParams, Item, ItemContainer, Path, Repr, ReprAlign, ReprStyle, ToCondition, Type,
+    Typedef,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -174,8 +175,8 @@ impl Struct {
 
     pub fn specialize(
         &self,
-        generic_values: &[Type],
-        mappings: &[(&Path, &Type)],
+        generic_values: &[GenericArgument],
+        mappings: &[(&Path, &GenericArgument)],
         config: &Config,
     ) -> Self {
         let mangled_path = mangle::mangle_path(&self.path, generic_values, &config.export.mangle);
@@ -365,7 +366,7 @@ impl Item for Struct {
 
     fn instantiate_monomorph(
         &self,
-        generic_values: &[Type],
+        generic_values: &[GenericArgument],
         library: &Library,
         out: &mut Monomorphs,
     ) {

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -103,7 +103,7 @@ impl Struct {
 
         Ok(Struct::new(
             path,
-            GenericParams::new(&item.generics),
+            GenericParams::load(&item.generics)?,
             fields,
             has_tag_field,
             is_enum_variant_body,
@@ -370,25 +370,7 @@ impl Item for Struct {
         library: &Library,
         out: &mut Monomorphs,
     ) {
-        assert!(
-            self.generic_params.len() > 0,
-            "{} is not generic",
-            self.path
-        );
-        assert!(
-            self.generic_params.len() == generic_values.len(),
-            "{} has {} params but is being instantiated with {} values",
-            self.path,
-            self.generic_params.len(),
-            generic_values.len(),
-        );
-
-        let mappings = self
-            .generic_params
-            .iter()
-            .zip(generic_values.iter())
-            .collect::<Vec<_>>();
-
+        let mappings = self.generic_params.call(self.path.name(), generic_values);
         let monomorph = self.specialize(generic_values, &mappings, library.get_config());
         out.insert_struct(library, self, monomorph, generic_values.to_owned());
     }

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -804,7 +804,7 @@ impl Type {
                     }
                 }
                 let path = generic.path();
-                if !generic_params.contains(path) {
+                if !generic_params.iter().any(|param| param.name() == path) {
                     if let Some(items) = library.get_items(path) {
                         if !out.items.contains(path) {
                             out.items.insert(path.clone());

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -11,8 +11,8 @@ use crate::bindgen::config::{Config, Language};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, ConditionWrite, Documentation, Field, GenericParams, Item, ItemContainer,
-    Path, ToCondition, Type,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, Field, GenericArgument, GenericParams, Item,
+    ItemContainer, Path, ToCondition, Type,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -155,7 +155,7 @@ impl Item for Typedef {
 
     fn instantiate_monomorph(
         &self,
-        generic_values: &[Type],
+        generic_values: &[GenericArgument],
         library: &Library,
         out: &mut Monomorphs,
     ) {

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -37,7 +37,7 @@ impl Typedef {
             let path = Path::new(item.ident.unraw().to_string());
             Ok(Typedef::new(
                 path,
-                GenericParams::new(&item.generics),
+                GenericParams::load(&item.generics)?,
                 x,
                 Cfg::append(mod_cfg, Cfg::load(&item.attrs)),
                 AnnotationSet::load(&item.attrs)?,
@@ -159,24 +159,7 @@ impl Item for Typedef {
         library: &Library,
         out: &mut Monomorphs,
     ) {
-        assert!(
-            self.generic_params.len() > 0,
-            "{} is not generic",
-            self.path
-        );
-        assert!(
-            self.generic_params.len() == generic_values.len(),
-            "{} has {} params but is being instantiated with {} values",
-            self.path,
-            self.generic_params.len(),
-            generic_values.len(),
-        );
-
-        let mappings = self
-            .generic_params
-            .iter()
-            .zip(generic_values.iter())
-            .collect::<Vec<_>>();
+        let mappings = self.generic_params.call(self.path.name(), generic_values);
 
         let mangled_path = mangle::mangle_path(
             &self.path,

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -62,7 +62,7 @@ impl Union {
 
         Ok(Union::new(
             path,
-            GenericParams::new(&item.generics),
+            GenericParams::load(&item.generics)?,
             fields,
             repr.align,
             tuple_union,
@@ -227,24 +227,7 @@ impl Item for Union {
         library: &Library,
         out: &mut Monomorphs,
     ) {
-        assert!(
-            self.generic_params.len() > 0,
-            "{} is not generic",
-            self.path
-        );
-        assert!(
-            self.generic_params.len() == generic_values.len(),
-            "{} has {} params but is being instantiated with {} values",
-            self.path,
-            self.generic_params.len(),
-            generic_values.len(),
-        );
-
-        let mappings = self
-            .generic_params
-            .iter()
-            .zip(generic_values.iter())
-            .collect::<Vec<_>>();
+        let mappings = self.generic_params.call(self.path.name(), generic_values);
 
         let mangled_path = mangle::mangle_path(
             &self.path,

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -10,8 +10,8 @@ use crate::bindgen::config::{Config, Language, LayoutConfig};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, ConditionWrite, Documentation, Field, GenericParams, Item, ItemContainer,
-    Path, Repr, ReprAlign, ReprStyle, ToCondition, Type,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, Field, GenericArgument, GenericParams, Item,
+    ItemContainer, Path, Repr, ReprAlign, ReprStyle, ToCondition,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -223,7 +223,7 @@ impl Item for Union {
 
     fn instantiate_monomorph(
         &self,
-        generic_values: &[Type],
+        generic_values: &[GenericArgument],
         library: &Library,
         out: &mut Monomorphs,
     ) {

--- a/src/bindgen/monomorph.rs
+++ b/src/bindgen/monomorph.rs
@@ -5,7 +5,9 @@
 use std::collections::HashMap;
 use std::mem;
 
-use crate::bindgen::ir::{Enum, GenericPath, OpaqueItem, Path, Struct, Type, Typedef, Union};
+use crate::bindgen::ir::{
+    Enum, GenericArgument, GenericPath, OpaqueItem, Path, Struct, Typedef, Union,
+};
 use crate::bindgen::library::Library;
 
 #[derive(Default, Clone, Debug)]
@@ -28,9 +30,9 @@ impl Monomorphs {
         library: &Library,
         generic: &Struct,
         monomorph: Struct,
-        parameters: Vec<Type>,
+        arguments: Vec<GenericArgument>,
     ) {
-        let replacement_path = GenericPath::new(generic.path.clone(), parameters);
+        let replacement_path = GenericPath::new(generic.path.clone(), arguments);
 
         debug_assert!(generic.generic_params.len() > 0);
         debug_assert!(!self.contains(&replacement_path));
@@ -48,9 +50,9 @@ impl Monomorphs {
         library: &Library,
         generic: &Enum,
         monomorph: Enum,
-        parameters: Vec<Type>,
+        arguments: Vec<GenericArgument>,
     ) {
-        let replacement_path = GenericPath::new(generic.path.clone(), parameters);
+        let replacement_path = GenericPath::new(generic.path.clone(), arguments);
 
         debug_assert!(generic.generic_params.len() > 0);
         debug_assert!(!self.contains(&replacement_path));
@@ -68,9 +70,9 @@ impl Monomorphs {
         library: &Library,
         generic: &Union,
         monomorph: Union,
-        parameters: Vec<Type>,
+        arguments: Vec<GenericArgument>,
     ) {
-        let replacement_path = GenericPath::new(generic.path.clone(), parameters);
+        let replacement_path = GenericPath::new(generic.path.clone(), arguments);
 
         debug_assert!(generic.generic_params.len() > 0);
         debug_assert!(!self.contains(&replacement_path));
@@ -87,9 +89,9 @@ impl Monomorphs {
         &mut self,
         generic: &OpaqueItem,
         monomorph: OpaqueItem,
-        parameters: Vec<Type>,
+        arguments: Vec<GenericArgument>,
     ) {
-        let replacement_path = GenericPath::new(generic.path.clone(), parameters);
+        let replacement_path = GenericPath::new(generic.path.clone(), arguments);
 
         debug_assert!(generic.generic_params.len() > 0);
         debug_assert!(!self.contains(&replacement_path));
@@ -104,9 +106,9 @@ impl Monomorphs {
         library: &Library,
         generic: &Typedef,
         monomorph: Typedef,
-        parameters: Vec<Type>,
+        arguments: Vec<GenericArgument>,
     ) {
-        let replacement_path = GenericPath::new(generic.path.clone(), parameters);
+        let replacement_path = GenericPath::new(generic.path.clone(), arguments);
 
         debug_assert!(generic.generic_params.len() > 0);
         debug_assert!(!self.contains(&replacement_path));

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -15,8 +15,8 @@ use crate::bindgen::cargo::{Cargo, PackageRef};
 use crate::bindgen::config::{Config, ParseConfig};
 use crate::bindgen::error::Error;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Constant, Documentation, Enum, Function, GenericParams, ItemMap,
-    OpaqueItem, Path, Static, Struct, Type, Typedef, Union,
+    AnnotationSet, Cfg, Constant, Documentation, Enum, Function, GenericParam, GenericParams,
+    ItemMap, OpaqueItem, Path, Static, Struct, Type, Typedef, Union,
 };
 use crate::bindgen::utilities::{SynAbiHelpers, SynAttributeHelpers, SynItemFnHelpers};
 
@@ -425,7 +425,10 @@ impl Parse {
     pub fn add_std_types(&mut self) {
         let mut add_opaque = |path: &str, generic_params: Vec<&str>| {
             let path = Path::new(path);
-            let generic_params: Vec<_> = generic_params.into_iter().map(Path::new).collect();
+            let generic_params: Vec<_> = generic_params
+                .into_iter()
+                .map(GenericParam::new_type_param)
+                .collect();
             self.opaque_items.try_insert(OpaqueItem::new(
                 path,
                 GenericParams(generic_params),

--- a/tests/expectations/const_generics.both.c
+++ b/tests/expectations/const_generics.both.c
@@ -1,0 +1,17 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define TITLE_SIZE 80
+
+typedef int8_t CArrayString_TITLE_SIZE[TITLE_SIZE];
+
+typedef int8_t CArrayString_40[40];
+
+typedef struct Book {
+  CArrayString_TITLE_SIZE title;
+  CArrayString_40 author;
+} Book;
+
+void root(struct Book *a);

--- a/tests/expectations/const_generics.both.compat.c
+++ b/tests/expectations/const_generics.both.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define TITLE_SIZE 80
+
+typedef int8_t CArrayString_TITLE_SIZE[TITLE_SIZE];
+
+typedef int8_t CArrayString_40[40];
+
+typedef struct Book {
+  CArrayString_TITLE_SIZE title;
+  CArrayString_40 author;
+} Book;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(struct Book *a);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/const_generics.c
+++ b/tests/expectations/const_generics.c
@@ -1,0 +1,17 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define TITLE_SIZE 80
+
+typedef int8_t CArrayString_TITLE_SIZE[TITLE_SIZE];
+
+typedef int8_t CArrayString_40[40];
+
+typedef struct {
+  CArrayString_TITLE_SIZE title;
+  CArrayString_40 author;
+} Book;
+
+void root(Book *a);

--- a/tests/expectations/const_generics.compat.c
+++ b/tests/expectations/const_generics.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define TITLE_SIZE 80
+
+typedef int8_t CArrayString_TITLE_SIZE[TITLE_SIZE];
+
+typedef int8_t CArrayString_40[40];
+
+typedef struct {
+  CArrayString_TITLE_SIZE title;
+  CArrayString_40 author;
+} Book;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(Book *a);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/const_generics.cpp
+++ b/tests/expectations/const_generics.cpp
@@ -1,0 +1,21 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+constexpr static const uintptr_t TITLE_SIZE = 80;
+
+template<uintptr_t CAP>
+using CArrayString = int8_t[CAP];
+
+struct Book {
+  CArrayString<TITLE_SIZE> title;
+  CArrayString<40> author;
+};
+
+extern "C" {
+
+void root(Book *a);
+
+} // extern "C"

--- a/tests/expectations/const_generics.pyx
+++ b/tests/expectations/const_generics.pyx
@@ -1,0 +1,19 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  const uintptr_t TITLE_SIZE # = 80
+
+  ctypedef int8_t CArrayString_TITLE_SIZE[TITLE_SIZE];
+
+  ctypedef int8_t CArrayString_40[40];
+
+  ctypedef struct Book:
+    CArrayString_TITLE_SIZE title;
+    CArrayString_40 author;
+
+  void root(Book *a);

--- a/tests/expectations/const_generics.tag.c
+++ b/tests/expectations/const_generics.tag.c
@@ -1,0 +1,17 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define TITLE_SIZE 80
+
+typedef int8_t CArrayString_TITLE_SIZE[TITLE_SIZE];
+
+typedef int8_t CArrayString_40[40];
+
+struct Book {
+  CArrayString_TITLE_SIZE title;
+  CArrayString_40 author;
+};
+
+void root(struct Book *a);

--- a/tests/expectations/const_generics.tag.compat.c
+++ b/tests/expectations/const_generics.tag.compat.c
@@ -1,0 +1,25 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define TITLE_SIZE 80
+
+typedef int8_t CArrayString_TITLE_SIZE[TITLE_SIZE];
+
+typedef int8_t CArrayString_40[40];
+
+struct Book {
+  CArrayString_TITLE_SIZE title;
+  CArrayString_40 author;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root(struct Book *a);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/const_generics.tag.pyx
+++ b/tests/expectations/const_generics.tag.pyx
@@ -1,0 +1,19 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  const uintptr_t TITLE_SIZE # = 80
+
+  ctypedef int8_t CArrayString_TITLE_SIZE[TITLE_SIZE];
+
+  ctypedef int8_t CArrayString_40[40];
+
+  cdef struct Book:
+    CArrayString_TITLE_SIZE title;
+    CArrayString_40 author;
+
+  void root(Book *a);

--- a/tests/expectations/const_generics_arrayvec.both.c
+++ b/tests/expectations/const_generics_arrayvec.both.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct ArrayVec_____u8__100 {
+  uint8_t *xs[100];
+  uint32_t len;
+} ArrayVec_____u8__100;
+
+int32_t push(struct ArrayVec_____u8__100 *v, uint8_t *elem);

--- a/tests/expectations/const_generics_arrayvec.both.compat.c
+++ b/tests/expectations/const_generics_arrayvec.both.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct ArrayVec_____u8__100 {
+  uint8_t *xs[100];
+  uint32_t len;
+} ArrayVec_____u8__100;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+int32_t push(struct ArrayVec_____u8__100 *v, uint8_t *elem);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/const_generics_arrayvec.c
+++ b/tests/expectations/const_generics_arrayvec.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  uint8_t *xs[100];
+  uint32_t len;
+} ArrayVec_____u8__100;
+
+int32_t push(ArrayVec_____u8__100 *v, uint8_t *elem);

--- a/tests/expectations/const_generics_arrayvec.compat.c
+++ b/tests/expectations/const_generics_arrayvec.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  uint8_t *xs[100];
+  uint32_t len;
+} ArrayVec_____u8__100;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+int32_t push(ArrayVec_____u8__100 *v, uint8_t *elem);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/const_generics_arrayvec.cpp
+++ b/tests/expectations/const_generics_arrayvec.cpp
@@ -1,0 +1,17 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+template<typename T, uintptr_t CAP>
+struct ArrayVec {
+  T xs[CAP];
+  uint32_t len;
+};
+
+extern "C" {
+
+int32_t push(ArrayVec<uint8_t*, 100> *v, uint8_t *elem);
+
+} // extern "C"

--- a/tests/expectations/const_generics_arrayvec.pyx
+++ b/tests/expectations/const_generics_arrayvec.pyx
@@ -1,0 +1,13 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  ctypedef struct ArrayVec_____u8__100:
+    uint8_t *xs[100];
+    uint32_t len;
+
+  int32_t push(ArrayVec_____u8__100 *v, uint8_t *elem);

--- a/tests/expectations/const_generics_arrayvec.tag.c
+++ b/tests/expectations/const_generics_arrayvec.tag.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct ArrayVec_____u8__100 {
+  uint8_t *xs[100];
+  uint32_t len;
+};
+
+int32_t push(struct ArrayVec_____u8__100 *v, uint8_t *elem);

--- a/tests/expectations/const_generics_arrayvec.tag.compat.c
+++ b/tests/expectations/const_generics_arrayvec.tag.compat.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct ArrayVec_____u8__100 {
+  uint8_t *xs[100];
+  uint32_t len;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+int32_t push(struct ArrayVec_____u8__100 *v, uint8_t *elem);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/const_generics_arrayvec.tag.pyx
+++ b/tests/expectations/const_generics_arrayvec.tag.pyx
@@ -1,0 +1,13 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  cdef struct ArrayVec_____u8__100:
+    uint8_t *xs[100];
+    uint32_t len;
+
+  int32_t push(ArrayVec_____u8__100 *v, uint8_t *elem);

--- a/tests/rust/const_generics.rs
+++ b/tests/rust/const_generics.rs
@@ -1,0 +1,15 @@
+#[repr(transparent)]
+pub struct CArrayString<const CAP: usize> {
+    pub chars: [i8; CAP],
+}
+
+pub const TITLE_SIZE: usize = 80;
+
+#[repr(C)]
+pub struct Book {
+    pub title: CArrayString<TITLE_SIZE>,
+    pub author: CArrayString<40>,
+}
+
+#[no_mangle]
+pub extern "C" fn root(a: *mut Book) {}

--- a/tests/rust/const_generics_arrayvec.rs
+++ b/tests/rust/const_generics_arrayvec.rs
@@ -1,0 +1,17 @@
+#[repr(C)]
+pub struct ArrayVec<T, const CAP: usize> {
+    // the `len` first elements of the array are initialized
+    xs: [T; CAP],
+    len: u32,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn push(v: *mut ArrayVec<*mut u8, 100>, elem: *mut u8) -> i32 {
+    if (*v).len < 100 {
+        (*v).xs[(*v).len] = elem;
+        (*v).len += 1;
+        1
+    } else {
+        0
+    }
+}


### PR DESCRIPTION
A rough implementation of const generics.

Well, this codebase is a delight to work with. I thought of this as a tricky feature, but it was mostly obvious what to do.

It helped that there was already a place where values could appear in types: array lengths. This reuses `ArrayLength`. (I can rename that to `ConstExpr`, if you like.)

The main iffy thing with this PR is that it monomorphizes `ArrayString<20>` and `ArrayString<N>` to two different C types, `ArrayString_20` and `ArrayString_N`, even if `N` is 20. To fix that, we'd have to fully evaluate constant expressions, which requires implementing Rust name lookups. I might need a little help if you want to go that route...