### PR TITLE
Allow `pub` access to `ReprType` fields

### DIFF
--- a/src/bindgen/ir/repr.rs
+++ b/src/bindgen/ir/repr.rs
@@ -14,8 +14,8 @@ pub enum ReprStyle {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ReprType {
-    kind: IntKind,
-    signed: bool,
+    pub kind: IntKind,
+    pub signed: bool,
 }
 
 impl ReprType {


### PR DESCRIPTION
The `unstable_ir` feature gives access to almost all the internals of the representation, but from outside the `cbindgen` crate there is no way to (safely) access the fields of `ReprType`.  This posed a problem for writing custom exporters that needed to know how particular `Enum`s are represented in the ABI.