### PR TITLE
Add with_cpp_compat to the builder

### DIFF
--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -150,6 +150,12 @@ impl Builder {
     }
 
     #[allow(unused)]
+    pub fn with_cpp_compat(mut self, cpp_compat: bool) -> Builder {
+        self.config.cpp_compat = cpp_compat;
+        self
+    }
+
+    #[allow(unused)]
     pub fn with_style(mut self, style: Style) -> Builder {
         self.config.style = style;
         self


### PR DESCRIPTION
I noticed recently that the `cpp_compat` flag isn't available when using the builder, so I figured I'd open a PR.