### PR TITLE
re-export bindgen::Library for proc macros

### DIFF
--- a/src/bindgen/mod.rs
+++ b/src/bindgen/mod.rs
@@ -67,4 +67,5 @@ pub use self::builder::Builder;
 pub use self::config::Profile; // disambiguate with cargo::Profile
 pub use self::config::*;
 pub use self::error::Error;
+#[cfg(feature = "unstable_ir")]
 pub use self::library::Library;


### PR DESCRIPTION
I'm writing my own proc macro which wraps around `cbindgen`, and I'd like to have access to `Library` to generate bindings without writing to a file and pointing `cbindgen` to that file.

Thanks