### PR TITLE
CI: Fix warnings in Github actions

### DIFF
--- a/.github/workflows/cbindgen.yml
+++ b/.github/workflows/cbindgen.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install stable
       uses: dtolnay/rust-toolchain@stable
@@ -22,43 +22,35 @@ jobs:
         components: "clippy, rustfmt"
 
     - name: Run rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: -- --check
+      run: |
+        cargo fmt --check
 
     - name: Run clippy
       run: |
         cargo clippy --workspace -- -D warnings
 
     - name: Install minimum supported Rust version
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: 1.54.0
+      id: msrv
+      uses: dtolnay/rust-toolchain@1.54
 
     - name: Build with minimum supported Rust version
       run: |
-        cargo +1.54.0 test nonexistent-test --verbose
+        cargo +${{steps.msrv.outputs.name}} test nonexistent-test --verbose
 
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
+    - name: Install stable Rust
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Install Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.8.*'
+        python-version: '3.8'
 
     - name: Install Cython
       run: |
@@ -73,12 +65,6 @@ jobs:
       run: |
         cargo build --verbose --no-default-features
 
-    - name: Test
-      env:
-        CBINDGEN_TEST_VERIFY: 1
-      run: |
-        cargo test --verbose
-
     - name: Test package
       env:
         CBINDGEN_TEST_VERIFY: 1
@@ -86,7 +72,16 @@ jobs:
         cargo package --verbose
         (cd target/package/cbindgen-$(cargo run -- --version | cut -d ' ' -f 2) && cargo test --verbose)
 
+    - name: Install nightly Rust
+      uses: dtolnay/rust-toolchain@nightly
+
+    - name: Test
+      env:
+        CBINDGEN_TEST_VERIFY: 1
+      run: |
+        cargo +nightly test --verbose
+
     - name: Test minimal-versions
       run: |
-        cargo update -Zminimal-versions
-        cargo test
+        cargo +nightly update -Zminimal-versions
+        cargo +nightly test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,14 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Build cbindgen
       run: |


### PR DESCRIPTION
Fixes the following warning:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/cargo@v1, actions-rs/toolchain@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

You can see the warnings at the bottom of example this job: https://github.com/eqrion/cbindgen/actions/runs/4366109547

Steps:
- upgrade checkout to v3
- Replace the actions-rs/cargo action, by simply calling cargo from the commandline. I don't see why one would want to involve a node.js action there in the first place.
- Replace the actions-rs/toolchain with dtolnays version, which uses the shell instead of node.js