### PR TITLE
fix/docs_typo

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -514,7 +514,7 @@ documentation_style = "doxy"
 # * "full": The full documentation.
 #
 # default: "full"
-documentation_style = "short"
+documentation_length = "short"
 
 
 


### PR DESCRIPTION
Tiny fix, the documented example has the `documentation_style` key twice instead of
`documentation_length`.
