### PR TITLE
Fix doc attribute parsing to properly handle block comments

### DIFF
--- a/tests/expectations-symbols/documentation_block.c.sym
+++ b/tests/expectations-symbols/documentation_block.c.sym
@@ -1,0 +1,5 @@
+{
+root;
+block_function;
+FOO;
+};

--- a/tests/expectations/documentation_attr.c
+++ b/tests/expectations/documentation_attr.c
@@ -8,13 +8,14 @@
  *like this one with a new line character at its end
  *and this one as well. So they are in the same paragraph
  *
- *Line ends with one new line should not break
+ *We treat empty doc comments as empty lines, so they break to the next paragraph.
  *
- *Line ends with two spaces and a new line
- *should break to next line
+ * Newlines are preserved with leading spaces added
+ * to prettify and avoid misinterpreting leading symbols.
+ *like headings and lists.
  *
- *Line ends with two new lines
+ * Line ends with two new lines
  *
- *Should break to next paragraph
+ * Should break to next paragraph
  */
 void root(void);

--- a/tests/expectations/documentation_attr.compat.c
+++ b/tests/expectations/documentation_attr.compat.c
@@ -12,14 +12,15 @@ extern "C" {
  *like this one with a new line character at its end
  *and this one as well. So they are in the same paragraph
  *
- *Line ends with one new line should not break
+ *We treat empty doc comments as empty lines, so they break to the next paragraph.
  *
- *Line ends with two spaces and a new line
- *should break to next line
+ * Newlines are preserved with leading spaces added
+ * to prettify and avoid misinterpreting leading symbols.
+ *like headings and lists.
  *
- *Line ends with two new lines
+ * Line ends with two new lines
  *
- *Should break to next paragraph
+ * Should break to next paragraph
  */
 void root(void);
 

--- a/tests/expectations/documentation_attr.cpp
+++ b/tests/expectations/documentation_attr.cpp
@@ -10,14 +10,15 @@ extern "C" {
 ///like this one with a new line character at its end
 ///and this one as well. So they are in the same paragraph
 ///
-///Line ends with one new line should not break
+///We treat empty doc comments as empty lines, so they break to the next paragraph.
 ///
-///Line ends with two spaces and a new line
-///should break to next line
+/// Newlines are preserved with leading spaces added
+/// to prettify and avoid misinterpreting leading symbols.
+///like headings and lists.
 ///
-///Line ends with two new lines
+/// Line ends with two new lines
 ///
-///Should break to next paragraph
+/// Should break to next paragraph
 void root();
 
 }  // extern "C"

--- a/tests/expectations/documentation_attr.pyx
+++ b/tests/expectations/documentation_attr.pyx
@@ -10,12 +10,13 @@ cdef extern from *:
   #like this one with a new line character at its end
   #and this one as well. So they are in the same paragraph
   #
-  #Line ends with one new line should not break
+  #We treat empty doc comments as empty lines, so they break to the next paragraph.
   #
-  #Line ends with two spaces and a new line
-  #should break to next line
+  # Newlines are preserved with leading spaces added
+  # to prettify and avoid misinterpreting leading symbols.
+  #like headings and lists.
   #
-  #Line ends with two new lines
+  # Line ends with two new lines
   #
-  #Should break to next paragraph
+  # Should break to next paragraph
   void root();

--- a/tests/expectations/documentation_block.c
+++ b/tests/expectations/documentation_block.c
@@ -1,0 +1,48 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Some docs.
+ */
+extern const uint32_t FOO;
+
+/**
+ * The root of all evil.
+ *
+ * But at least it contains some more documentation as someone would expect
+ * from a simple test case like this.
+ *
+ * # Hint
+ * Always ensure that everything is properly documented, even if you feel lazy.
+ * **Sometimes** it is also helpful to include some markdown formatting.
+ *
+ * ////////////////////////////////////////////////////////////////////////////
+ *
+ * Attention:
+ *
+ *    This is an indentation test.
+ *    The indentation should be preserved in the generated documentation.
+ *
+ * ...and here is my shopping list to check that we do not mess with line breaks and indentation:
+ * - Bread
+ *    - Brown
+ *    - White
+ * - Milk
+ * - Eggs
+ */
+void root(void);
+
+/**
+ * In this block, we're testing indentation handling.
+ * Since all of these lines are equally indented, we want to discard the common leading whitespace,
+ *    but preserve the relative indentation and line breaks.
+ *
+ *    Including between paragraphs,
+ *
+ * - And
+ *   - within
+ *   - Lists
+ */
+void block_function(void);

--- a/tests/expectations/documentation_block.compat.c
+++ b/tests/expectations/documentation_block.compat.c
@@ -1,0 +1,56 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * Some docs.
+ */
+extern const uint32_t FOO;
+
+/**
+ * The root of all evil.
+ *
+ * But at least it contains some more documentation as someone would expect
+ * from a simple test case like this.
+ *
+ * # Hint
+ * Always ensure that everything is properly documented, even if you feel lazy.
+ * **Sometimes** it is also helpful to include some markdown formatting.
+ *
+ * ////////////////////////////////////////////////////////////////////////////
+ *
+ * Attention:
+ *
+ *    This is an indentation test.
+ *    The indentation should be preserved in the generated documentation.
+ *
+ * ...and here is my shopping list to check that we do not mess with line breaks and indentation:
+ * - Bread
+ *    - Brown
+ *    - White
+ * - Milk
+ * - Eggs
+ */
+void root(void);
+
+/**
+ * In this block, we're testing indentation handling.
+ * Since all of these lines are equally indented, we want to discard the common leading whitespace,
+ *    but preserve the relative indentation and line breaks.
+ *
+ *    Including between paragraphs,
+ *
+ * - And
+ *   - within
+ *   - Lists
+ */
+void block_function(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/tests/expectations/documentation_block.cpp
+++ b/tests/expectations/documentation_block.cpp
@@ -1,0 +1,47 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+extern "C" {
+
+/// Some docs.
+extern const uint32_t FOO;
+
+/// The root of all evil.
+///
+/// But at least it contains some more documentation as someone would expect
+/// from a simple test case like this.
+///
+/// # Hint
+/// Always ensure that everything is properly documented, even if you feel lazy.
+/// **Sometimes** it is also helpful to include some markdown formatting.
+///
+/// ////////////////////////////////////////////////////////////////////////////
+///
+/// Attention:
+///
+///    This is an indentation test.
+///    The indentation should be preserved in the generated documentation.
+///
+/// ...and here is my shopping list to check that we do not mess with line breaks and indentation:
+/// - Bread
+///    - Brown
+///    - White
+/// - Milk
+/// - Eggs
+void root();
+
+/// In this block, we're testing indentation handling.
+/// Since all of these lines are equally indented, we want to discard the common leading whitespace,
+///    but preserve the relative indentation and line breaks.
+///
+///    Including between paragraphs,
+///
+/// - And
+///   - within
+///   - Lists
+void block_function();
+
+}  // extern "C"

--- a/tests/expectations/documentation_block.pyx
+++ b/tests/expectations/documentation_block.pyx
@@ -1,0 +1,45 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  # Some docs.
+  extern const uint32_t FOO;
+
+  # The root of all evil.
+  #
+  # But at least it contains some more documentation as someone would expect
+  # from a simple test case like this.
+  #
+  # # Hint
+  # Always ensure that everything is properly documented, even if you feel lazy.
+  # **Sometimes** it is also helpful to include some markdown formatting.
+  #
+  # ////////////////////////////////////////////////////////////////////////////
+  #
+  # Attention:
+  #
+  #    This is an indentation test.
+  #    The indentation should be preserved in the generated documentation.
+  #
+  # ...and here is my shopping list to check that we do not mess with line breaks and indentation:
+  # - Bread
+  #    - Brown
+  #    - White
+  # - Milk
+  # - Eggs
+  void root();
+
+  # In this block, we're testing indentation handling.
+  # Since all of these lines are equally indented, we want to discard the common leading whitespace,
+  #    but preserve the relative indentation and line breaks.
+  #
+  #    Including between paragraphs,
+  #
+  # - And
+  #   - within
+  #   - Lists
+  void block_function();

--- a/tests/rust/documentation_attr.rs
+++ b/tests/rust/documentation_attr.rs
@@ -1,12 +1,12 @@
-#[doc="With doc attr, each attr contribute to one line of document"]
-#[doc="like this one with a new line character at its end"]
-#[doc="and this one as well. So they are in the same paragraph"]
-#[doc=""]
-#[doc="Line ends with one new line\nshould not break"]
-#[doc=""]
-#[doc="Line ends with two spaces and a new line  \nshould break to next line"]
-#[doc=""]
-#[doc="Line ends with two new lines\n\nShould break to next paragraph"]
+#[doc = "With doc attr, each attr contribute to one line of document"]
+#[doc = "like this one with a new line character at its end"]
+#[doc = "and this one as well. So they are in the same paragraph"]
+#[doc = ""]
+#[doc = "We treat empty doc comments as empty lines, so they break to the next paragraph."]
+#[doc = ""]
+#[doc = "Newlines are preserved with leading spaces added\nto prettify and avoid misinterpreting leading symbols."]
+#[doc = "like headings and lists."]
+#[doc = ""]
+#[doc = "Line ends with two new lines\n\nShould break to next paragraph"]
 #[no_mangle]
-pub extern "C" fn root() {
-}
+pub extern "C" fn root() {}

--- a/tests/rust/documentation_block.rs
+++ b/tests/rust/documentation_block.rs
@@ -1,0 +1,48 @@
+/**
+The root of all evil.
+
+But at least it contains some more documentation as someone would expect
+from a simple test case like this.
+
+# Hint
+Always ensure that everything is properly documented, even if you feel lazy.
+**Sometimes** it is also helpful to include some markdown formatting.
+
+////////////////////////////////////////////////////////////////////////////
+
+Attention:
+
+   This is an indentation test.
+   The indentation should be preserved in the generated documentation.
+
+...and here is my shopping list to check that we do not mess with line breaks and indentation:
+- Bread
+   - Brown
+   - White
+- Milk
+- Eggs
+*/
+#[no_mangle]
+pub extern "C" fn root() {}
+
+/**
+Some docs.
+*/
+#[no_mangle]
+pub static FOO: u32 = 4;
+
+mod abc {
+    /**
+    In this block, we're testing indentation handling.
+    Since all of these lines are equally indented, we want to discard the common leading whitespace,
+       but preserve the relative indentation and line breaks.
+
+       Including between paragraphs,
+
+    - And
+      - within
+      - Lists
+    */
+    #[no_mangle]
+    pub extern "C" fn block_function() {}
+}


### PR DESCRIPTION
The existing parsing logic is flawed, as it concatenates consecutive lines, e.g. this:

```
/// # Heading
/// This is the first paragraph.
///
/// - First
/// - Second
/// - Third
```
...becomes this (correct):
```
/**
 * # Heading
 * This is the first paragraph.
 *
 * - First
 * - Second
 * - Third
 */
```

But the same thing as a block comment:
```
/**
# Heading
This is the first paragraph.

- First
- Second
- Third
*/
```

...becomes this (broken):
```
/**
 * # Heading This is the first paragraph.
 *
 *- First - Second - Third
 */
```

The current splitting logic (introduced in #454) tries to join together lines in the same paragraph but without properly parsing and interpreting the markdown, leading to removing semantically-important line breaks.
It also allows for broken syntax if a `/` is placed at the beginning of a line, since there is no leading space after the `*` marker (creating a `*/` which closes the comment block).

The simpler approach in this PR is to simply split on newlines, which makes the parsing behaviour of block doc comments more consistent with single-line doc comments. We also add a single space at the start of each line, which is normally included in single-line doc comments but not in the block variant and prevents us accidentally creating a `*/`.

EDIT: I also realised I had to remove "common" whitespace between all lines in the block, or else block doc comments within modules are parsed with leading whitespace included, which is usually not intended. I have included tests for all new functionality and slightly modified the `documentation_attr` test for the new behaviour.