### PR TITLE
Fix specialization of `SomeType<N>` when `N` is a const parameter.

### DIFF
--- a/tests/expectations/const_generics_thru.both.c
+++ b/tests/expectations/const_generics_thru.both.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Inner_1 {
+  uint8_t bytes[1];
+} Inner_1;
+
+typedef struct Outer_1 {
+  struct Inner_1 inner;
+} Outer_1;
+
+typedef struct Inner_2 {
+  uint8_t bytes[2];
+} Inner_2;
+
+typedef struct Outer_2 {
+  struct Inner_2 inner;
+} Outer_2;
+
+struct Outer_1 one(void);
+
+struct Outer_2 two(void);

--- a/tests/expectations/const_generics_thru.both.compat.c
+++ b/tests/expectations/const_generics_thru.both.compat.c
@@ -1,0 +1,32 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Inner_1 {
+  uint8_t bytes[1];
+} Inner_1;
+
+typedef struct Outer_1 {
+  struct Inner_1 inner;
+} Outer_1;
+
+typedef struct Inner_2 {
+  uint8_t bytes[2];
+} Inner_2;
+
+typedef struct Outer_2 {
+  struct Inner_2 inner;
+} Outer_2;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+struct Outer_1 one(void);
+
+struct Outer_2 two(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/const_generics_thru.c
+++ b/tests/expectations/const_generics_thru.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  uint8_t bytes[1];
+} Inner_1;
+
+typedef struct {
+  Inner_1 inner;
+} Outer_1;
+
+typedef struct {
+  uint8_t bytes[2];
+} Inner_2;
+
+typedef struct {
+  Inner_2 inner;
+} Outer_2;
+
+Outer_1 one(void);
+
+Outer_2 two(void);

--- a/tests/expectations/const_generics_thru.compat.c
+++ b/tests/expectations/const_generics_thru.compat.c
@@ -1,0 +1,32 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  uint8_t bytes[1];
+} Inner_1;
+
+typedef struct {
+  Inner_1 inner;
+} Outer_1;
+
+typedef struct {
+  uint8_t bytes[2];
+} Inner_2;
+
+typedef struct {
+  Inner_2 inner;
+} Outer_2;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+Outer_1 one(void);
+
+Outer_2 two(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/const_generics_thru.cpp
+++ b/tests/expectations/const_generics_thru.cpp
@@ -1,0 +1,23 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+template<uintptr_t N>
+struct Inner {
+  uint8_t bytes[N];
+};
+
+template<uintptr_t N>
+struct Outer {
+  Inner<N> inner;
+};
+
+extern "C" {
+
+Outer<1> one();
+
+Outer<2> two();
+
+} // extern "C"

--- a/tests/expectations/const_generics_thru.pyx
+++ b/tests/expectations/const_generics_thru.pyx
@@ -1,0 +1,23 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  ctypedef struct Inner_1:
+    uint8_t bytes[1];
+
+  ctypedef struct Outer_1:
+    Inner_1 inner;
+
+  ctypedef struct Inner_2:
+    uint8_t bytes[2];
+
+  ctypedef struct Outer_2:
+    Inner_2 inner;
+
+  Outer_1 one();
+
+  Outer_2 two();

--- a/tests/expectations/const_generics_thru.tag.c
+++ b/tests/expectations/const_generics_thru.tag.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Inner_1 {
+  uint8_t bytes[1];
+};
+
+struct Outer_1 {
+  struct Inner_1 inner;
+};
+
+struct Inner_2 {
+  uint8_t bytes[2];
+};
+
+struct Outer_2 {
+  struct Inner_2 inner;
+};
+
+struct Outer_1 one(void);
+
+struct Outer_2 two(void);

--- a/tests/expectations/const_generics_thru.tag.compat.c
+++ b/tests/expectations/const_generics_thru.tag.compat.c
@@ -1,0 +1,32 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Inner_1 {
+  uint8_t bytes[1];
+};
+
+struct Outer_1 {
+  struct Inner_1 inner;
+};
+
+struct Inner_2 {
+  uint8_t bytes[2];
+};
+
+struct Outer_2 {
+  struct Inner_2 inner;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+struct Outer_1 one(void);
+
+struct Outer_2 two(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/const_generics_thru.tag.pyx
+++ b/tests/expectations/const_generics_thru.tag.pyx
@@ -1,0 +1,23 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  cdef struct Inner_1:
+    uint8_t bytes[1];
+
+  cdef struct Outer_1:
+    Inner_1 inner;
+
+  cdef struct Inner_2:
+    uint8_t bytes[2];
+
+  cdef struct Outer_2:
+    Inner_2 inner;
+
+  Outer_1 one();
+
+  Outer_2 two();

--- a/tests/rust/const_generics_thru.rs
+++ b/tests/rust/const_generics_thru.rs
@@ -1,0 +1,22 @@
+// Propagating const arguments through generics that use generics.
+
+#[repr(C)]
+pub struct Inner<const N: usize> {
+    pub bytes: [u8; N],
+}
+
+#[repr(C)]
+pub struct Outer<const N: usize> {
+    pub inner: Inner<N>, // don't declare two different structs named `Inner_N`
+}
+
+#[no_mangle]
+pub extern "C" fn one() -> Outer<1> {
+    Outer { inner: Inner { bytes: [0] } }
+}
+
+#[no_mangle]
+pub extern "C" fn two() -> Outer<2> {
+    Outer { inner: Inner { bytes: [0, 0] } }
+}
+


### PR DESCRIPTION
See #761. The test case that triggers the bug is like this:

```rust
#[repr(C)]
pub struct Inner<const N: usize> {
    pub bytes: [u8; N],
}

#[repr(C)]
pub struct Outer<const N: usize> {
    pub inner: Inner<N>, // BUG: declares two different structs named `Inner_N`
}

...code that uses Outer<1> and Outer<2>...
```

When monomorphizing `Outer<1>`, specializing the type `Inner<N>` should result in `Inner<1>`, but it produced `Inner<N>` instead. This happens because `N` was initially parsed as a type, not a constant, so we were thoughtlessly calling `Type::specialize` on it. This can't possibly work; the desired answer `1` is not a type.

The fix is to explicitly handle this special case where the identifier was initially parsed as a type but it's a const.