### PR TITLE
refactor: bump `syn` to v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,9 +354,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -364,22 +364,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "syn",
+ "syn 3.0.3",
  "tempfile",
  "toml",
 ]
@@ -379,7 +379,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -423,7 +423,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -443,6 +443,17 @@ name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ quote = "1"
 heck = "0.5"
 
 [dependencies.syn]
-version = "2.0.85"
+version = "3.0"
 default-features = false
 features = ["clone-impls", "extra-traits", "fold", "full", "parsing", "printing"]
 

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -225,16 +225,21 @@ trait SynFnArgHelpers {
 fn gen_self_type(receiver: &syn::Receiver) -> Result<Type, String> {
     let mut self_ty = Type::Path(GenericPath::self_path());
 
-    // Custom self type
-    if receiver.colon_token.is_some() {
-        self_ty = Type::load(receiver.ty.as_ref())?.unwrap_or(self_ty);
-    }
+    let is_const = match &receiver.kind {
+        syn::ReceiverKind::Reference(_, _, mut_token) => mut_token.is_none(),
+        // Custom self type
+        syn::ReceiverKind::Typed(_, ty) => {
+            self_ty = Type::load(ty)?.unwrap_or(self_ty);
 
-    if receiver.reference.is_none() {
-        return Ok(self_ty);
-    }
+            match &**ty {
+                syn::Type::Reference(ref_ty) => ref_ty.mutability.is_none(),
+                _ => return Ok(self_ty),
+            }
+        }
+        syn::ReceiverKind::Value => return Ok(self_ty),
+        _ => return Err(String::from("Receiver is of an unsupported kind")),
+    };
 
-    let is_const = receiver.mutability.is_none();
     Ok(Type::Ptr {
         ty: Box::new(self_ty),
         is_const,

--- a/src/bindgen/ir/generic_path.rs
+++ b/src/bindgen/ir/generic_path.rs
@@ -40,7 +40,7 @@ impl GenericParam {
                 ref default,
                 ..
             }) => {
-                let default = match default.as_ref().map(Type::load).transpose()? {
+                let default = match default.as_ref().map(|(_, ty)| Type::load(ty)).transpose()? {
                     None => None,
                     Some(None) => Some(GenericArgument::Type(Type::Primitive(PrimitiveType::Void))),
                     Some(Some(ty)) => Some(GenericArgument::Type(ty)),
@@ -69,7 +69,7 @@ impl GenericParam {
                     ty: GenericParamType::Const(ty),
                     default: default
                         .as_ref()
-                        .map(ConstExpr::load)
+                        .map(|(_, ty)| ConstExpr::load(ty))
                         .transpose()?
                         .map(GenericArgument::Const),
                 })),

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -375,7 +375,7 @@ impl Type {
                     None => Type::Primitive(PrimitiveType::Void),
                 };
 
-                let is_const = pointer.mutability.is_none();
+                let is_const = matches!(pointer.mutability, syn::PointerMutability::Const(_));
                 Type::Ptr {
                     ty: Box::new(converted),
                     is_const,
@@ -412,7 +412,7 @@ impl Type {
                 let len = ConstExpr::load(len)?;
                 Type::Array(Box::new(converted), len)
             }
-            syn::Type::BareFn(ref function) => {
+            syn::Type::FnPtr(ref function) => {
                 let mut wildcard_counter = 0;
                 let mut args = function.inputs.iter().try_skip_map(|x| {
                     Type::load(&x.ty).map(|opt_ty| {


### PR DESCRIPTION
Following the [recent release of `syn` v3](https://github.com/dtolnay/syn/releases/tag/3.0.0), this bumps the dependency and makes the necessary refactors, with the goal of reducing dependency duplication in the dependents. The [MSRV of `syn` v3 is now 1.71](https://crates.io/crates/syn/3.0.0/code/Cargo.toml#L14) but that shouldn't be a problem with `cbindgen`'s MSRV of 1.74.

I've been trough the changelog and didn't find any other relevant breaking changes (but there is quite a few of them so I could have missed some). The biggest change is how receivers and the constness of pointers is now encoded: compare [`Receiver@v3`](https://docs.rs/syn/3.0.3/syn/struct.Receiver.html) with [`Receiver@v2`](https://docs.rs/syn/2.0.119/syn/struct.Receiver.html) and [`TypePtr@v3`](https://docs.rs/syn/3.0.3/syn/struct.TypePtr.html) with [`TypePtr@v2`](https://docs.rs/syn/2.0.119/syn/struct.TypePtr.html).

I've run `cargo test` but didn't do any other kind of testing.