### PR TITLE
Fix MSRV documentation and clippy warnings from 1.40 -> 1.54

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,2 @@
 # Specify the minimum supported Rust version
-msrv = "1.40.0"
+msrv = "1.54.0"

--- a/.github/workflows/cbindgen.yml
+++ b/.github/workflows/cbindgen.yml
@@ -17,21 +17,15 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt
+        components: "clippy, rustfmt"
 
     - name: Run rustfmt
       uses: actions-rs/cargo@v1
       with:
         command: fmt
         args: -- --check
-
-    - name: Install clippy
-      uses: dtolnay/rust-toolchain@clippy
 
     - name: Run clippy
       run: |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `cbindgen` &emsp; [![Build Status]][actions] [![Latest Version]][crates.io] [![Api Rustdoc]][rustdoc] [![Rust](https://img.shields.io/badge/rust-1.32%2B-blue.svg?maxAge=3600)](https://github.com/eqrion/cbindgen)
+# `cbindgen` &emsp; [![Build Status]][actions] [![Latest Version]][crates.io] [![Api Rustdoc]][rustdoc] [![Rust](https://img.shields.io/badge/rust-1.54%2B-blue.svg?maxAge=3600)](https://github.com/eqrion/cbindgen)
 
 [Build Status]: https://github.com/eqrion/cbindgen/workflows/cbindgen/badge.svg
 [actions]: https://github.com/eqrion/cbindgen/actions

--- a/src/bindgen/cargo/cargo_metadata.rs
+++ b/src/bindgen/cargo/cargo_metadata.rs
@@ -202,14 +202,9 @@ fn discover_target(manifest_path: &Path) -> Option<String> {
     };
 
     let field = "host: ";
-    rustc_output.lines().find_map(|l| {
-        // XXX l.strip_prefix(field) re-implemented to preserve MSRV
-        if l.starts_with(field) {
-            Some(l[field.len()..].into())
-        } else {
-            None
-        }
-    })
+    rustc_output
+        .lines()
+        .find_map(|l| l.strip_prefix(field).map(|stripped| stripped.to_string()))
 }
 
 /// The main entry point to obtaining metadata

--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -296,7 +296,7 @@ impl CDecl {
                     ) {
                         let align_length = out.line_length_for_align();
                         out.push_set_spaces(align_length);
-                        for (i, &(ref arg_ident, ref arg_ty)) in args.iter().enumerate() {
+                        for (i, (arg_ident, arg_ty)) in args.iter().enumerate() {
                             if i != 0 {
                                 out.write(",");
                                 out.new_line();
@@ -315,7 +315,7 @@ impl CDecl {
                         config: &Config,
                         args: &[(Option<String>, CDecl)],
                     ) {
-                        for (i, &(ref arg_ident, ref arg_ty)) in args.iter().enumerate() {
+                        for (i, (arg_ident, arg_ty)) in args.iter().enumerate() {
                             if i != 0 {
                                 out.write(", ");
                             }

--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -30,10 +30,7 @@ enum CDeclarator {
 
 impl CDeclarator {
     fn is_ptr(&self) -> bool {
-        match self {
-            CDeclarator::Ptr { .. } | CDeclarator::Func { .. } => true,
-            _ => false,
-        }
+        matches!(self, CDeclarator::Ptr { .. } | CDeclarator::Func { .. })
     }
 }
 

--- a/src/bindgen/dependencies.rs
+++ b/src/bindgen/dependencies.rs
@@ -26,17 +26,15 @@ impl Dependencies {
         // Sort untagged enums and opaque structs into their own layers because they don't
         // depend on each other or anything else.
         let ordering = |a: &ItemContainer, b: &ItemContainer| match (a, b) {
-            (&ItemContainer::Enum(ref x), &ItemContainer::Enum(ref y))
+            (ItemContainer::Enum(x), ItemContainer::Enum(y))
                 if x.tag.is_none() && y.tag.is_none() =>
             {
                 x.path.cmp(&y.path)
             }
-            (&ItemContainer::Enum(ref x), _) if x.tag.is_none() => Ordering::Less,
-            (_, &ItemContainer::Enum(ref x)) if x.tag.is_none() => Ordering::Greater,
+            (ItemContainer::Enum(x), _) if x.tag.is_none() => Ordering::Less,
+            (_, ItemContainer::Enum(x)) if x.tag.is_none() => Ordering::Greater,
 
-            (&ItemContainer::OpaqueItem(ref x), &ItemContainer::OpaqueItem(ref y)) => {
-                x.path.cmp(&y.path)
-            }
+            (ItemContainer::OpaqueItem(x), ItemContainer::OpaqueItem(y)) => x.path.cmp(&y.path),
             (&ItemContainer::OpaqueItem(_), _) => Ordering::Less,
             (_, &ItemContainer::OpaqueItem(_)) => Ordering::Greater,
 

--- a/src/bindgen/ir/annotation.rs
+++ b/src/bindgen/ir/annotation.rs
@@ -130,19 +130,19 @@ impl AnnotationSet {
 
     pub fn list(&self, name: &str) -> Option<Vec<String>> {
         match self.annotations.get(name) {
-            Some(&AnnotationValue::List(ref x)) => Some(x.clone()),
+            Some(AnnotationValue::List(x)) => Some(x.clone()),
             _ => None,
         }
     }
     pub fn atom(&self, name: &str) -> Option<Option<String>> {
         match self.annotations.get(name) {
-            Some(&AnnotationValue::Atom(ref x)) => Some(x.clone()),
+            Some(AnnotationValue::Atom(x)) => Some(x.clone()),
             _ => None,
         }
     }
     pub fn bool(&self, name: &str) -> Option<bool> {
         match self.annotations.get(name) {
-            Some(&AnnotationValue::Bool(ref x)) => Some(*x),
+            Some(AnnotationValue::Bool(x)) => Some(*x),
             _ => None,
         }
     }
@@ -152,7 +152,7 @@ impl AnnotationSet {
         T: Default + FromStr,
     {
         match self.annotations.get(name) {
-            Some(&AnnotationValue::Atom(ref x)) => Some(
+            Some(AnnotationValue::Atom(x)) => Some(
                 x.as_ref()
                     .map_or(T::default(), |y| y.parse::<T>().ok().unwrap()),
             ),

--- a/src/bindgen/ir/item.rs
+++ b/src/bindgen/ir/item.rs
@@ -219,12 +219,12 @@ impl<T: Item + Clone> ItemMap<T> {
         F: FnMut(&T),
     {
         match self.data.get(path) {
-            Some(&ItemValue::Cfg(ref items)) => {
+            Some(ItemValue::Cfg(items)) => {
                 for item in items {
                     callback(item);
                 }
             }
-            Some(&ItemValue::Single(ref item)) => {
+            Some(ItemValue::Single(item)) => {
                 callback(item);
             }
             None => {}

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -300,10 +300,7 @@ impl PrimitiveType {
     }
 
     fn can_cmp_order(&self) -> bool {
-        match *self {
-            PrimitiveType::Bool => false,
-            _ => true,
-        }
+        !matches!(*self, PrimitiveType::Bool)
     }
 
     fn can_cmp_eq(&self) -> bool {
@@ -551,10 +548,7 @@ impl Type {
     pub fn is_primitive_or_ptr_primitive(&self) -> bool {
         match *self {
             Type::Primitive(..) => true,
-            Type::Ptr { ref ty, .. } => match ty.as_ref() {
-                Type::Primitive(..) => true,
-                _ => false,
-            },
+            Type::Ptr { ref ty, .. } => matches!(ty.as_ref(), Type::Primitive(..)),
             _ => false,
         }
     }

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -515,10 +515,10 @@ impl Parse {
                     self.load_syn_ty(crate_name, mod_cfg, item);
                 }
                 syn::Item::Impl(ref item_impl) => {
-                    let has_assoc_const = item_impl.items.iter().any(|item| match item {
-                        syn::ImplItem::Const(_) => true,
-                        _ => false,
-                    });
+                    let has_assoc_const = item_impl
+                        .items
+                        .iter()
+                        .any(|item| matches!(item, syn::ImplItem::Const(_)));
                     if has_assoc_const {
                         impls_with_assoc_consts.push(item_impl);
                     }

--- a/src/bindgen/writer.rs
+++ b/src/bindgen/writer.rs
@@ -207,10 +207,10 @@ impl<'a, F: Write> SourceWriter<'a, F> {
         InnerWriter(self).write_fmt(fmt).unwrap();
     }
 
-    pub fn write_horizontal_source_list<'b, S: Source>(
+    pub fn write_horizontal_source_list<S: Source>(
         &mut self,
         items: &[S],
-        list_type: ListType<'b>,
+        list_type: ListType<'_>,
     ) {
         for (i, item) in items.iter().enumerate() {
             item.write(&self.bindings.config, self);
@@ -228,11 +228,7 @@ impl<'a, F: Write> SourceWriter<'a, F> {
         }
     }
 
-    pub fn write_vertical_source_list<'b, S: Source>(
-        &mut self,
-        items: &[S],
-        list_type: ListType<'b>,
-    ) {
+    pub fn write_vertical_source_list<S: Source>(&mut self, items: &[S], list_type: ListType<'_>) {
         let align_length = self.line_length_for_align();
         self.push_set_spaces(align_length);
         for (i, item) in items.iter().enumerate() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,7 @@ fn main() {
                 .long("lang")
                 .value_name("LANGUAGE")
                 .help("Specify the language to output bindings in")
-                .possible_values(&["c++", "C++", "c", "C", "cython", "Cython"]),
+                .possible_values(["c++", "C++", "c", "C", "cython", "Cython"]),
         )
         .arg(
             Arg::new("cpp-compat")
@@ -176,7 +176,7 @@ fn main() {
                 .long("style")
                 .value_name("STYLE")
                 .help("Specify the declaration style to use for bindings")
-                .possible_values(&["Both", "both", "Tag", "tag", "Type", "type"]),
+                .possible_values(["Both", "both", "Tag", "tag", "Type", "type"]),
         )
         .arg(
             Arg::new("d")
@@ -253,7 +253,7 @@ fn main() {
                     "Specify the profile to use when expanding macros. \
                      Has no effect otherwise."
                 )
-                .possible_values(&["Debug", "debug", "Release", "release"]),
+                .possible_values(["Debug", "debug", "Release", "release"]),
         )
         .arg(
             Arg::new("quiet")

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -23,7 +23,7 @@ fn run_cbindgen(
     style: Option<Style>,
 ) -> Vec<u8> {
     let program = Path::new(cbindgen_path);
-    let mut command = Command::new(&program);
+    let mut command = Command::new(program);
     match language {
         Language::Cxx => {}
         Language::C => {


### PR DESCRIPTION
The MSRV is currently Rust 1.54.
- Update the badge in the Readme specifying the MSRV
- Update the .clippy.toml to the current MSRV
- Fix clippy warnings after updating the clippy.toml

The individual steps of fixing the warnings are in seperate commits for easier review. Should probably be squashed before merging.