### PR TITLE
Better line breaking in function pointer types

### DIFF
--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -4,11 +4,11 @@
 
 use std::io::Write;
 
+use crate::bindgen::config::Layout;
 use crate::bindgen::declarationtyperesolver::DeclarationType;
 use crate::bindgen::ir::{ConstExpr, Function, GenericArgument, Type};
 use crate::bindgen::writer::{ListType, SourceWriter};
 use crate::bindgen::{Config, Language};
-use crate::bindgen::config::Layout;
 
 // This code is for translating Rust types into C declarations.
 // See Section 6.7, Declarations, in the C standard for background.
@@ -289,7 +289,11 @@ impl CDecl {
                         out.write("void");
                     }
 
-                    fn write_vertical<F:Write>(out: &mut SourceWriter<F>, config: &Config, args: &Vec<(Option<String>, CDecl)>) {
+                    fn write_vertical<F: Write>(
+                        out: &mut SourceWriter<F>,
+                        config: &Config,
+                        args: &Vec<(Option<String>, CDecl)>,
+                    ) {
                         let align_length = out.line_length_for_align();
                         out.push_set_spaces(align_length);
                         for (i, &(ref arg_ident, ref arg_ty)) in args.iter().enumerate() {
@@ -306,7 +310,11 @@ impl CDecl {
                         out.pop_tab();
                     }
 
-                    fn write_horizontal<F:Write>(out: &mut SourceWriter<F>, config: &Config, args: &Vec<(Option<String>, CDecl)>) {
+                    fn write_horizontal<F: Write>(
+                        out: &mut SourceWriter<F>,
+                        config: &Config,
+                        args: &Vec<(Option<String>, CDecl)>,
+                    ) {
                         for (i, &(ref arg_ident, ref arg_ty)) in args.iter().enumerate() {
                             if i != 0 {
                                 out.write(", ");
@@ -319,16 +327,18 @@ impl CDecl {
                         }
                     }
 
-
                     match layout {
                         Layout::Vertical => write_vertical(out, config, args),
                         Layout::Horizontal => write_horizontal(out, config, args),
                         Layout::Auto => {
-                           if out.line_length_for_align() + out.measure(|out| write_horizontal(out, config,args)) > config.line_length {
-                               write_vertical(out, config, args)
-                           } else {
-                               write_horizontal(out, config, args)
-                           }
+                            if out.line_length_for_align()
+                                + out.measure(|out| write_horizontal(out, config, args))
+                                > config.line_length
+                            {
+                                write_vertical(out, config, args)
+                            } else {
+                                write_horizontal(out, config, args)
+                            }
                         }
                     }
                     out.write(")");

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -242,7 +242,7 @@ impl Source for Function {
                     }
                 }
             }
-            cdecl::write_func(out, func, false, config);
+            cdecl::write_func(out, func, Layout::Horizontal, config);
 
             if !func.extern_decl {
                 if let Some(ref postfix) = postfix {
@@ -285,7 +285,7 @@ impl Source for Function {
                     }
                 }
             }
-            cdecl::write_func(out, func, true, config);
+            cdecl::write_func(out, func, Layout::Vertical, config);
             if !func.extern_decl {
                 if let Some(ref postfix) = postfix {
                     out.new_line();

--- a/tests/expectations/fns.pyx
+++ b/tests/expectations/fns.pyx
@@ -11,7 +11,9 @@ cdef extern from *:
     void (*anonymousArg)(int32_t);
     int32_t (*returnsNumber)();
     int8_t (*namedArgs)(int32_t first, int16_t snd);
-    int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
+    int8_t (*namedArgsWildcards)(int32_t _,
+                                 int16_t named,
+                                 int64_t _1);
 
   void root(Fns _fns);
 

--- a/tests/expectations/fns.tag.pyx
+++ b/tests/expectations/fns.tag.pyx
@@ -11,7 +11,9 @@ cdef extern from *:
     void (*anonymousArg)(int32_t);
     int32_t (*returnsNumber)();
     int8_t (*namedArgs)(int32_t first, int16_t snd);
-    int8_t (*namedArgsWildcards)(int32_t _, int16_t named, int64_t _1);
+    int8_t (*namedArgsWildcards)(int32_t _,
+                                 int16_t named,
+                                 int64_t _1);
 
   void root(Fns _fns);
 

--- a/tests/expectations/function_pointer.c
+++ b/tests/expectations/function_pointer.c
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef void (*MyCallback)(uintptr_t a, uintptr_t b);
+
+typedef void (*MyOtherCallback)(uintptr_t a,
+                                uintptr_t lot,
+                                uintptr_t of,
+                                uintptr_t args);
+
+void my_function(MyCallback a, MyOtherCallback b);

--- a/tests/expectations/function_pointer.compat.c
+++ b/tests/expectations/function_pointer.compat.c
@@ -1,0 +1,21 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef void (*MyCallback)(uintptr_t a, uintptr_t b);
+
+typedef void (*MyOtherCallback)(uintptr_t a,
+                                uintptr_t lot,
+                                uintptr_t of,
+                                uintptr_t args);
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void my_function(MyCallback a, MyOtherCallback b);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/function_pointer.cpp
+++ b/tests/expectations/function_pointer.cpp
@@ -1,0 +1,18 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+using MyCallback = void(*)(uintptr_t a, uintptr_t b);
+
+using MyOtherCallback = void(*)(uintptr_t a,
+                                uintptr_t lot,
+                                uintptr_t of,
+                                uintptr_t args);
+
+extern "C" {
+
+void my_function(MyCallback a, MyOtherCallback b);
+
+} // extern "C"

--- a/tests/expectations/function_pointer.pyx
+++ b/tests/expectations/function_pointer.pyx
@@ -1,0 +1,16 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  ctypedef void (*MyCallback)(uintptr_t a, uintptr_t b);
+
+  ctypedef void (*MyOtherCallback)(uintptr_t a,
+                                   uintptr_t lot,
+                                   uintptr_t of,
+                                   uintptr_t args);
+
+  void my_function(MyCallback a, MyOtherCallback b);

--- a/tests/rust/function_pointer.rs
+++ b/tests/rust/function_pointer.rs
@@ -1,0 +1,7 @@
+pub type MyCallback = Option<unsafe extern "C" fn(a: usize, b: usize)>;
+
+pub type MyOtherCallback =
+    Option<unsafe extern "C" fn(a: usize, lot: usize, of: usize, args: usize)>;
+
+#[no_mangle]
+pub extern "C" fn my_function(a: MyCallback, b: MyOtherCallback) {}


### PR DESCRIPTION
The current implementation never goes to a new line when writing a function pointer type, this can lead to long, difficult to read lines.

The goal of this change is to make that a bit more sensible.

Here is a rust code example

```
   1   │ pub type MyCallback = Option<unsafe extern "C" fn(a: usize, b: usize)>;
   2   │
   3   │ pub type MyOtherCallback =
   4   │     Option<unsafe extern "C" fn(a: usize, lot: usize, of: usize, args: usize)>;
   5   │
   6   │ #[no_mangle]
   7   │ pub extern "C" fn my_function(a: MyCallback, b: MyOtherCallback) {}
```

right now when generating the corresponding C header we get

```
   1   │ #include <stdarg.h>
   2   │ #include <stdbool.h>
   3   │ #include <stdint.h>
   4   │ #include <stdlib.h>
   5   │
   6   │ typedef void (*MyCallback)(uintptr_t a, uintptr_t b);
   7   │
   8   │ typedef void (*MyOtherCallback)(uintptr_t a, uintptr_t lot, uintptr_t of, uintptr_t args);
   9   │
  10   │ void my_function(MyCallback a, MyOtherCallback b);
```

line 8 here is already quite long and will be even longer if we add new args to `MyOtherCallback`

With the changes in this commit, we now get

```
   1   │ #include <stdarg.h>
   2   │ #include <stdbool.h>
   3   │ #include <stdint.h>
   4   │ #include <stdlib.h>
   5   │
   6   │ typedef void (*MyCallback)(uintptr_t a, uintptr_t b);
   7   │
   8   │ typedef void (*MyOtherCallback)(uintptr_t a,
   9   │                                 uintptr_t lot,
  10   │                                 uintptr_t of,
  11   │                                 uintptr_t args);
  12   │
  13   │ void my_function(MyCallback a, MyOtherCallback b);
```

which is way better and more scalable if new args are added to `MyOtherCallback`

The behavior is configurable using the already existing `fn.args` configuration parameter. In this case setting it to `Horizontal` gives back the same .h as previously and setting it to `Vertical` makes the generator go to a new line even for the shorter `MyCallback` declaration:

```
   1   │ #include <stdarg.h>
   2   │ #include <stdbool.h>
   3   │ #include <stdint.h>
   4   │ #include <stdlib.h>
   5   │
   6   │ typedef void (*MyCallback)(uintptr_t a,
   7   │                            uintptr_t b);
   8   │
   9   │ typedef void (*MyOtherCallback)(uintptr_t a,
  10   │                                 uintptr_t lot,
  11   │                                 uintptr_t of,
  12   │                                 uintptr_t args);
  13   │
  14   │ void my_function(MyCallback a,
  15   │                  MyOtherCallback b);
```