### PR TITLE
bitflags: allow parsing unnamed ("_") bitflags

### DIFF
--- a/src/bindgen/bitflags.rs
+++ b/src/bindgen/bitflags.rs
@@ -4,6 +4,7 @@
 
 use proc_macro2::TokenStream;
 use std::collections::HashSet;
+use syn::ext::IdentExt;
 use syn::fold::Fold;
 use syn::parse::{Parse, ParseStream, Parser, Result as ParseResult};
 
@@ -245,7 +246,7 @@ impl Parse for Flag {
         Ok(Self {
             attrs: input.call(syn::Attribute::parse_outer)?,
             const_token: input.parse()?,
-            name: input.parse()?,
+            name: input.call(syn::Ident::parse_any)?,
             equals_token: input.parse()?,
             value: input.parse()?,
             semicolon_token: input.parse()?,
@@ -262,7 +263,12 @@ impl Parse for Flags {
         let _ = braced!(content in input);
         let mut flags = vec![];
         while !content.is_empty() {
-            flags.push(content.parse()?);
+            let flag: Flag = content.parse()?;
+            if flag.name == "_" {
+                debug!("Continuing past unnamed bitflag");
+                continue;
+            }
+            flags.push(flag);
         }
         Ok(Flags(flags))
     }

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -247,7 +247,7 @@ impl Literal {
             }
             Literal::FieldAccess { ref base, .. } => base.visit(visitor),
             Literal::Struct { ref fields, .. } => {
-                for (_name, field) in fields.iter() {
+                for field in fields.values() {
                     if !field.value.visit(visitor) {
                         return false;
                     }

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -138,7 +138,7 @@ impl Struct {
         if fields.is_empty() {
             warn!(
                 "Passing zero-sized struct {} across the FFI boundary is undefined behavior",
-                &path
+                path
             );
             is_transparent = false;
         }

--- a/src/bindgen/language_backend/cython.rs
+++ b/src/bindgen/language_backend/cython.rs
@@ -268,7 +268,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
         write!(
             out,
             "{}struct {}",
-            &self.config.style.cython_def(),
+            self.config.style.cython_def(),
             o.export_name()
         );
         out.open_brace();
@@ -284,7 +284,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
 
         self.write_documentation(out, &t.documentation);
 
-        write!(out, "{} ", &self.config.language.typedef());
+        write!(out, "{} ", self.config.language.typedef());
 
         self.write_field(
             out,

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -623,7 +623,7 @@ impl Parse {
                 {
                     info!(
                         "Skip {}::{} - (fn's outside of the binding crate are not used).",
-                        crate_name, &function.sig.ident
+                        crate_name, function.sig.ident
                     );
                     return;
                 }
@@ -637,14 +637,14 @@ impl Parse {
                     mod_cfg.as_ref(),
                 ) {
                     Ok(func) => {
-                        info!("Take {}::{}.", crate_name, &function.sig.ident);
+                        info!("Take {}::{}.", crate_name, function.sig.ident);
 
                         self.functions.push(func);
                     }
                     Err(msg) => {
                         error!(
                             "Cannot use fn {}::{} ({}).",
-                            crate_name, &function.sig.ident, msg
+                            crate_name, function.sig.ident, msg
                         );
                     }
                 }
@@ -713,7 +713,7 @@ impl Parse {
         {
             info!(
                 "Skip {}::{} - (fn's outside of the binding crate are not used).",
-                crate_name, &sig.ident
+                crate_name, sig.ident
             );
             return;
         }
@@ -791,7 +791,7 @@ impl Parse {
         for item in items.into_iter() {
             if let syn::Visibility::Public(_) = item.vis {
             } else {
-                warn!("Skip {}::{} - (not `pub`).", crate_name, &item.ident);
+                warn!("Skip {}::{} - (not `pub`).", crate_name, item.ident);
                 return;
             }
 
@@ -805,7 +805,7 @@ impl Parse {
                 Some(impl_path.clone()),
             ) {
                 Ok(constant) => {
-                    info!("Take {}::{}::{}.", crate_name, impl_path, &item.ident);
+                    info!("Take {}::{}::{}.", crate_name, impl_path, item.ident);
                     let mut any = false;
                     self.structs.for_items_mut(&impl_path, |item| {
                         any = true;
@@ -816,12 +816,12 @@ impl Parse {
                     if !any && !self.constants.try_insert(constant) {
                         error!(
                             "Conflicting name for constant {}::{}::{}.",
-                            crate_name, impl_path, &item.ident,
+                            crate_name, impl_path, item.ident,
                         );
                     }
                 }
                 Err(msg) => {
-                    warn!("Skip {}::{} - ({})", crate_name, &item.ident, msg);
+                    warn!("Skip {}::{} - ({})", crate_name, item.ident, msg);
                 }
             }
         }
@@ -842,21 +842,21 @@ impl Parse {
         {
             info!(
                 "Skip {}::{} - (const's outside of the binding crate are not used).",
-                crate_name, &item.ident
+                crate_name, item.ident
             );
             return;
         }
 
         if let syn::Visibility::Public(_) = item.vis {
         } else {
-            warn!("Skip {}::{} - (not `pub`).", crate_name, &item.ident);
+            warn!("Skip {}::{} - (not `pub`).", crate_name, item.ident);
             return;
         }
 
         let path = Path::new(item.ident.unraw().to_string());
         match Constant::load(path, mod_cfg, &item.ty, &item.expr, &item.attrs, None) {
             Ok(constant) => {
-                info!("Take {}::{}.", crate_name, &item.ident);
+                info!("Take {}::{}.", crate_name, item.ident);
 
                 let full_name = constant.path.clone();
                 if !self.constants.try_insert(constant) {
@@ -864,7 +864,7 @@ impl Parse {
                 }
             }
             Err(msg) => {
-                warn!("Skip {}::{} - ({})", crate_name, &item.ident, msg);
+                warn!("Skip {}::{} - ({})", crate_name, item.ident, msg);
             }
         }
     }
@@ -884,7 +884,7 @@ impl Parse {
         {
             info!(
                 "Skip {}::{} - (static's outside of the binding crate are not used).",
-                crate_name, &item.ident
+                crate_name, item.ident
             );
             return;
         }
@@ -893,15 +893,15 @@ impl Parse {
             let path = Path::new(exported_name);
             match Static::load(path, item, mod_cfg) {
                 Ok(constant) => {
-                    info!("Take {}::{}.", crate_name, &item.ident);
+                    info!("Take {}::{}.", crate_name, item.ident);
                     self.globals.try_insert(constant);
                 }
                 Err(msg) => {
-                    warn!("Skip {}::{} - ({})", crate_name, &item.ident, msg);
+                    warn!("Skip {}::{} - ({})", crate_name, item.ident, msg);
                 }
             }
         } else {
-            warn!("Skip {}::{} - (not `no_mangle`).", crate_name, &item.ident);
+            warn!("Skip {}::{} - (not `no_mangle`).", crate_name, item.ident);
         }
     }
 
@@ -915,11 +915,11 @@ impl Parse {
     ) {
         match Struct::load(&config.layout, item, mod_cfg) {
             Ok(st) => {
-                info!("Take {}::{}.", crate_name, &item.ident);
+                info!("Take {}::{}.", crate_name, item.ident);
                 self.structs.try_insert(st);
             }
             Err(msg) => {
-                info!("Take {}::{} - opaque ({}).", crate_name, &item.ident, msg);
+                info!("Take {}::{} - opaque ({}).", crate_name, item.ident, msg);
                 let path = Path::new(item.ident.unraw().to_string());
                 self.opaque_items.try_insert(
                     OpaqueItem::load(path, &item.generics, &item.attrs, mod_cfg).unwrap(),
@@ -938,12 +938,12 @@ impl Parse {
     ) {
         match Union::load(&config.layout, item, mod_cfg) {
             Ok(st) => {
-                info!("Take {}::{}.", crate_name, &item.ident);
+                info!("Take {}::{}.", crate_name, item.ident);
 
                 self.unions.try_insert(st);
             }
             Err(msg) => {
-                info!("Take {}::{} - opaque ({}).", crate_name, &item.ident, msg);
+                info!("Take {}::{} - opaque ({}).", crate_name, item.ident, msg);
                 let path = Path::new(item.ident.unraw().to_string());
                 self.opaque_items.try_insert(
                     OpaqueItem::load(path, &item.generics, &item.attrs, mod_cfg).unwrap(),
@@ -962,11 +962,11 @@ impl Parse {
     ) {
         match Enum::load(item, mod_cfg, config) {
             Ok(en) => {
-                info!("Take {}::{}.", crate_name, &item.ident);
+                info!("Take {}::{}.", crate_name, item.ident);
                 self.enums.try_insert(en);
             }
             Err(msg) => {
-                info!("Take {}::{} - opaque ({}).", crate_name, &item.ident, msg);
+                info!("Take {}::{} - opaque ({}).", crate_name, item.ident, msg);
                 let path = Path::new(item.ident.unraw().to_string());
                 self.opaque_items.try_insert(
                     OpaqueItem::load(path, &item.generics, &item.attrs, mod_cfg).unwrap(),
@@ -979,12 +979,12 @@ impl Parse {
     fn load_syn_ty(&mut self, crate_name: &str, mod_cfg: Option<&Cfg>, item: &syn::ItemType) {
         match Typedef::load(item, mod_cfg) {
             Ok(st) => {
-                info!("Take {}::{}.", crate_name, &item.ident);
+                info!("Take {}::{}.", crate_name, item.ident);
 
                 self.typedefs.try_insert(st);
             }
             Err(msg) => {
-                info!("Take {}::{} - opaque ({}).", crate_name, &item.ident, msg);
+                info!("Take {}::{} - opaque ({}).", crate_name, item.ident, msg);
                 let path = Path::new(item.ident.unraw().to_string());
                 self.opaque_items.try_insert(
                     OpaqueItem::load(path, &item.generics, &item.attrs, mod_cfg).unwrap(),

--- a/tests/rust/bitflags.rs
+++ b/tests/rust/bitflags.rs
@@ -18,6 +18,11 @@ bitflags! {
         const FLEX_START = 1 << 3;
         const MIXED = 1 << 4 | AlignFlags::FLEX_START.bits() | AlignFlags::END.bits();
         const MIXED_SELF = 1 << 5 | AlignFlags::FLEX_START.bits() | AlignFlags::END.bits();
+
+        // External sources may set any bits,
+        // avoid truncating unknown bits by
+        // supplying an unnamed value with all bits set.
+        const _ = !0;
     }
 }
 
@@ -48,6 +53,8 @@ bitflags! {
         const A = 1;
         const B = 2;
         const AB = Self::A.bits() | Self::B.bits();
+
+        const _ = !0;
     }
 }
 


### PR DESCRIPTION
To avoid potentially truncating unknown bits within the derived methods, [the documentation recommends](https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags) adding an unnamed flag with all bits set. This commit allows cbindgen to skip parsing those flags without throwing an error (like it did previously, then skipping the entire item!), and only emit the named flags with values.

Before:
```
WARN: Failed to parse bitflags invocation: Error("expected identifier, found keyword `_`")
...
typedef uint8_t Flags;
```

After:
```
INFO: Take my_crate::Flags.
DEBUG: Continuing past unnamed bitflag
INFO: Take my_crate::Flags::A.
INFO: Take my_crate::Flags::B.
INFO: Take my_crate::Flags::C.
INFO: Take my_crate::Flags::D.
...
typedef uint8_t Flags;
#define Flags_A (uint8_t)(1 << 0)
#define Flags_B (uint8_t)(1 << 1)
#define Flags_C (uint8_t)(1 << 2)
#define Flags_D (uint8_t)(1 << 3)
```

I'm unsure if `unraw()` would be needed due to my use of the `IdentExt::parse_any`, might be worth adding as a test case?

And in order to pass `cargo clippy` with yesterday's Stable release (1.97.0), I had to do another commit with some fixes. Let me know if you'd prefer a cleaner history.
