### PR TITLE
Move expand infinite recursion fix

### DIFF
--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -345,6 +345,24 @@ impl Builder {
     }
 
     pub fn generate(self) -> Result<Bindings, Error> {
+        // If macro expansion is enabled, then cbindgen will attempt to build the crate
+        // and will run its build script which may run cbindgen again. That second run may start
+        // infinite recursion, or overwrite previously written files with bindings.
+        // So if we are called recursively, we are skipping the whole generation
+        // and produce "noop" bindings that won't be able to overwrite anything.
+        if std::env::var("_CBINDGEN_IS_RUNNING").is_ok() {
+            return Ok(Bindings::new(
+                self.config,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                true,
+            ));
+        }
+
         let mut result = Parse::new();
 
         if self.std_types {

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -54,24 +54,6 @@ impl Library {
     }
 
     pub fn generate(mut self) -> Result<Bindings, Error> {
-        // If macro expansion is enabled, then cbindgen will attempt to build the crate
-        // and will run its build script which may run cbindgen again. That second run may start
-        // infinite recursion, or overwrite previously written files with bindings.
-        // So if we are called recursively, we are skipping the whole generation
-        // and produce "noop" bindings that won't be able to overwrite anything.
-        if std::env::var("_CBINDGEN_IS_RUNNING").is_ok() {
-            return Ok(Bindings::new(
-                self.config,
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                true,
-            ));
-        }
-
         self.transfer_annotations();
         self.simplify_standard_types();
 


### PR DESCRIPTION
The original fix was supposed to avoid infinitely expanding the macros when cbindgen was generated in `build.rs` with the `parse.expand` option.

However, it was not completely fixing the issue: a call to `parse_lib` which triggers the infinite recursion occurs before the old check was actually done (in the parent `generate` method).

Here, the check is simply done earlier to completely avoid the infinite loop.

I believe this fix would resolve #758.